### PR TITLE
Add learn-from-session skill + two CLAUDE.md guardrails

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,10 @@ git push -u origin <branch>
 gh pr create --repo idvorkin/chop-conventions
 ```
 
+## Process-Signaling Safety
+
+Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) MUST exclude lifeline processes or risk wedging the VM / locking out the SSH session: `tailscaled`, `etserver`, **`etterminal`**, `tmux` (bare + `"tmux:"*`), `sshd`, init-like (`sh`, `init`, `systemd`), and kernel threads (`kthreadd`, `kworker*`, `ksoftirqd*`, `migration*`, `rcu_*`). Test the exclude list with a unit test before deploying — see `skills/machine-doctor/doctor-guards.md` for an example.
+
 ## Structure
 
 - `dev-setup/` - Development environment configuration (beads, hooks, gitignore, justfile, tailscale)
@@ -45,6 +49,10 @@ Skills are Claude Code slash commands that live in `skills/<name>/SKILL.md`.
   - Machine-level (all projects): `~/.claude/skills/<name>` -> `<chop-conventions>/skills/<name>`
   - Project-level (one project): `<project>/.claude/skills/<name>` -> `<chop-conventions>/skills/<name>`
 - After adding a skill, create the symlink and document it in the README skills table
+
+### Size Guideline
+
+When a skill's `SKILL.md` exceeds ~500 lines, or a single tier's detail exceeds ~100 lines, factor the tier into a supplementary `.md` in the same directory with a "loaded on demand" note at the top. `SKILL.md` stays navigable at a glance; detailed runbooks live next door. See `skills/machine-doctor/doctor-guards.md` as a reference.
 
 ## Agents
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Machine-level skills go in `~/.claude/skills/` and are available everywhere. Pro
 | `gen-image` | machine | Generate illustrations via Gemini image API |
 | `gist-image` | machine | Host images on GitHub gists for PRs/issues |
 | `image-explore` | machine | Brainstorm and compare visual directions |
+| `learn-from-session` | machine | Extract durable lessons from a session into the right CLAUDE.md files |
 | `machine-doctor` | machine | Diagnose system health, kill rogue processes |
 | `showboat` | machine | Create executable demo documents with screenshots |
 | `up-to-date` | machine | Sync git repo with upstream |

--- a/skills/learn-from-session/SKILL.md
+++ b/skills/learn-from-session/SKILL.md
@@ -1,56 +1,50 @@
 ---
 name: learn-from-session
-description: Extract durable lessons from a completed Claude session and codify them in the right CLAUDE.md files. Use at the end of a long session, after a bug hunt that surfaced an environmental quirk, or when the user asks "what can we learn from this session". Proposes brief, filtered additions and asks for approval before editing.
+description: Extract durable lessons from a completed Claude session and codify them in the right CLAUDE.md files or skills. Use at the end of a long session, after a bug hunt that surfaced a non-obvious constraint, or when the user asks "what can we learn from this session". Discovers CLAUDE.md files dynamically, routes lessons by generic scope (project / shared conventions / environment / machine-local), enforces neutral voice, and asks for approval before editing.
 allowed-tools: Bash, Read, Edit, Glob, Grep
 ---
 
 # Learn From Session
 
-Extract durable lessons from the current session and apply them to the right CLAUDE.md file(s). Igor-specific counterpart to `claude-md-management:revise-claude-md` — aware of this dev environment's repo layout (larry-blog / settings / chop-conventions) and quirks (OrbStack VM, no systemd, fork workflow).
+Extract durable lessons from the current session and apply them to the right CLAUDE.md file(s) or skills. Works on any machine with any repo layout — discovers CLAUDE.md files dynamically, routes by scope category not by repo name.
 
 ## When to use
 
 - User says "what can we learn from this session", "apply to CLAUDE.md", or similar
 - End of a long session where multiple corrections piled up
 - After a bug hunt that uncovered a non-obvious environmental constraint
-- After shipping a new pattern worth standardizing (e.g., `~/.zshrc` boot hook, exclude list for signal-based scripts)
+- After shipping a new pattern worth standardizing (boot hook, exclude list, dep check recipe)
 
-**Do NOT use** when the session was routine — not every session produces CLAUDE.md-worthy material. If the reflection step yields nothing durable, say so and stop.
+**Do NOT use** when the session was routine. Not every session produces CLAUDE.md-worthy material. If the reflection step yields nothing durable, say so and stop.
 
 ## The Iron Rule: Brevity
 
 CLAUDE.md files are loaded into every prompt on every turn. Every line costs tokens on every future call. Additions must earn their cost.
 
-Target: **≤5 lines per addition**, bullets preferred. One concept per line.
+Target: **≤5 lines per addition**, bullets preferred. One concept per line. Skills can be longer since they're loaded on demand, but CLAUDE.md is a hard cap.
 
-## Step 0: Identify Target Repos and Files
+## Step 0: Discover CLAUDE.md Files
 
-Known CLAUDE.md homes for Igor's environment:
+Find every CLAUDE.md and `.claude.local.md` that could be a target. Start from repos actually touched in this session, then broaden.
 
 ```bash
