### PR TITLE
Add post-sync context clear prompt to up-to-date skill

### DIFF
--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -215,6 +215,16 @@ Then summarize findings in a table:
 
 Then take the actions and report results.
 
+## Post-Sync: Offer Context Clear
+
+After all sync actions are complete and the summary is shown, ask the user if they'd like to clear their conversation context (via `/clear`). This is useful because:
+
+- They often run `/up-to-date` at the start of a new work session
+- The previous conversation context may be stale or irrelevant
+- A fresh context helps avoid confusion from old file reads and outdated state
+
+Simply ask: "Want to `/clear` context for a fresh start?"
+
 ## Safety Rules
 
 - NEVER force push


### PR DESCRIPTION
## Summary
- After up-to-date skill finishes syncing, offer to `/clear` conversation context
- Users typically run this at session start when old context is stale

## Test plan
- [ ] Run `/up-to-date` and verify it asks about clearing context at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)