### PR TITLE
Add clock and background-usage skills

### DIFF
--- a/skills/background-usage/SKILL.md
+++ b/skills/background-usage/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: background-usage
+description: Check Claude Code plan usage via a hidden tmux session. Reports weekly usage percentage, time until reset, and pacing status.
+allowed-tools: Bash, Read
+---
+
+# Background Usage Check
+
+Check your Claude Code plan usage without leaving your current session. Spawns a hidden tmux session, captures the `/usage` output, and reports a summary.
+
+## Steps
+
+### 1. Clean up any stale session
+
+```bash
+tmux kill-session -t cc-usage-check 2>/dev/null || true
+```
+
+### 2. Spawn hidden Claude session
+
+```bash
+tmux new-session -d -s cc-usage-check "claude"
+```
+
+### 3. Wait for Claude to start
+
+Poll until the Claude prompt appears (look for the `❯` character):
+
+```bash
+for i in $(seq 1 20); do
+  if tmux capture-pane -t cc-usage-check -p 2>/dev/null | grep -q '❯'; then
+    echo "Claude ready after ${i}s"
+    break
+  fi
+  sleep 1
+done
+```
+
+If Claude is not ready after 20 seconds, clean up and report an error.
+
+### 4. Send /usage and wait for output
+
+```bash
+tmux send-keys -t cc-usage-check '/usage' Enter
+```
+
+Poll until the usage dialog appears (look for "% used"):
+
+```bash
+for i in $(seq 1 30); do
+  if tmux capture-pane -t cc-usage-check -p 2>/dev/null | grep -q '% used'; then
+    echo "Usage dialog ready after ${i}s"
+    break
+  fi
+  sleep 1
+done
+```
+
+### 5. Capture and clean up
+
+```bash
+tmux capture-pane -t cc-usage-check -p > /tmp/cc-usage-output.txt
+tmux kill-session -t cc-usage-check 2>/dev/null || true
+```
+
+**Always kill the session**, even if earlier steps failed. If any step above errored, run the kill command before reporting the error.
+
+### 6. Read and parse the output
+
+Read `/tmp/cc-usage-output.txt` and extract ONLY the "Current week (all models)" section. Ignore "Current session" and "Current week (Sonnet only)" lines.
+
+From that section, extract:
+- **Usage percentage**: the number before "% used"
+- **Reset date/time**: from the "Resets" line (e.g., "Resets Mar 21, 3pm (UTC)")
+
+### 7. Calculate time remaining
+
+Get the current UTC time for comparison:
+
+```bash
+date -u '+%Y-%m-%d %H:%M UTC'
+```
+
+From the reset date/time (which is in UTC), calculate hours remaining from now.
+
+- If >= 48 hours remaining: report as "N days"
+- If < 48 hours remaining: report as "N hours"
+
+### 8. Calculate pacing
+
+Determine what percentage of the weekly period has elapsed (the period is 7 days, use the reset time to work backward to find the start).
+
+- `time_elapsed_pct` = percentage of the 7-day period that has passed
+- `usage_pct` = the usage percentage from step 6
+
+Pacing:
+- If `usage_pct <= time_elapsed_pct` → "On track"
+- If `usage_pct > time_elapsed_pct` but `usage_pct < 2 * time_elapsed_pct` → "Burning fast"
+- If `usage_pct >= 2 * time_elapsed_pct` → "Slow down"
+
+### 9. Report
+
+Output a single-line summary:
+
+> **Usage: N% used | X days until reset | On track**
+
+Examples:
+> **Usage: 9% used | 4 days until reset | On track**
+> **Usage: 65% used | 18 hours until reset | Burning fast**
+> **Usage: 40% used | 6 days until reset | Slow down**
+
+If capture failed or output was empty:
+> **Usage: ERROR — could not capture /usage output. The cc-usage-check tmux session has been cleaned up.**
+
+## Safety
+
+- Always kill the `cc-usage-check` tmux session when done, even on failure
+- If the tmux session already exists, kill it first before creating a new one
+- If capture fails or output is empty, report the error template above instead of guessing
+- This skill assumes `claude` is on PATH and the user is already authenticated