-find ~/gits/larry-blog ~/settings ~/gits/chop-conventions -maxdepth 3 -name CLAUDE.md 2>/dev/null
+# Active working dirs from this session (infer from git contexts you've used)
+# Then find CLAUDE.md / .claude.local.md under each + under $HOME
+find <repo-1> <repo-2> "$HOME" -maxdepth 4 \
+    \( -name CLAUDE.md -o -name .claude.local.md \) 2>/dev/null
 ```
 
-Scope routing:
-
-| Type of lesson | Home |
-|---|---|
-| OrbStack/VM environment quirk, bash pattern, tool alias, shell pitfall | `~/settings/CLAUDE.md` |
-| Skill format / agent rules / general coding rules / process-safety / PR hygiene | `~/gits/chop-conventions/CLAUDE.md` |
-| Blog content workflow / post placement / TOC / AI slop label / permalink rules | `~/gits/larry-blog/CLAUDE.md` |
-| Something specific to a project you were working in | That project's `CLAUDE.md` |
-
-If a lesson spans scopes, pick the most specific home.
+For each file found, **Read its opening section** to understand what scope it covers. Do not infer scope from the path — names and layouts differ across machines. A file named `settings/CLAUDE.md` might be dotfiles on one machine and a project's user-facing settings docs on another.
 
 ## Step 1: Reflect
 
 Walk back through the session and answer these prompts explicitly. Each should have either a concrete answer or "none in this session":
 
-1. **What environmental constraint surprised us?** (e.g., `/sys/fs/cgroup` read-only, no systemd as PID 1, tool aliased to a non-standard binary, file doesn't exist on first run)
-2. **What safety gotcha almost shipped?** (e.g., lifeline process missing from an exclude list, race condition, signal handler timing, destructive default)
-3. **What was the *right* place for content we initially put in the *wrong* place?** (e.g., blog post choice, skill size, file hierarchy, module boundary)
-4. **What pattern worked well enough to codify?** (e.g., idempotent boot hook, dependency check before main loop, smoke test with low thresholds, rebase-before-PR)
-5. **What tool invocation ate time before landing on the right one?** (e.g., `ps --sort` failed because `ps` is aliased to `procs`; `pgrep` matched the current shell because the pattern wasn't anchored)
+1. **What environmental constraint surprised us?** (host OS quirk, container limitation, read-only filesystem, PID 1 weirdness, tool shadowed by an alias, binary at an unexpected path)
+2. **What safety gotcha almost shipped?** (lifeline process missing from an exclude list, race condition, signal handler timing, destructive default, missing dep check)
+3. **What was the *right* place for content we initially put in the *wrong* place?** (file choice, module boundary, doc location, skill boundary)
+4. **What pattern worked well enough to codify?** (idempotent boot hook, dep check before main loop, smoke test with low thresholds, rebase-before-PR)
+5. **What tool invocation ate time before landing on the right one?** (wrong flag, shadowed binary, pattern that matched unintended targets, subshell trap timing)
 
 If fewer than two prompts have real answers, the session likely doesn't need CLAUDE.md updates. Tell the user and stop.
 
@@ -59,17 +53,28 @@ If fewer than two prompts have real answers, the session likely doesn't need CLA
 Keep only lessons that are:
 
 - **Durable** — will be true in future sessions, not specific to this bug or commit
-- **Non-obvious** — not already in the default Claude Code system prompt (e.g., "prefer editing existing files" is already there)
+- **Non-obvious** — not already in the default Claude Code system prompt or trivially discoverable
 - **Actionable** — tells a future Claude what to do or not do, not just a retrospective story
 
 Discard:
 
 - One-off fix narratives ("in this session we fixed X by doing Y")
-- Anything already in the repo's CLAUDE.md, the default system prompt, or chop-conventions guardrails
+- Anything already in the repo's CLAUDE.md, the default system prompt, or shared guardrails
 - Warnings about behavior that a self-aware Claude would discover in one tool call
-- Things that would be true of any Linux box (CLAUDE.md should capture what's special here)
+- Things that would be true of any Linux/Mac box — CLAUDE.md captures what's *special* about this environment
 
-## Step 3: Draft Additions
+## Step 3: Route Each Lesson to a Scope
+
+Use **generic scope categories**, most-specific-wins. Do not route by repo name — route by what kind of rule the lesson is.
+
+1. **Project-local** — specific to the repo you're actively working in (its layout, conventions, PR flow, domain rules). Goes in that repo's `CLAUDE.md`.
+2. **Shared conventions** — general coding / skill / PR / safety rules that apply across multiple projects. Goes in whichever repo holds cross-project conventions (varies by environment — could be a `conventions/`, `shared/`, or similar repo).
+3. **Environment / machine / shell** — OS quirks, tool aliases, boot mechanisms, path surprises, shell patterns. Goes in the repo that owns dotfiles / machine setup for this environment.
+4. **Truly personal or machine-only** — applies to one machine only and should not be committed. Goes in `.claude.local.md` (must be gitignored).
+
+If a lesson spans scopes, pick the most specific. If you're unsure which file owns a lesson, show the user both options and ask.
+
+## Step 4: Draft Concise Additions
 
 For each surviving lesson, write the addition in this shape:
 
@@ -83,47 +88,73 @@ For each surviving lesson, write the addition in this shape:
 ​```
 ```
 
-Style rules:
+### Voice rules — critical
 
-- **No narrative.** Don't say "in this session...". Write as a durable rule.
+CLAUDE.md is a **directive to a future Claude**, not a personal diary or retrospective. Future Claude is the reader; the current user is *not* in the frame.
+
+**Wrong voice** (do not write CLAUDE.md like this):
+
+- First person singular: "I prefer X", "I learned that...", "my workflow is..."
+- Collective first person: "we discovered", "we do X this way"
+- Named-user anecdotes: "the user is on a Mac", "Igor likes...", "Alice prefers..."
+- Past-tense narrative: "the session showed that...", "yesterday we hit..."
+- Opinion framing: "I think this is better", "this feels cleaner"
+
+**Right voice:**
+
+- Imperative: "Prefer X", "Use Y before Z", "Exclude lifeline processes from signal-based scripts"
+- Declarative fact: "PID 1 is a bash respawn loop, NOT systemd", "`ps` is aliased to `procs`"
+- Neutral rule: "Scripts that send signals by pattern MUST exclude..."
+
+**Voice check before showing diffs:** re-read each proposed addition. Would it still make sense to a reader who never saw this session? If it only works as a message *from* the original user, rewrite it as a standalone rule.
+
+### Style rules
+
+- **No narrative.** Never say "in this session..." — write as a durable rule, not as a report.
 - **No preamble.** Jump straight to the fact or the instruction.
-- **Use code fences for commands and file paths.** Make them skimmable.
+- **Use code fences** for commands and file paths so they're skimmable.
 - **Bold only the one key term** a reader would grep for. Not the whole bullet.
-- **Avoid duplication.** If a nearby CLAUDE.md section already touches the topic, extend it instead of adding a new section.
+- **Avoid duplication.** If a nearby section already touches the topic, extend it instead of adding a new section.
 
-## Step 4: Present and Approve
+## Step 5: Consider Skill Changes
 
-Show all proposed diffs in one message, grouped by target file. End with a single explicit ask: "Apply these?" Wait for explicit approval before editing any file. Don't partial-apply unless the user picks specific ones.
+Not every lesson belongs in CLAUDE.md. Some lessons are better expressed as:
 
-## Step 5: Apply
+- **An update to an existing skill** — if the lesson is a new check, constraint, or step that a skill should enforce (e.g., "the doctor skill should verify X"), propose editing that skill's `SKILL.md` instead of CLAUDE.md.
+- **A new skill** — if the lesson is a repeatable workflow or recipe that doesn't fit any existing skill, propose a new skill directory with its own `SKILL.md`. Example triggers: a pattern the session re-used three times, a bespoke multi-step recipe, a safety check that should become callable.
+
+Surface these proposals in the Step 6 diff batch alongside CLAUDE.md changes so the user can approve everything together. Skills can be longer than CLAUDE.md entries since they're loaded on demand, but still follow the voice rules — skills are also directives to a future Claude.
+
+## Step 6: Present and Approve
+
+Show all proposed changes in one message, grouped by target file. Include CLAUDE.md diffs, skill updates, and new-skill proposals side by side. End with a single explicit ask: "Apply these?" Wait for explicit approval before editing any file. Do not partial-apply unless the user picks specific items.
+
+## Step 7: Apply
 
 On approval:
 
-1. **Create a feature branch per repo** — naming: `claude-md-<short-topic>` or `claude-md-session-<date>`
-2. **Apply the edits** using the Edit tool (not Write — these are targeted insertions)
-3. **Commit per repo** with a descriptive message that cites the session learning, not "update CLAUDE.md". Include the standard `Co-Authored-By` trailer.
-4. **Push to origin** (the fork) and **create a PR against upstream** — check `gh auth status` first to confirm the fork workflow applies
-5. **Report PR URLs with `/files` appended** so the user can skim the diff directly
+1. **Create a feature branch per repo** — naming: `claude-md-<short-topic>` or `session-learnings-<date>`
+2. **Apply edits** using the Edit tool (not Write — these are targeted insertions)
+3. **Commit per repo** with a descriptive message that cites the lesson itself, not "update CLAUDE.md". Include the standard `Co-Authored-By` trailer.
+4. **Push** and **create a PR** if the repo uses a PR workflow — check `gh auth status` and `git remote -v` first to detect fork vs direct-push flow. Otherwise commit locally and inform the user.
+5. **Report** PR URLs with `/files` appended so the user can skim diffs directly.
 
 If the user says "just commit locally, no PR" or "just do it on main", follow that instead — but ask if unclear.
-
-## Step 6: Optional — Also Update a Related Skill
-
-If the lesson is a recurring pattern that deserves automation (e.g., a new type of check, a new safety rule that should be enforced by tooling), consider whether an existing skill can codify it. Flag this to the user as a follow-up, don't action it in the same session without explicit direction.
 
 ## Anti-patterns
 
 Red flags that you're adding noise to CLAUDE.md:
 
-- **Narrative phrasing** — "We learned that X...", "In this session we discovered...", "Remember that..."
+- **Wrong voice** — first person ("I", "we"), named-user anecdotes ("Igor likes"), narrative ("in this session we discovered..."), opinion framing ("I think this feels better")
 - **Vague generalities** — "Always test before deploying", "Be careful with X"
-- **Already-covered territory** — "Use feature branches" (already in guardrails), "Prefer editing existing files" (already in system prompt)
+- **Already-covered territory** — guardrail rules already in the shared conventions repo, or things already in the default Claude Code system prompt ("prefer editing existing files", "use feature branches")
 - **One-off bug postmortems** — the bug is fixed; the narrative belongs in the commit message, not CLAUDE.md
 - **Entries longer than 5 lines** without a strong reason
-- **Verbatim code blocks** that exceed ~10 lines — link to the real file instead
-- **Anything a future Claude would trivially discover** — `ls`, `pwd`, `git status` etc.
+- **Verbatim code blocks longer than ~10 lines** — link to the real file instead
+- **Trivial discoverables** — `ls`, `pwd`, `git status`, anything one tool call could surface
+- **Machine-only paths or secrets** — these belong in `.claude.local.md`, not the shared `CLAUDE.md`
 
 ## Related
 
-- `claude-md-management:revise-claude-md` — upstream generic version (this skill is an Igor-aware wrapper)
-- `claude-md-management:claude-md-improver` — audits CLAUDE.md quality across repos; use when you want to *improve* existing content rather than *add* new content
+- `claude-md-management:revise-claude-md` — upstream generic version; this skill adds explicit scope routing, voice rules, and skill-update proposals on top
+- `claude-md-management:claude-md-improver` — audits existing CLAUDE.md quality rather than adding new content

--- a/skills/learn-from-session/SKILL.md
+++ b/skills/learn-from-session/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: learn-from-session
+description: Extract durable lessons from a completed Claude session and codify them in the right CLAUDE.md files. Use at the end of a long session, after a bug hunt that surfaced an environmental quirk, or when the user asks "what can we learn from this session". Proposes brief, filtered additions and asks for approval before editing.
+allowed-tools: Bash, Read, Edit, Glob, Grep
+---
+
+# Learn From Session
+
+Extract durable lessons from the current session and apply them to the right CLAUDE.md file(s). Igor-specific counterpart to `claude-md-management:revise-claude-md` — aware of this dev environment's repo layout (larry-blog / settings / chop-conventions) and quirks (OrbStack VM, no systemd, fork workflow).
+
+## When to use
+
+- User says "what can we learn from this session", "apply to CLAUDE.md", or similar
+- End of a long session where multiple corrections piled up
+- After a bug hunt that uncovered a non-obvious environmental constraint
+- After shipping a new pattern worth standardizing (e.g., `~/.zshrc` boot hook, exclude list for signal-based scripts)
+
+**Do NOT use** when the session was routine — not every session produces CLAUDE.md-worthy material. If the reflection step yields nothing durable, say so and stop.
+
+## The Iron Rule: Brevity
+
+CLAUDE.md files are loaded into every prompt on every turn. Every line costs tokens on every future call. Additions must earn their cost.
+
+Target: **≤5 lines per addition**, bullets preferred. One concept per line.
+
+## Step 0: Identify Target Repos and Files
+
+Known CLAUDE.md homes for Igor's environment:
+
+```bash
+find ~/gits/larry-blog ~/settings ~/gits/chop-conventions -maxdepth 3 -name CLAUDE.md 2>/dev/null
+```
+
+Scope routing:
+
+| Type of lesson | Home |
+|---|---|
+| OrbStack/VM environment quirk, bash pattern, tool alias, shell pitfall | `~/settings/CLAUDE.md` |
+| Skill format / agent rules / general coding rules / process-safety / PR hygiene | `~/gits/chop-conventions/CLAUDE.md` |
+| Blog content workflow / post placement / TOC / AI slop label / permalink rules | `~/gits/larry-blog/CLAUDE.md` |
+| Something specific to a project you were working in | That project's `CLAUDE.md` |
+
+If a lesson spans scopes, pick the most specific home.
+
+## Step 1: Reflect
+
+Walk back through the session and answer these prompts explicitly. Each should have either a concrete answer or "none in this session":
+
+1. **What environmental constraint surprised us?** (e.g., `/sys/fs/cgroup` read-only, no systemd as PID 1, tool aliased to a non-standard binary, file doesn't exist on first run)
+2. **What safety gotcha almost shipped?** (e.g., lifeline process missing from an exclude list, race condition, signal handler timing, destructive default)
+3. **What was the *right* place for content we initially put in the *wrong* place?** (e.g., blog post choice, skill size, file hierarchy, module boundary)
+4. **What pattern worked well enough to codify?** (e.g., idempotent boot hook, dependency check before main loop, smoke test with low thresholds, rebase-before-PR)
+5. **What tool invocation ate time before landing on the right one?** (e.g., `ps --sort` failed because `ps` is aliased to `procs`; `pgrep` matched the current shell because the pattern wasn't anchored)
+
+If fewer than two prompts have real answers, the session likely doesn't need CLAUDE.md updates. Tell the user and stop.
+
+## Step 2: Filter by Durability
+
+Keep only lessons that are:
+
+- **Durable** — will be true in future sessions, not specific to this bug or commit
+- **Non-obvious** — not already in the default Claude Code system prompt (e.g., "prefer editing existing files" is already there)
+- **Actionable** — tells a future Claude what to do or not do, not just a retrospective story
+
+Discard:
+
+- One-off fix narratives ("in this session we fixed X by doing Y")
+- Anything already in the repo's CLAUDE.md, the default system prompt, or chop-conventions guardrails
+- Warnings about behavior that a self-aware Claude would discover in one tool call
+- Things that would be true of any Linux box (CLAUDE.md should capture what's special here)
+
+## Step 3: Draft Additions
+
+For each surviving lesson, write the addition in this shape:
+
+```
+### Update: <absolute path to CLAUDE.md>
+
+**Why:** <one-line justification citing this session's cost or risk>
+
+​```diff
++ <the addition — ≤5 lines, prefer bullets, no preamble>
+​```
+```
+
+Style rules:
+
+- **No narrative.** Don't say "in this session...". Write as a durable rule.
+- **No preamble.** Jump straight to the fact or the instruction.
+- **Use code fences for commands and file paths.** Make them skimmable.
+- **Bold only the one key term** a reader would grep for. Not the whole bullet.
+- **Avoid duplication.** If a nearby CLAUDE.md section already touches the topic, extend it instead of adding a new section.
+
+## Step 4: Present and Approve
+
+Show all proposed diffs in one message, grouped by target file. End with a single explicit ask: "Apply these?" Wait for explicit approval before editing any file. Don't partial-apply unless the user picks specific ones.
+
+## Step 5: Apply
+
+On approval:
+
+1. **Create a feature branch per repo** — naming: `claude-md-<short-topic>` or `claude-md-session-<date>`
+2. **Apply the edits** using the Edit tool (not Write — these are targeted insertions)
+3. **Commit per repo** with a descriptive message that cites the session learning, not "update CLAUDE.md". Include the standard `Co-Authored-By` trailer.
+4. **Push to origin** (the fork) and **create a PR against upstream** — check `gh auth status` first to confirm the fork workflow applies
+5. **Report PR URLs with `/files` appended** so the user can skim the diff directly
+
+If the user says "just commit locally, no PR" or "just do it on main", follow that instead — but ask if unclear.
+
+## Step 6: Optional — Also Update a Related Skill
+
+If the lesson is a recurring pattern that deserves automation (e.g., a new type of check, a new safety rule that should be enforced by tooling), consider whether an existing skill can codify it. Flag this to the user as a follow-up, don't action it in the same session without explicit direction.
+
+## Anti-patterns
+
+Red flags that you're adding noise to CLAUDE.md:
+
+- **Narrative phrasing** — "We learned that X...", "In this session we discovered...", "Remember that..."
+- **Vague generalities** — "Always test before deploying", "Be careful with X"
+- **Already-covered territory** — "Use feature branches" (already in guardrails), "Prefer editing existing files" (already in system prompt)
+- **One-off bug postmortems** — the bug is fixed; the narrative belongs in the commit message, not CLAUDE.md
+- **Entries longer than 5 lines** without a strong reason
+- **Verbatim code blocks** that exceed ~10 lines — link to the real file instead
+- **Anything a future Claude would trivially discover** — `ls`, `pwd`, `git status` etc.
+
+## Related
+
+- `claude-md-management:revise-claude-md` — upstream generic version (this skill is an Igor-aware wrapper)
+- `claude-md-management:claude-md-improver` — audits CLAUDE.md quality across repos; use when you want to *improve* existing content rather than *add* new content

--- a/skills/learn-from-session/SKILL.md
+++ b/skills/learn-from-session/SKILL.md
@@ -88,26 +88,6 @@ For each surviving lesson, write the addition in this shape:
 ​```
 ```
 
-### Voice rules — critical
-
-CLAUDE.md is a **directive to a future Claude**, not a personal diary or retrospective. Future Claude is the reader; the current user is *not* in the frame.
-
-**Wrong voice** (do not write CLAUDE.md like this):
-
-- First person singular: "I prefer X", "I learned that...", "my workflow is..."
-- Collective first person: "we discovered", "we do X this way"
-- Named-user anecdotes: "the user is on a Mac", "Igor likes...", "Alice prefers..."
-- Past-tense narrative: "the session showed that...", "yesterday we hit..."
-- Opinion framing: "I think this is better", "this feels cleaner"
-
-**Right voice:**
-
-- Imperative: "Prefer X", "Use Y before Z", "Exclude lifeline processes from signal-based scripts"
-- Declarative fact: "PID 1 is a bash respawn loop, NOT systemd", "`ps` is aliased to `procs`"
-- Neutral rule: "Scripts that send signals by pattern MUST exclude..."
-
-**Voice check before showing diffs:** re-read each proposed addition. Would it still make sense to a reader who never saw this session? If it only works as a message *from* the original user, rewrite it as a standalone rule.
-
 ### Style rules
 
 - **No narrative.** Never say "in this session..." — write as a durable rule, not as a report.
@@ -145,7 +125,7 @@ If the user says "just commit locally, no PR" or "just do it on main", follow th
 
 Red flags that you're adding noise to CLAUDE.md:
 
-- **Wrong voice** — first person ("I", "we"), named-user anecdotes ("Igor likes"), narrative ("in this session we discovered..."), opinion framing ("I think this feels better")
+- **Narrative phrasing** — "We learned that X...", "In this session we discovered...", "Remember that..."
 - **Vague generalities** — "Always test before deploying", "Be careful with X"
 - **Already-covered territory** — guardrail rules already in the shared conventions repo, or things already in the default Claude Code system prompt ("prefer editing existing files", "use feature branches")
 - **One-off bug postmortems** — the bug is fixed; the narrative belongs in the commit message, not CLAUDE.md


### PR DESCRIPTION
## Summary

New skill plus two CLAUDE.md rules extracted from a recent session that surfaced them:

### 1. New skill: \`learn-from-session\`

At \`skills/learn-from-session/SKILL.md\`. Igor-aware counterpart to \`claude-md-management:revise-claude-md\` — knows about the three-repo layout (larry-blog / settings / chop-conventions) and the OrbStack VM environment, enforces a hard \"≤5 lines per addition\" brevity rule, and filters narrative fluff out of proposed additions.

Install:
\`\`\`bash
ln -sf \$PWD/skills/learn-from-session ~/.claude/skills/learn-from-session
\`\`\`

README updated with the new skill row in Available Skills.

### 2. CLAUDE.md: Process-Signaling Safety

Scripts that signal processes by pattern (cpulimit, pkill, kill-by-comm) MUST exclude lifeline processes: \`tailscaled\`, \`etserver\`, \`etterminal\`, \`tmux\`, \`sshd\`, init-like (\`sh\`, \`init\`, \`systemd\`), and kernel threads. Missing \`etterminal\` in cpu-watchdog.sh's exclude list would have SIGSTOP'd the live SSH session on next runaway — this rule would have caught it before deploy.

### 3. CLAUDE.md: Skill Size

When \`SKILL.md\` exceeds ~500 lines or a single tier passes ~100 lines, factor the tier into a supplementary \`.md\` loaded on demand. Reference: \`skills/machine-doctor/doctor-guards.md\`.

## Test plan

- [x] Skill symlink created at \`~/.claude/skills/learn-from-session\` and resolves correctly
- [x] SKILL.md has valid YAML frontmatter (\`name\`, \`description\`, \`allowed-tools\`)
- [x] CLAUDE.md changes apply cleanly
- [x] README skills table alphabetized correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)