### PR TITLE
feat(showboat): add hot reload to pandoc template

### DIFF
--- a/skills/showboat/pandoc-template.html
+++ b/skills/showboat/pandoc-template.html
@@ -81,5 +81,24 @@
   </head>
   <body>
     $body$
+    <script>
+      // Hot reload: polls for file changes and reloads when updated (local dev only)
+      (function () {
+        let lastModified = "";
+        async function poll() {
+          try {
+            const resp = await fetch(location.href, {
+              method: "HEAD",
+              cache: "no-cache",
+            });
+            const modified = resp.headers.get("Last-Modified") || "";
+            if (lastModified && modified !== lastModified) location.reload();
+            lastModified = modified;
+          } catch (e) {}
+          setTimeout(poll, 2000);
+        }
+        setTimeout(poll, 2000);
+      })();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds a hot reload script to the showboat pandoc template
- Polls `Last-Modified` header via `HEAD` request every 2 seconds, reloads page on change
- Works with Python's `http.server` out of the box — no extra dependencies

## Test plan
- [ ] Run `python3 -m http.server` serving a showboat doc rendered with the template
- [ ] Edit the HTML file and confirm the browser auto-reloads within ~2s
- [ ] Confirm no errors in browser console when server is stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic page refresh capability to walkthrough HTML when file changes are detected, eliminating manual reload steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->