### PR TITLE
Add guidance: hard bugs signal architecture problems

### DIFF
--- a/dev-inner-loop/clean-code.md
+++ b/dev-inner-loop/clean-code.md
@@ -9,3 +9,4 @@ Use const whenever you can
 Use types whenever you can
 Use data objects when you can POJO/POCO, or pydantic objects
 Use humble objects (called a manager) when interacting with external systems, if there isn't one, ask user if they want one - This makes testing easier - This makes it easy to test business logic
+Hard bugs signal architecture problems - If a bug is difficult to fix, STOP and ask: is there an architectural issue? Don't patch around bad architecture - log the issue and discuss with the user first.


### PR DESCRIPTION
## Summary

- Add clean-code guidance: when a bug is difficult to fix, stop and ask if there's an architectural issue
- Don't patch around bad architecture - log the issue and discuss first

## Why

Hard bugs are often symptoms of deeper architectural problems. Patching around them creates technical debt and makes the codebase harder to maintain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance recommending architectural review when encountering difficult-to-fix bugs, encouraging discussion before implementing solutions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->