### PR TITLE
fix: Correct beads repo URL

### DIFF
--- a/dev-setup/beads-claude-code.md
+++ b/dev-setup/beads-claude-code.md
@@ -1,6 +1,6 @@
 # Beads + Claude Code Integration
 
-Best practices for using [beads](https://github.com/beads-project/beads) issue tracking with Claude Code.
+Best practices for using [beads](https://github.com/steveyegge/beads) issue tracking with Claude Code.
 
 ## Status Line Configuration
 


### PR DESCRIPTION
## Summary
- Fix beads repo URL from `beads-project/beads` (doesn't exist) to `steveyegge/beads` (correct)

## Test plan
- [x] Verify steveyegge/beads exists
- [x] Verify beads-project/beads doesn't exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project repository URL reference in development setup documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->