### PR TITLE
Add ammon skill for Denmark time lookup

### DIFF
--- a/skills/ammon/SKILL.md
+++ b/skills/ammon/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: ammon
+description: What time is it for Ammon? Looks up the current time in Denmark (Europe/Copenhagen timezone) and reports it.
+allowed-tools: Bash
+---
+
+# What Time Is It for Ammon?
+
+Ammon is in Denmark. Look up the current time there and tell the user.
+
+## Steps
+
+Run both timezone lookups together:
+
+```bash
+echo "Denmark: $(TZ='Europe/Copenhagen' date '+%H:%M %Z (%A, %B %d, %Y)')"
+echo "PST:     $(TZ='America/Los_Angeles' date '+%I:%M %p %Z (%A, %B %d, %Y)')"
+```
+
+**Important:** The machine may report in UTC. Always use the explicit `TZ=` commands above to get the correct local times — never trust the system clock's default timezone.
+
+## Output Format
+
+Report both times conversationally, e.g.:
+
+> It's 14:30 CET for Ammon in Denmark (Wednesday, January 15, 2025).
+> That's 5:30 AM PST for you.
+
+If Ammon's time is outside normal waking hours (before 07:00 or after 23:00), mention that he's likely asleep.


### PR DESCRIPTION
## Summary
- Adds a new `/ammon` skill that reports the current time for Ammon in Denmark (CET, 24h format)
- Also shows the caller's time in PST (12h AM/PM format)
- Notes if Ammon is likely asleep (before 7am or after 11pm)

## Test plan
- [ ] Run `/ammon` skill and verify Denmark time is correct
- [ ] Verify PST time shows in 12-hour AM/PM format

🤖 Generated with [Claude Code](https://claude.com/claude-code)