### PR TITLE
Add build-bd skill for static beads CLI installation

### DIFF
--- a/skills/build-bd/SKILL.md
+++ b/skills/build-bd/SKILL.md
@@ -1,0 +1,50 @@
+# Build bd (Beads CLI)
+
+Install or upgrade the `bd` CLI tool with a fully static build to avoid shared library issues (e.g., ICU version mismatches across machines).
+
+## Usage
+
+```
+/build-bd
+```
+
+## Steps
+
+1. Check current version:
+
+   ```bash
+   bd --version 2>/dev/null || echo "bd not installed"
+   ```
+
+2. Find the latest available version:
+
+   ```bash
+   go list -m -json github.com/steveyegge/beads@latest 2>&1 | grep '"Version"'
+   ```
+
+3. If already on the latest version, report that and stop. Otherwise, proceed to build.
+
+4. Build the latest version statically with CGO disabled (use the explicit version tag):
+
+   ```bash
+   CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@v0.54.0
+   ```
+
+   `CGO_ENABLED=0` forces pure-Go alternatives for all dependencies (ICU regex, SQLite, etc.), producing a binary with zero shared library dependencies.
+
+5. Verify:
+
+   ```bash
+   bd --version
+   ldd "$(which bd)" 2>&1  # Should say "not a dynamic executable"
+   ```
+
+## Why static?
+
+The `bd` binary uses `go-icu-regex` (CGo) which links against the system's ICU library. Different machines have different ICU versions (e.g., Homebrew's `icu4c@77` vs system `libicu76`), causing runtime failures:
+
+```
+bd: error while loading shared libraries: libicui18n.so.77: cannot open shared object file
+```
+
+Static compilation eliminates this entirely.

--- a/skills/build-bd/SKILL.md
+++ b/skills/build-bd/SKILL.md
@@ -4,7 +4,7 @@ Install or upgrade the `bd` CLI tool with a fully static build to avoid shared l
 
 ## Usage
 
-```
+```text
 /build-bd
 ```
 
@@ -24,26 +24,31 @@ Install or upgrade the `bd` CLI tool with a fully static build to avoid shared l
 
 3. If already on the latest version, report that and stop. Otherwise, proceed to build.
 
-4. Build the latest version statically with CGO disabled (use the explicit version tag):
+4. Build the latest version statically with CGO disabled (use the version from step 2):
 
    ```bash
-   CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@v0.54.0
+   CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@latest
    ```
 
    `CGO_ENABLED=0` forces pure-Go alternatives for all dependencies (ICU regex, SQLite, etc.), producing a binary with zero shared library dependencies.
+
+   > **macOS warning:** `CGO_ENABLED=0` can cause crashes (e.g., during `bd init`) due to CGO/SQLite incompatibilities on macOS. macOS users should use `CGO_ENABLED=1` instead — see upstream `docs/INSTALLING.md` for details.
 
 5. Verify:
 
    ```bash
    bd --version
+   # Linux:
    ldd "$(which bd)" 2>&1  # Should say "not a dynamic executable"
+   # macOS:
+   otool -L "$(which bd)"  # Should show no external library entries
    ```
 
 ## Why static?
 
 The `bd` binary uses `go-icu-regex` (CGo) which links against the system's ICU library. Different machines have different ICU versions (e.g., Homebrew's `icu4c@77` vs system `libicu76`), causing runtime failures:
 
-```
+```text
 bd: error while loading shared libraries: libicui18n.so.77: cannot open shared object file
 ```
 


### PR DESCRIPTION
## Summary
- Adds `build-bd` skill that installs/upgrades the beads CLI (`bd`) with `CGO_ENABLED=0` for fully static builds
- Avoids ICU shared library version mismatches across machines (e.g., Homebrew `icu4c@77` vs system `libicu76`)
- Checks latest version first, skips build if already up to date

## Test plan
- [ ] Run `/build-bd` on a fresh machine — should install latest `bd` statically
- [ ] Run `/build-bd` when already on latest — should report up to date and skip
- [ ] Verify `ldd $(which bd)` says "not a dynamic executable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a step-by-step skill guide for installing and upgrading a fully static bd CLI. Includes how to check current and latest versions, retrieve the latest release, build with CGO disabled for zero shared-library dependencies, verify the resulting binary at runtime, and explains the rationale for static linking with example commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->