### PR TITLE
Link gen-image to generate.py from image-explore

### DIFF
--- a/skills/gen-image/gemini-image.sh
+++ b/skills/gen-image/gemini-image.sh
@@ -24,6 +24,11 @@ if [[ $# -gt 3 ]]; then
 fi
 ASPECT_RATIO="${ASPECT_RATIO:-3:4}"
 
+# Auto-source ~/.env if API key is not already set
+if [[ -z "${GOOGLE_API_KEY:-}" && -f ~/.env ]]; then
+    source ~/.env
+fi
+
 if [[ -z "${GOOGLE_API_KEY:-}" ]]; then
     echo "Error: GOOGLE_API_KEY environment variable is not set" >&2
     exit 1


### PR DESCRIPTION
## Summary
- **gen-image SKILL.md**: Replace manual `gemini-image.sh` invocations with `generate.py` from image-explore, which handles env loading, raccoon style, ref image resolution, and parallel batch execution
- **gemini-image.sh**: Add `~/.env` auto-sourcing so API keys work in background shell processes (fixes failures when running via `run_in_background`)
- Remove duplicated raccoon style text and ref image instructions from SKILL.md (now managed by `raccoon-style.txt` and `generate.py`)

## Test plan
- [ ] Run `/gen-image _d/some-post.md` and verify it uses `generate.py` for generation
- [ ] Verify `gemini-image.sh` works when `GOOGLE_API_KEY` is only in `~/.env`
- [ ] Verify batch mode generates multiple images in parallel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added batch image generation capability with parallel execution support
  * Dynamic style and reference image configuration management

* **Documentation**
  * Updated workflow instructions for image generation process

* **Refactor**
  * Automated API key loading from local environment file
  * Streamlined generation workflow using Python wrapper for unified configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->