--- a/skills/clock/SKILL.md
+++ b/skills/clock/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: clock
+description: Schedule recurring tasks in your session. Defaults to time check every 15 min.
+allowed-tools: Bash, CronCreate, CronList, CronDelete, Skill
+---
+
+# Clock — Session Scheduler
+
+Schedule a recurring task in your session. Reports the current time, then sets up a CronCreate loop.
+
+## Usage
+
+```
+/clock                          # default: time every 15 min
+/clock 15m                      # time every 15 min (explicit)
+/clock 4h /background-usage     # run /background-usage every 4 hours
+/clock 30m remind me to stretch # custom reminder every 30 min
+/clock 1h time                  # time every hour
+```
+
+**Arguments:**
+- **interval** (optional): Duration like `15m`, `30m`, `1h`, `4h`. Default: `15m`
+- **action** (optional): What to do on each tick. Default: `time`
+  - `time` — report current time
+  - `/skill-name` — invoke a skill (e.g., `/background-usage`)
+  - any other text — use as a reminder message
+
+**Supported intervals:** `15m`, `20m`, `30m`, `1h`, `2h`, `4h`. Other values are not supported — ask the user to pick a supported interval.
+
+## Steps
+
+### 1. Parse arguments
+
+Extract interval and action from the arguments. If no arguments, use `15m` and `time`.
+
+### 2. Report current time and execute action immediately
+
+Always report the current time first:
+
+```bash
+echo "PST: $(TZ='America/Los_Angeles' date '+%I:%M %p %Z (%A, %B %d, %Y)')"
+```
+
+Tell the user conversationally:
+
+> It's 3:45 PM PST, Monday Mar 17.
+
+Then execute the action right now (this IS the first tick — no separate one-shot needed):
+- If action is `time`: you just reported it, done.
+- If action is `/skill-name`: invoke the skill now.
+- If action is custom text: show the reminder now.
+
+### 3. Convert interval to cron expression
+
+| Interval | Cron expression | Notes |
+|----------|----------------|-------|
+| `15m`    | `3,18,33,48 * * * *` | At :03, :18, :33, :48 each hour |
+| `20m`    | `7,27,47 * * * *` | At :07, :27, :47 each hour |
+| `30m`    | `7,37 * * * *` | At :07, :37 each hour |
+| `1h`     | `57 * * * *` | At :57 each hour |
+| `2h`     | `57 */2 * * *` | Every 2 hours at :57 |
+| `4h`     | `57 */4 * * *` | Every 4 hours at :57 |
+
+### 4. Build the cron prompt
+
+**If action is `time`:**
+```
+Report the current time to the user. Run: TZ='America/Los_Angeles' date '+%I:%M %p %Z (%A, %B %d, %Y)' — then tell them the time in one line, e.g. "Clock: It's 4:48 PM PST, Monday Mar 17." Keep it to one line.
+```
+
+**If action is a `/skill-name`:**
+```
+Run the <skill-name> skill now.
+```
+
+**If action is custom text:**
+```
+Reminder: <the text>. Also report the current time (run: TZ='America/Los_Angeles' date '+%I:%M %p %Z').
+```
+
+### 5. Create the recurring cron job
+
+- **cron**: (from step 3)
+- **recurring**: true
+- **prompt**: (from step 4)
+
+### 6. Set up self-renewal
+
+CronCreate jobs auto-expire after 3 days. Create a one-shot renewal that fires ~70 hours from now and re-invokes `/clock` with the same arguments.
+
+Use `date` to calculate the renewal time reliably:
+
+```bash
+date -u -d '+70 hours' '+%M %H %d %m *'
+```
+
+Use that output directly as the cron expression.
+
+- **cron**: (output of the date command above)
+- **recurring**: false
+- **prompt**: `The clock cron job is about to expire. Re-invoke: /clock <original arguments>. Run the skill now.`
+
+### 7. Confirm
+
+> Scheduled: **<action>** every **<interval>**. Auto-renews before the 3-day expiry.
+
+## Notes
+
+- If the user runs `/clock` again with the same or different args, just create new cron jobs — a few hours of overlap is fine.
+- All cron minutes are offset to avoid :00/:15/:30/:45 congestion marks.
+- Session-only: all cron jobs die when Claude exits.
+- For `/skill-name` actions, the skill must be available in the session.


### PR DESCRIPTION
## Summary

- **clock**: Session scheduler via CronCreate. Defaults to time check every 15 min, accepts interval + action args (e.g., `/clock 4h /background-usage`). Self-renews before 3-day expiry.
- **background-usage**: Checks plan usage by spawning a hidden tmux session, sending `/usage`, and capturing output via polling. Reports weekly usage %, time until reset, and pacing (on track / burning fast / slow down).

## Test plan

- [ ] Run `/clock` in a session, verify time is reported and cron job is created
- [ ] Run `/clock 4h /background-usage` and verify scheduled action
- [ ] Run `/background-usage` and verify tmux session is created, captured, and cleaned up
- [ ] Verify symlinks in `~/.claude/skills/` resolve correctly

🤖 Generated with [Claude Code](https://claude.ai/claude-code)