### PR TITLE
Allow force push for backlink-only fork divergence

### DIFF
--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -114,6 +114,6 @@ Ask: "Want to `/clear` context for a fresh start?"
 
 ## Safety
 
-- NEVER force push
+- NEVER force push — **except** when syncing a fork's main and the only divergence is automated backlink commits (`chore: update backlinks [skip ci]`). In that case, force push to the fork is safe and expected.
 - NEVER delete unmerged branches without asking
 - NEVER commit/discard uncommitted changes without user approval


### PR DESCRIPTION
## Summary
- Updates the up-to-date skill's safety rules to allow force pushing a fork's main when the only divergence is automated backlink commits (`chore: update backlinks [skip ci]`)
- This is a safe, expected scenario that previously required manual approval every time

## Test plan
- [ ] Run `/up-to-date` on a repo where fork main diverged due to backlink commits
- [ ] Verify force push proceeds without unnecessary prompting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated safety guidance to permit force pushing when syncing a fork's main branch with only automated backlink commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->