### PR TITLE
Add PWA repos tracking list

### DIFF
--- a/pwa/repos.md
+++ b/pwa/repos.md
@@ -1,0 +1,52 @@
+# Igor's PWA Repos
+
+Track PWA projects to ensure they stay in sync with latest conventions.
+
+## Surge-Deployed PWAs
+
+Production PWAs using VitePWA + Surge deployment.
+
+| Repo                                                             | Live URL                        | Status |
+| ---------------------------------------------------------------- | ------------------------------- | ------ |
+| [igor-breathe](https://github.com/idvorkin/igor-breathe)         | https://igor-breathe.surge.sh   | Active |
+| [igor-timer](https://github.com/idvorkin/igor-timer)             | https://igor-timer.surge.sh     | Active |
+| [magic-monitor](https://github.com/idvorkin/magic-monitor)       | https://magic-monitor.surge.sh  | Active |
+| [swing-analyzer](https://github.com/idvorkin/swing-analyzer)     | https://swing-analyzer.surge.sh | Active |
+| [humane-tracker-1](https://github.com/idvorkin/humane-tracker-1) | https://humane-tracker.surge.sh | Active |
+| [stacktrainer](https://github.com/idvorkin/stacktrainer)         | https://stacktrainer.surge.sh   | Active |
+| [stack-picker-2](https://github.com/idvorkin/stack-picker-2)     | TBD                             | Active |
+
+## GitHub Pages Apps
+
+Static apps on GitHub Pages (may or may not have PWA features).
+
+| Repo                                                                           | Live URL                                            | Has PWA |
+| ------------------------------------------------------------------------------ | --------------------------------------------------- | ------- |
+| [tax-calculator](https://github.com/idvorkin/tax-calculator)                   | https://idvorkin.github.io/tax-calculator/          | TBD     |
+| [mathflash](https://github.com/idvorkin/mathflash)                             | https://idvorkin.github.io/mathflash/               | TBD     |
+| [world-happiness-report](https://github.com/idvorkin/world-happiness-report)   | https://idvorkin.github.io/world-happiness-report/  | TBD     |
+| [donut-profit-calculator](https://github.com/idvorkin/donut-profit-calculator) | https://idvorkin.github.io/donut-profit-calculator/ | TBD     |
+
+## Swing Variants (Dev/Experiments)
+
+Development copies of swing-analyzer for testing.
+
+| Repo                     | Notes                 |
+| ------------------------ | --------------------- |
+| swing-2 through swing-6  | Experimental branches |
+| swing-analyzer-pr-review | PR review testing     |
+
+## Sync Checklist
+
+When updating PWA conventions, check these repos:
+
+- [ ] Update VitePWA config pattern
+- [ ] Update service worker strategy
+- [ ] Update manifest requirements
+- [ ] Update GitHub Actions workflows
+- [ ] Update surge deployment pattern
+
+## See Also
+
+- [PWA Enablement Spec](./PWA_ENABLEMENT_SPEC.md) - Implementation guide
+- [Surge Deployment](../deployment/surge.md) - Deployment setup


### PR DESCRIPTION
## Why

No central list of Igor's PWA repos exists, making it hard to know which repos need updating when PWA conventions change.

## Intent

Provide a single source of truth for:
- Which repos have PWA features
- Their live URLs for quick testing
- A sync checklist when updating conventions

## Success Criteria

- [ ] Can quickly see all PWA repos and their status
- [ ] Can verify live URLs work
- [ ] Know which repos to update when conventions change

## Summary

Adds `pwa/repos.md` with:
- Surge-deployed PWAs (7 repos)
- GitHub Pages apps (4 repos)
- Swing variants (dev/experiments)
- Sync checklist for convention updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for tracked PWAs, including deployment status, live URLs, and resource guides.
  * Includes curated links to PWA enablement and deployment best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->