### PR TITLE
docs: Add tmux + neovim tips for file review

### DIFF
--- a/dev-inner-loop/running-commands.md
+++ b/dev-inner-loop/running-commands.md
@@ -1,3 +1,44 @@
-Put all command scripts into the justfile
-Check justfile to see if the command you want to run is already there.
-When running python scripts, since they are done with UV script shebangs, you can just run them directly E.g. - To run: foo.py - . ./foo.py
+# Running Commands
+
+## Justfile
+
+Put all command scripts into the justfile. Check justfile to see if the command you want to run is already there.
+
+## Python Scripts
+
+When running python scripts with UV script shebangs, run them directly:
+
+```bash
+./foo.py
+```
+
+## Tmux + Neovim
+
+Open files for user review in a tmux split (keeps Claude's terminal available):
+
+```bash
+# Open file in 2/3 width split on right
+tmux split-window -h -l 66% "nvim /path/to/file"
+
+# Open git diff in nvim
+tmux split-window -h -l 66% "nvim -c 'Git diff'"
+
+# Open specific file at line number
+tmux split-window -h -l 66% "nvim +42 /path/to/file"
+
+# Vertical split (top/bottom) - useful for logs
+tmux split-window -v -l 50% "nvim /path/to/file"
+```
+
+This is useful when:
+
+- Showing retros, diffs, or long files for user review
+- User wants to edit while Claude continues working
+- Comparing files side-by-side with the terminal
+
+## CLI Troubleshooting
+
+| Problem              | Fix                   |
+| -------------------- | --------------------- |
+| Git output truncated | `git --no-pager diff` |
+| head/cat errors      | `unset PAGER`         |


### PR DESCRIPTION
## Summary
- Add tmux split-window commands to open files in nvim for user review
- Include 2/3 split, git diff, and line number examples
- Add CLI troubleshooting table
- Restructure running-commands.md with proper markdown sections

## Use Case
When Claude needs to show a file for user review (retros, diffs, long files), opening in a tmux split keeps Claude's terminal available while user edits.

```bash
# Open file in 2/3 width split on right
tmux split-window -h -l 66% "nvim /path/to/file"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)