### PR TITLE
Replace pre-commit with prek in all conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --status in_progress  # Claim work
+bd close <id>         # Complete work
+bd sync               # Sync with git
+```
+
+## Landing the Plane (Session Completion)
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd sync
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+

--- a/dev-inner-loop/clean-commits.md
+++ b/dev-inner-loop/clean-commits.md
@@ -6,7 +6,7 @@ When making commits propose to the user to split them to be logical users.
 
 ### Avoid mixing linting/formatting with edits.
 
-Before editig a file, try to run the pre-commit hooks on it.
+Before editing a file, try to run the prek hooks on it.
 If something is changed, propose committing it by itself.
 
 E.g.
@@ -14,10 +14,9 @@ E.g.
 ```
 git stash # store other changes
 git add file_to_change
-pre-commit
+prek run --files file_to_change
 git add file_to_change  # if it was changed
-git commit -m "chore: pre-commiting  file_to_change
-
+git commit -m "chore: apply formatting to file_to_change"
 ```
 
 ### Seeing full diffs
@@ -93,4 +92,4 @@ git commit -m "Add feature X"
 
 Try to avoid grouping independent changes in 1 checkin. If it makes sense, offer the user to split them into logical commits
 
-Run pre-commit before trying to commit and after staging.
+Run prek before trying to commit and after staging.

--- a/dev-setup/beads.md
+++ b/dev-setup/beads.md
@@ -120,32 +120,14 @@ git push
 
 ### 5. Install Git Hooks for Zero-Lag Sync
 
-Create `.githooks/pre-commit`:
+Chain bd hooks on top of prek (see [githooks.md](./githooks.md)):
 
 ```bash
-#!/bin/bash
-# Flush pending beads changes before commit
-if command -v bd &> /dev/null && [ -d ".beads" ]; then
-    bd sync --quiet 2>/dev/null || true
-fi
+prek install               # Install prek hook first
+bd hooks install --chain   # Chain bd hooks on top
 ```
 
-Create `.githooks/post-merge`:
-
-```bash
-#!/bin/bash
-# Import beads changes after merge/pull
-if command -v bd &> /dev/null && [ -d ".beads" ]; then
-    bd sync --quiet 2>/dev/null || true
-fi
-```
-
-Enable hooks:
-
-```bash
-git config core.hooksPath .githooks
-chmod +x .githooks/pre-commit .githooks/post-merge
-```
+This installs pre-commit, post-merge, and other hooks automatically. Do NOT use `core.hooksPath` — it conflicts with prek.
 
 ### 6. Use a Dedicated Sync Branch
 

--- a/dev-setup/justfile.md
+++ b/dev-setup/justfile.md
@@ -6,7 +6,7 @@ default:
     @just --list
 ```
 
-Ensure we always have a test command, and fast-test command (it's called by pre-commit).
+Ensure we always have a test command, and fast-test command (it's called by prek hooks).
 It can just print 0/0 tests passed until we have more tests
 
 ```


### PR DESCRIPTION
## Summary

- Rewrite `dev-setup/githooks.md` to document prek as the standard git hooks tool
- Update `dev-setup/beads.md` to use `bd hooks install --chain` instead of `.githooks/` + `core.hooksPath`
- Update `dev-inner-loop/clean-commits.md` to reference `prek run` instead of `pre-commit`
- Update `dev-setup/justfile.md` to reference prek hooks

prek is a Rust-based drop-in replacement for Python pre-commit. Same `.pre-commit-config.yaml`, faster startup, no Python runtime.

## Test plan

- [x] All hooks pass on commit
- [x] Conventions are internally consistent (no remaining pre-commit references in guidance docs)
- [x] `.pre-commit-config.yaml` unchanged (prek reads it as-is)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup and workflow guides to replace pre-commit tool references with prek
  * Revised hook installation process to use prek chaining for integrated tools
  * Updated example commands and corrected documentation typos

<!-- end of auto-generated comment: release notes by coderabbit.ai -->