### PR TITLE
docs: Add beads-metadata branch tracking fix for fork workflows

### DIFF
--- a/dev-setup/beads.md
+++ b/dev-setup/beads.md
@@ -261,6 +261,21 @@ bd sync --status            # Check sync status
 - Check `.beads/config.yaml` for sync-branch setting
 - Ensure git hooks are installed
 
+**Permission denied on `bd sync` (fork-based workflows)**
+
+If you use a fork workflow (`origin` = your fork, `upstream` = main repo), the `beads-metadata` branch may be tracking the wrong remote:
+
+```bash
+# Check current tracking
+git branch -vv | grep beads-metadata
+
+# If it shows "upstream" instead of "origin", fix it:
+git branch --set-upstream-to=origin/beads-metadata beads-metadata
+
+# Now sync will push to your fork
+bd sync
+```
+
 **Stale `in_progress` issues**
 
 - Review with `bd list --status=in_progress`


### PR DESCRIPTION
## Summary

- Add troubleshooting section for "permission denied on bd sync" in fork-based workflows
- Documents the fix: `git branch --set-upstream-to=origin/beads-metadata beads-metadata`

## Context

When using a fork workflow (`origin` = your fork, `upstream` = main repo), the `beads-metadata` branch may be tracking `upstream` instead of `origin`. This causes `bd sync` to fail with permission errors when trying to push.

## Test plan

- [x] Verified fix works in swing-analyzer project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting guidance for fork-based workflows, addressing permission issues with sync operations and providing diagnostic commands and remediation steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->