### PR TITLE
feat(gen-image): add reference image support for consistency

### DIFF
--- a/skills/gen-image/gemini-image.sh
+++ b/skills/gen-image/gemini-image.sh
@@ -1,46 +1,90 @@
 #!/bin/bash
-# Generate an image using the Gemini image generation API.
+# ABOUTME: Generates images via the Gemini image generation API.
+# ABOUTME: Supports reference images for character consistency.
 #
-# Usage: gemini-image.sh <prompt> <output-file> [api-url]
+# Usage: gemini-image.sh <prompt> <output-file> [api-url] [ref-image...]
 #
 # Environment:
-#   GOOGLE_API_KEY  (required) — your Google API key
+#   GOOGLE_API_KEY   (required) — your Google API key
+#   ASPECT_RATIO     (optional) — aspect ratio, e.g. "3:4" (default: 3:4)
 #
-# The script sends the prompt to the Gemini image generation endpoint,
-# extracts the base64-encoded image from the response, and decodes it
-# to the output file. If the output file ends in .webp and cwebp is
-# available, the image is converted; otherwise it falls back to .png.
+# Reference images are passed as additional positional arguments after
+# the API URL. They are sent as inline_data parts alongside the text
+# prompt to maintain character consistency across generations.
 
 set -euo pipefail
 
-PROMPT="${1:?Usage: gemini-image.sh <prompt> <output-file> [api-url]}"
-OUTPUT="${2:?Usage: gemini-image.sh <prompt> <output-file> [api-url]}"
+PROMPT="${1:?Usage: gemini-image.sh <prompt> <output-file> [api-url] [ref-image...]}"
+OUTPUT="${2:?Usage: gemini-image.sh <prompt> <output-file> [api-url] [ref-image...]}"
 API_URL="${3:-https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-image:generateContent}"
+REF_IMAGES=()
+if [[ $# -gt 3 ]]; then
+    shift 3
+    REF_IMAGES=("$@")
+fi
+ASPECT_RATIO="${ASPECT_RATIO:-3:4}"
 
 if [[ -z "${GOOGLE_API_KEY:-}" ]]; then
     echo "Error: GOOGLE_API_KEY environment variable is not set" >&2
     exit 1
 fi
 
-# Build the request payload
-PAYLOAD=$(jq -n \
-    --arg prompt "$PROMPT" \
+# Use temp files to avoid shell argument length limits with large base64 data
+PARTS_FILE=$(mktemp /tmp/gemini-parts-XXXXXX.json)
+PAYLOAD_FILE=$(mktemp /tmp/gemini-payload-XXXXXX.json)
+RESPONSE_FILE=$(mktemp /tmp/gemini-response-XXXXXX.json)
+trap 'rm -f "$PARTS_FILE" "$PAYLOAD_FILE" "$RESPONSE_FILE"' EXIT
+
+# Build the parts array: text prompt first, then any reference images
+jq -n --arg prompt "$PROMPT" '[{ text: $prompt }]' > "$PARTS_FILE"
+
+for ref in "${REF_IMAGES[@]}"; do
+    if [[ ! -f "$ref" ]]; then
+        echo "Warning: Reference image not found, skipping: $ref" >&2
+        continue
+    fi
+    # Detect mime type from extension
+    ref_ext="${ref##*.}"
+    ref_ext="${ref_ext,,}"
+    case "$ref_ext" in
+        png)  ref_mime="image/png" ;;
+        jpg|jpeg) ref_mime="image/jpeg" ;;
+        webp) ref_mime="image/webp" ;;
+        *)    ref_mime="image/png" ;;
+    esac
+    REF_B64_FILE=$(mktemp /tmp/gemini-ref-XXXXXX.b64)
+    base64 -w0 "$ref" > "$REF_B64_FILE" 2>/dev/null || base64 "$ref" > "$REF_B64_FILE"
+    jq --arg mime "$ref_mime" --rawfile data "$REF_B64_FILE" \
+        '. + [{ inlineData: { mimeType: $mime, data: $data } }]' \
+        "$PARTS_FILE" > "${PARTS_FILE}.tmp" && mv "${PARTS_FILE}.tmp" "$PARTS_FILE"
+    rm -f "$REF_B64_FILE"
+    echo "Attached reference image: $ref" >&2
+done
+
+# Build the request payload with imageConfig for aspect ratio
+jq -n \
+    --slurpfile parts "$PARTS_FILE" \
+    --arg aspect "$ASPECT_RATIO" \
     '{
         contents: [{
-            parts: [{ text: $prompt }]
+            parts: $parts[0]
         }],
         generationConfig: {
-            responseModalities: ["TEXT", "IMAGE"]
+            responseModalities: ["TEXT", "IMAGE"],
+            imageConfig: {
+                aspectRatio: $aspect
+            }
         }
-    }')
+    }' > "$PAYLOAD_FILE"
 
 echo "Calling Gemini API..." >&2
 
-# Make the API call
-RESPONSE=$(curl -s -X POST \
+# Make the API call using file input to avoid argument length limits
+curl -s -X POST \
     "${API_URL}?key=${GOOGLE_API_KEY}" \
     -H "Content-Type: application/json" \
-    -d "$PAYLOAD")
+    -d @"$PAYLOAD_FILE" > "$RESPONSE_FILE"
+RESPONSE=$(cat "$RESPONSE_FILE")
 
 # Check for errors in the response
 ERROR=$(echo "$RESPONSE" | jq -r '.error.message // empty' 2>/dev/null)


### PR DESCRIPTION
## Summary
- Add reference image support to `gemini-image.sh` for character consistency across generations
- Enrich default raccoon prompt with missing traits (shorts, mask markings, ringed tail, chibi proportions)
- Add `imageConfig` with proper aspect ratio enum values
- Document `--ref` flag and canonical reference image (`raccoon-nerd.webp`)

## Changes
- **gemini-image.sh**: Accept ref images as extra positional args, base64-encode via temp files (avoids shell arg length limits), add `ASPECT_RATIO` env var for `imageConfig`
- **SKILL.md**: New `--ref` flag, canonical reference image section, enriched raccoon prompt, stronger mismatched Crocs wording, updated generation examples

## Test plan
- [x] Tested with reference image (raccoon-nerd.webp) — character consistency improved
- [x] Tested without reference image — backward compatible
- [x] Tested with both Gemini 2.5 Flash and 3 Pro models
- [x] Verified mismatched Crocs compliance with stronger prompt wording
- [x] Verified pink shirt + custom text ("AMELIORATE") works on both models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for providing reference images to maintain character consistency in generated outputs
  * Introduced validated aspect ratio configuration with explicit supported values
  * Enhanced raccoon-style generation with canonical reference imagery for improved visual consistency
  * Improved error handling and diagnostic feedback for reference image processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->