### PR TITLE
up-to-date: replace shell diagnosis with parallel Python helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,15 @@ gh pr create --repo idvorkin/chop-conventions
 
 Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) MUST exclude lifeline processes or risk wedging the VM / locking out the SSH session: `tailscaled`, `etserver`, **`etterminal`**, `tmux` (bare + `"tmux:"*`), `sshd`, init-like (`sh`, `init`, `systemd`), and kernel threads (`kthreadd`, `kworker*`, `ksoftirqd*`, `migration*`, `rcu_*`). Test the exclude list with a unit test before deploying — see `skills/machine-doctor/doctor-guards.md` for an example.
 
+## Scripting Language Defaults
+
+**Default to Python for any non-trivial script, not shell.** Shell is for one-liners and the occasional `just` target. Anything with branching, data structures, or more than ~20 lines should be Python.
+
+- Use the `uv run --script` shebang with an inline PEP 723 dependency block so scripts self-bootstrap — no venvs, no `pip install`, no setup steps for the user. See [`python/uv-shebang-deps.md`](python/uv-shebang-deps.md) and [`python/python-cli.md`](python/python-cli.md).
+- Stdlib is enough for most helpers. Only add dependencies when they earn their keep (Typer + Rich for user-facing CLIs; plain stdlib for programmatic JSON-emitting helpers).
+- Put pure logic behind functions that can be unit-tested without subprocess mocking. Shell out to external tools (`git`, `gh`, etc.) through a thin wrapper so the business logic stays testable.
+- Working example: [`skills/up-to-date/diagnose.py`](skills/up-to-date/diagnose.py) — stdlib-only, `uv run` shebang, parallelized subprocess calls, unit-tested pure functions.
+
 ## Structure
 
 - `dev-setup/` - Development environment configuration (beads, hooks, gitignore, justfile, tailscale)

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,30 @@
+# Python Conventions
+
+**Python is the default scripting language in chop-conventions projects.** Shell is reserved for one-liners and `just` targets. Anything with branching, data structures, or more than ~20 lines should be Python.
+
+## Why Python over shell
+
+- **Readable and testable** — pure functions can be unit-tested with `unittest`/`pytest`; shell logic can't.
+- **Real data structures** — dataclasses, JSON output, exceptions.
+- **Parallelism is tractable** — `concurrent.futures.ThreadPoolExecutor` beats `&`/`wait`/tempfile juggling.
+- **uv makes distribution trivial** — scripts are single files with an inline dependency block; users only need `uv` installed.
+
+The one real downside is that git/gh calls go through a `subprocess.run(...)` wrapper instead of being the script itself. One thin `git()` helper function (3 lines) makes this a non-issue after a handful of calls.
+
+## How to write a Python script
+
+1. **Start with the uv shebang and dependency block.** See [`uv-shebang-deps.md`](uv-shebang-deps.md). Stdlib-only scripts use `dependencies = []`; user-facing CLIs should use Typer + Rich per [`python-cli.md`](python-cli.md).
+2. **Structure for testability.** Put pure logic (parsing, classification, formatting) behind functions with no I/O. Put subprocess calls and file reads in a thin orchestrator that calls those pure functions.
+3. **Shell out through a wrapper.** `def git(*args): return subprocess.run(["git", *args], capture_output=True, text=True, check=True).stdout.strip()` — one helper makes the rest of the script read cleanly.
+4. **Write the test first.** Unit-test the pure functions with `unittest` (stdlib, zero deps). Run with `python3 -m unittest test_<name>.py` from the script's directory.
+
+## Examples
+
+- **Stdlib-only JSON emitter, parallel subprocess:** [`../skills/up-to-date/diagnose.py`](../skills/up-to-date/diagnose.py) + [`../skills/up-to-date/test_diagnose.py`](../skills/up-to-date/test_diagnose.py)
+- **Typer + Rich user-facing CLI:** see [`python-cli.md`](python-cli.md)
+
+## When shell is OK
+
+- One-liners in `justfile` targets
+- Hooks where startup latency matters more than maintainability (rare)
+- Wrapping a Python script with a shebang-less file for a `PATH` entry

--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -8,102 +8,123 @@ allowed-tools: Bash, Read
 
 Diagnose and sync the current git repo with upstream.
 
-## Step 1: Remote Hygiene
+## Step 1: Diagnose
 
-Check remotes follow convention before doing anything else.
-
-**Convention:** `origin` = your fork (push here), `upstream` = canonical repo (PRs target here). Single-remote repos use `origin` as source of truth.
-
-**Fork orgs** (must use PRs, never direct push to canonical): `idvorkin-ai-tools`
+Run the helper — it fetches, queries `gh pr view`, and checks remote hygiene in parallel, then prints JSON:
 
 ```bash
-git remote -v
+~/.claude/skills/up-to-date/diagnose.py
 ```
 
-Check for these problems and report in output table:
-1. **Non-standard names** — remotes named anything other than `origin`/`upstream` (e.g., `fork`)
-2. **Swapped remotes** — `origin` points to canonical repo when a fork remote exists
-3. **Fork org without PR workflow** — a known fork org remote exists but isn't set up as `origin`
+(Project-level installs: the script lives alongside this SKILL.md at `<project>/.claude/skills/up-to-date/diagnose.py`. If `~/.claude/skills/up-to-date/diagnose.py` is missing, use the project-local path instead.)
 
-If issues found, **offer fix commands but don't execute automatically**:
-```bash
-git remote rename <canonical> upstream
-git remote rename <fork> origin
-git branch --set-upstream-to=upstream/main main
+The JSON output has this shape:
+
+```json
+{
+  "remotes": {
+    "entries": [{"name": "origin", "url": "..."}, ...],
+    "source": "upstream",
+    "is_fork_workflow": true,
+    "issues": [{"kind": "...", "detail": "...", "fix": "..."}]
+  },
+  "branch": {
+    "name": "main",
+    "is_main": true,
+    "behind": 0,
+    "ahead": 0,
+    "behind_commits": ["abc123 subject", ...],
+    "leftover_commits": [...]
+  },
+  "worktree": {
+    "uncommitted": ["M  foo.py", ...],
+    "stashes": ["stash@{0}: ...", ...]
+  },
+  "pr": {
+    "state": "MERGED",
+    "number": 42,
+    "title": "...",
+    "mergeable": "MERGEABLE",
+    "review_decision": "APPROVED",
+    "recent_reviews": [...],
+    "recent_comments": [...]
+  },
+  "errors": []
+}
 ```
 
-## Step 2: Diagnose
+Conventions:
+- `remotes.source` is either `"upstream"` (fork workflow) or `"origin"` (single-remote). Use this as `SRC` for all subsequent git commands.
+- `pr` is `null` on main or when no PR exists for the current branch.
+- `branch.leftover_commits` lists commits on a feature branch not yet in `source/main` — relevant when the PR is merged but work continued.
+- `errors` contains any subprocess failures the script wants surfaced (empty on the happy path).
 
-```bash
-# Determine source of truth
-SRC=$(git remote | grep -q '^upstream$' && echo upstream || echo origin)
+## Step 2: Report Hygiene
 
-git fetch --all --prune 2>&1
-git branch --show-current
-git status --porcelain
-git stash list
-echo "Behind $SRC/main:" && git rev-list --count HEAD..$SRC/main
-echo "Ahead of $SRC/main:" && git rev-list --count $SRC/main..HEAD
-git log --oneline HEAD..$SRC/main | head -10
-```
+If `remotes.issues` is non-empty, show them in the output table and offer the `fix` commands — **do not execute automatically**. Known issue kinds:
 
-On a feature branch, also check:
-```bash
-gh pr view --json state,number,title,mergeable,reviewDecision 2>/dev/null || echo "NO_PR"
-```
+- `non_standard_name` — remote named something other than `origin`/`upstream`
+- `swapped_remotes` — `origin` points at canonical while a fork remote exists
+- `fork_without_canonical` — fork remote exists but no canonical upstream
 
 ## Step 3: Act
 
-Use `SRC` from diagnosis. After any action on main, clean up merged branches:
+Use `SRC = remotes.source`. After any action on main, clean up merged branches:
+
 ```bash
 git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
 ```
 
-### On main
+### On main (`branch.is_main` true)
+
 ```bash
 git pull $SRC main
 # Fork workflow: keep fork in sync
 [ "$SRC" = "upstream" ] && git push origin main
 ```
 
-### Feature branch + PR merged
-Check for leftover commits (made after PR merged), then switch to main:
+### Feature branch + PR merged (`pr.state == "MERGED"`)
+
+Check `branch.leftover_commits` first:
+- Non-empty → **ASK USER**: new PR for leftovers, or discard?
+- Empty → safe to switch to main and delete branch
+
 ```bash
 BRANCH=$(git branch --show-current)
-LEFTOVER=$(git log --oneline $SRC/main..$BRANCH)
-# If leftover commits exist → ASK USER: new PR or discard?
 git checkout main && git pull $SRC main
 [ "$SRC" = "upstream" ] && git push origin main
-git branch -d "$BRANCH"  # use -D only if user confirmed discard of leftovers
+git branch -d "$BRANCH"  # use -D only if user confirmed discarding leftovers
 ```
 
-### Feature branch + PR open
-Report status and show recent feedback:
-```bash
-gh pr view --json reviews,comments --jq '.reviews[-3:], .comments[-3:]'
-```
+### Feature branch + PR open (`pr.state == "OPEN"`)
 
-### Feature branch + PR closed (not merged)
-Ask user: delete branch or keep working?
+Report status from the JSON. `pr.recent_reviews` and `pr.recent_comments` already hold the last 3 of each — surface those to the user.
 
-### Feature branch + no PR
-- Has commits ahead → ask if user wants to create PR
-- No commits ahead → ask if user wants to delete branch
+### Feature branch + PR closed, not merged (`pr.state == "CLOSED"`)
+
+**Ask user**: delete branch or keep working?
+
+### Feature branch + no PR (`pr` is null)
+
+- `branch.ahead > 0` → ask if the user wants to create a PR
+- `branch.ahead == 0` → ask if the user wants to delete the branch
 
 ### Uncommitted changes
-List with `git status`. **Ask user**: commit, stash, or discard. Never act automatically.
+
+If `worktree.uncommitted` is non-empty, list the files and **ask user**: commit, stash, or discard. Never act automatically.
 
 ### Stashed changes
-List with `git stash list` and inform user.
+
+If `worktree.stashes` is non-empty, list them and inform the user.
 
 ## Output Format
 
 | Check | Status | Action |
 |---|---|---|
-| Remote naming | pass/fail | Offer rename commands |
+| Remote naming | pass/fail | Offer rename commands from issue `fix` field |
 | Workflow | PR / direct push | Warn if fork org pushing direct |
-| Branch | `branch-name` | — |
-| PR | #N STATE | Context-dependent |
+| Branch | `branch.name` | — |
+| PR | `#N STATE` | Context-dependent |
 | Uncommitted | N files | Listed below |
 | Behind source/main | N commits | Will pull |
 | Stashes | N stashes | Listed below |
@@ -117,3 +138,23 @@ Ask: "Want to `/clear` context for a fresh start?"
 - NEVER force push — **except** when syncing a fork's main and the only divergence is automated backlink commits (`chore: update backlinks [skip ci]`). In that case, force push to the fork is safe and expected.
 - NEVER delete unmerged branches without asking
 - NEVER commit/discard uncommitted changes without user approval
+
+## Manual fallback
+
+If `diagnose.py` is missing or errors, fall back to running commands directly:
+
+```bash
+SRC=$(git remote | grep -q '^upstream$' && echo upstream || echo origin)
+git remote -v
+git fetch --all --prune
+git branch --show-current
+git status --porcelain
+git stash list
+git rev-list --count HEAD..$SRC/main   # behind
+git rev-list --count $SRC/main..HEAD   # ahead
+gh pr view --json state,number,title,mergeable,reviewDecision 2>/dev/null
+```
+
+## Implementation
+
+The `diagnose.py` script is ~150 lines of stdlib Python with a `#!/usr/bin/env -S uv run --script` shebang, so it runs without manual env setup wherever `uv` is installed. Pure classification logic (`parse_remotes`, `is_fork_url`, `classify_remotes`) is unit-tested in `test_diagnose.py` — run `python3 -m unittest test_diagnose.py` from this directory.

--- a/skills/up-to-date/diagnose.py
+++ b/skills/up-to-date/diagnose.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
+"""Diagnose git repo state for the up-to-date skill.
+
+Runs git + gh in parallel and emits a single JSON blob describing:
+    remotes (with hygiene issues), branch state, worktree state, PR state.
+
+The skill reads the JSON and decides what action to take — this script
+does NOT mutate anything.
+
+Usage:
+    ./diagnose.py           # prints JSON to stdout
+    ./diagnose.py --pretty  # pretty-printed JSON
+
+Tested as a library via test_diagnose.py (pure functions importable).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+FORK_ORGS = ["idvorkin-ai-tools"]
+
+
+# ---------- Data types ----------
+
+
+@dataclass(frozen=True)
+class Remote:
+    name: str
+    url: str
+
+
+@dataclass
+class RemoteIssue:
+    kind: str  # non_standard_name | swapped_remotes | fork_without_canonical
+    detail: str
+    fix: str
+
+
+@dataclass
+class RemoteAnalysis:
+    entries: list[Remote]
+    source: str  # "upstream" or "origin"
+    is_fork_workflow: bool
+    issues: list[RemoteIssue] = field(default_factory=list)
+
+
+# ---------- Pure functions (tested) ----------
+
+
+def parse_remotes(raw: str) -> list[Remote]:
+    """Parse `git remote -v` output into a deduped list of Remotes.
+
+    Each remote appears twice (fetch + push); we keep one entry per name.
+    """
+    seen: dict[str, Remote] = {}
+    for line in raw.strip().splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        name, url = parts[0], parts[1]
+        seen.setdefault(name, Remote(name=name, url=url))
+    return list(seen.values())
+
+
+def is_fork_url(url: str, fork_orgs: list[str]) -> bool:
+    """True if a git URL's owner segment matches a known fork org.
+
+    Matches both SSH (`git@github.com:org/repo`) and HTTPS
+    (`https://github.com/org/repo`) URL forms, anchored on the org segment
+    so `idvorkin` does not false-match against `idvorkin-ai-tools`.
+    """
+    for org in fork_orgs:
+        # SSH: git@host:org/...   HTTPS: https://host/org/...
+        pattern = rf"(?::|/){re.escape(org)}(?:/|$)"
+        if re.search(pattern, url):
+            return True
+    return False
+
+
+def classify_remotes(remotes: list[Remote], fork_orgs: list[str]) -> RemoteAnalysis:
+    """Determine source of truth, fork-workflow status, and hygiene issues."""
+    issues: list[RemoteIssue] = []
+    by_name = {r.name: r for r in remotes}
+
+    # Source of truth: prefer upstream, else origin, else first remote.
+    if "upstream" in by_name:
+        source = "upstream"
+    elif "origin" in by_name:
+        source = "origin"
+    elif remotes:
+        source = remotes[0].name
+    else:
+        source = "origin"
+
+    # Check 1: non-standard remote names
+    for r in remotes:
+        if r.name not in ("origin", "upstream"):
+            issues.append(
+                RemoteIssue(
+                    kind="non_standard_name",
+                    detail=f"remote '{r.name}' should be named 'origin' or 'upstream'",
+                    fix=f"git remote rename {r.name} <origin|upstream>",
+                )
+            )
+
+    fork_remotes = [r for r in remotes if is_fork_url(r.url, fork_orgs)]
+    canonical_remotes = [r for r in remotes if not is_fork_url(r.url, fork_orgs)]
+    is_fork_workflow = bool(fork_remotes and canonical_remotes)
+
+    # Check 2: swapped remotes — origin pointing at canonical while fork also exists
+    if fork_remotes and canonical_remotes:
+        origin = by_name.get("origin")
+        upstream = by_name.get("upstream")
+        origin_is_canonical = origin is not None and not is_fork_url(origin.url, fork_orgs)
+        upstream_is_fork = upstream is not None and is_fork_url(upstream.url, fork_orgs)
+        if origin_is_canonical or upstream_is_fork:
+            issues.append(
+                RemoteIssue(
+                    kind="swapped_remotes",
+                    detail="origin should point to your fork; upstream should point to canonical",
+                    fix=(
+                        "git remote rename origin upstream && "
+                        "git remote rename <fork> origin && "
+                        "git branch --set-upstream-to=upstream/main main"
+                    ),
+                )
+            )
+
+    # Check 3: lone fork — fork remote exists but no canonical to PR against
+    if fork_remotes and not canonical_remotes:
+        fork = fork_remotes[0]
+        issues.append(
+            RemoteIssue(
+                kind="fork_without_canonical",
+                detail=f"'{fork.name}' is a fork but no canonical 'upstream' remote exists",
+                fix="git remote add upstream <canonical-repo-url>",
+            )
+        )
+
+    return RemoteAnalysis(
+        entries=remotes,
+        source=source,
+        is_fork_workflow=is_fork_workflow,
+        issues=issues,
+    )
+
+
+# ---------- Subprocess helpers ----------
+
+
+def _run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    """Thin wrapper around subprocess.run capturing text output."""
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def git(*args: str, check: bool = True) -> str:
+    """Run `git <args>` and return stdout (stripped)."""
+    result = _run(["git", *args], check=check)
+    return result.stdout.strip()
+
+
+def gh_pr_view_json(fields: str) -> dict[str, Any] | None:
+    """Run `gh pr view --json <fields>` and return parsed dict, or None if no PR."""
+    proc = _run(["gh", "pr", "view", "--json", fields], check=False)
+    if proc.returncode != 0:
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+# ---------- Orchestrator ----------
+
+
+def run_diagnose() -> dict[str, Any]:
+    """Collect full diagnosis as a JSON-serializable dict."""
+    errors: list[str] = []
+
+    # Remote hygiene — needs to happen before fetch so we know the source name.
+    remotes_raw = git("remote", "-v", check=False)
+    remotes = parse_remotes(remotes_raw)
+    analysis = classify_remotes(remotes, FORK_ORGS)
+    src = analysis.source
+
+    # Run fetch and PR lookup in parallel — they don't depend on each other.
+    # gh pr view reads local branch state, not the remote fetch result.
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        fetch_fut = pool.submit(
+            _run, ["git", "fetch", "--all", "--prune"], False
+        )
+        pr_fut = pool.submit(
+            gh_pr_view_json,
+            "state,number,title,mergeable,reviewDecision,reviews,comments",
+        )
+        fetch_proc = fetch_fut.result()
+        pr_data = pr_fut.result()
+
+    if fetch_proc.returncode != 0:
+        errors.append(f"git fetch failed: {fetch_proc.stderr.strip()}")
+
+    # Branch state
+    branch_name = git("branch", "--show-current", check=False)
+    is_main = branch_name == "main"
+
+    behind = int(git("rev-list", "--count", f"HEAD..{src}/main", check=False) or "0")
+    ahead = int(git("rev-list", "--count", f"{src}/main..HEAD", check=False) or "0")
+
+    behind_commits_raw = git("log", "--oneline", f"HEAD..{src}/main", check=False)
+    behind_commits = [ln for ln in behind_commits_raw.splitlines() if ln][:10]
+
+    leftover_commits: list[str] = []
+    if not is_main and branch_name:
+        leftover_raw = git(
+            "log", "--oneline", f"{src}/main..{branch_name}", check=False
+        )
+        leftover_commits = [ln for ln in leftover_raw.splitlines() if ln][:10]
+
+    # Worktree state
+    uncommitted_raw = git("status", "--porcelain", check=False)
+    uncommitted = [ln for ln in uncommitted_raw.splitlines() if ln]
+    stash_raw = git("stash", "list", check=False)
+    stashes = [ln for ln in stash_raw.splitlines() if ln]
+
+    # PR state — only on feature branches, and only if we got data
+    pr_block: dict[str, Any] | None = None
+    if not is_main and pr_data:
+        reviews = pr_data.get("reviews", []) or []
+        comments = pr_data.get("comments", []) or []
+        pr_block = {
+            "state": pr_data.get("state"),
+            "number": pr_data.get("number"),
+            "title": pr_data.get("title"),
+            "mergeable": pr_data.get("mergeable"),
+            "review_decision": pr_data.get("reviewDecision"),
+            "recent_reviews": reviews[-3:],
+            "recent_comments": comments[-3:],
+        }
+
+    return {
+        "remotes": {
+            "entries": [asdict(r) for r in analysis.entries],
+            "source": analysis.source,
+            "is_fork_workflow": analysis.is_fork_workflow,
+            "issues": [asdict(i) for i in analysis.issues],
+        },
+        "branch": {
+            "name": branch_name,
+            "is_main": is_main,
+            "behind": behind,
+            "ahead": ahead,
+            "behind_commits": behind_commits,
+            "leftover_commits": leftover_commits,
+        },
+        "worktree": {
+            "uncommitted": uncommitted,
+            "stashes": stashes,
+        },
+        "pr": pr_block,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Diagnose git repo state for up-to-date skill")
+    parser.add_argument("--pretty", action="store_true", help="pretty-print JSON")
+    args = parser.parse_args()
+
+    data = run_diagnose()
+    indent = 2 if args.pretty else None
+    json.dump(data, sys.stdout, indent=indent)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/up-to-date/test_diagnose.py
+++ b/skills/up-to-date/test_diagnose.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Unit tests for diagnose.py pure functions.
+
+Run with: python3 -m unittest test_diagnose.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+# Make sibling diagnose.py importable
+sys.path.insert(0, str(Path(__file__).parent))
+
+from diagnose import (  # noqa: E402
+    Remote,
+    classify_remotes,
+    is_fork_url,
+    parse_remotes,
+)
+
+FORK_ORGS = ["idvorkin-ai-tools"]
+
+
+class TestParseRemotes(unittest.TestCase):
+    def test_single_remote_dedups_fetch_and_push(self):
+        raw = (
+            "origin\tgit@github.com:idvorkin/chop.git (fetch)\n"
+            "origin\tgit@github.com:idvorkin/chop.git (push)\n"
+        )
+        self.assertEqual(
+            parse_remotes(raw),
+            [Remote("origin", "git@github.com:idvorkin/chop.git")],
+        )
+
+    def test_two_remotes(self):
+        raw = (
+            "origin\tgit@github.com:idvorkin-ai-tools/chop.git (fetch)\n"
+            "origin\tgit@github.com:idvorkin-ai-tools/chop.git (push)\n"
+            "upstream\tgit@github.com:idvorkin/chop.git (fetch)\n"
+            "upstream\tgit@github.com:idvorkin/chop.git (push)\n"
+        )
+        result = parse_remotes(raw)
+        self.assertEqual(len(result), 2)
+        self.assertIn(Remote("origin", "git@github.com:idvorkin-ai-tools/chop.git"), result)
+        self.assertIn(Remote("upstream", "git@github.com:idvorkin/chop.git"), result)
+
+    def test_empty_output(self):
+        self.assertEqual(parse_remotes(""), [])
+
+
+class TestIsForkUrl(unittest.TestCase):
+    def test_ssh_url_matches(self):
+        self.assertTrue(is_fork_url("git@github.com:idvorkin-ai-tools/foo.git", FORK_ORGS))
+
+    def test_https_url_matches(self):
+        self.assertTrue(is_fork_url("https://github.com/idvorkin-ai-tools/foo", FORK_ORGS))
+
+    def test_non_fork_does_not_match(self):
+        self.assertFalse(is_fork_url("git@github.com:idvorkin/foo.git", FORK_ORGS))
+
+    def test_substring_does_not_false_match(self):
+        # A user org named "idvorkin" should NOT match fork org "idvorkin-ai-tools"
+        self.assertFalse(is_fork_url("git@github.com:idvorkin/idvorkin-ai-tools-plugin.git", FORK_ORGS))
+
+
+class TestClassifyRemotes(unittest.TestCase):
+    def test_single_canonical_origin_is_clean(self):
+        remotes = [Remote("origin", "git@github.com:idvorkin/foo.git")]
+        result = classify_remotes(remotes, FORK_ORGS)
+        self.assertEqual(result.source, "origin")
+        self.assertFalse(result.is_fork_workflow)
+        self.assertEqual(result.issues, [])
+
+    def test_proper_fork_workflow_is_clean(self):
+        remotes = [
+            Remote("origin", "git@github.com:idvorkin-ai-tools/foo.git"),
+            Remote("upstream", "git@github.com:idvorkin/foo.git"),
+        ]
+        result = classify_remotes(remotes, FORK_ORGS)
+        self.assertEqual(result.source, "upstream")
+        self.assertTrue(result.is_fork_workflow)
+        self.assertEqual(result.issues, [])
+
+    def test_non_standard_remote_name_flagged(self):
+        remotes = [
+            Remote("origin", "git@github.com:idvorkin/foo.git"),
+            Remote("fork", "git@github.com:idvorkin-ai-tools/foo.git"),
+        ]
+        result = classify_remotes(remotes, FORK_ORGS)
+        kinds = [i.kind for i in result.issues]
+        self.assertIn("non_standard_name", kinds)
+
+    def test_swapped_remotes_flagged(self):
+        # origin points at canonical; upstream points at fork — backwards
+        remotes = [
+            Remote("origin", "git@github.com:idvorkin/foo.git"),
+            Remote("upstream", "git@github.com:idvorkin-ai-tools/foo.git"),
+        ]
+        result = classify_remotes(remotes, FORK_ORGS)
+        kinds = [i.kind for i in result.issues]
+        self.assertIn("swapped_remotes", kinds)
+
+    def test_lone_fork_remote_flagged(self):
+        # Only a fork exists; no canonical remote to PR against
+        remotes = [Remote("origin", "git@github.com:idvorkin-ai-tools/foo.git")]
+        result = classify_remotes(remotes, FORK_ORGS)
+        kinds = [i.kind for i in result.issues]
+        self.assertIn("fork_without_canonical", kinds)
+
+    def test_issue_includes_fix_command(self):
+        remotes = [
+            Remote("origin", "git@github.com:idvorkin/foo.git"),
+            Remote("upstream", "git@github.com:idvorkin-ai-tools/foo.git"),
+        ]
+        result = classify_remotes(remotes, FORK_ORGS)
+        for issue in result.issues:
+            self.assertTrue(issue.fix, f"issue {issue.kind} missing fix command")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Replaces the shell-based diagnosis step in the `up-to-date` skill with `skills/up-to-date/diagnose.py`, a stdlib-only Python helper with a `uv run --script` shebang. Collapses ~5 sequential Bash round-trips into one, and runs `git fetch --all --prune` + `gh pr view` concurrently via `ThreadPoolExecutor`. End-to-end runtime is now ~2.6s, dominated by the network fetch the gh call hides inside of.
- Script emits a single JSON blob (`remotes` / `branch` / `worktree` / `pr` / `errors`) that the rewritten `SKILL.md` reads structured, instead of parsing shell output. Pure classification functions (`parse_remotes`, `is_fork_url`, `classify_remotes`) are unit-tested in `test_diagnose.py` — 13 tests, stdlib `unittest`, zero deps. Run with `python3 -m unittest test_diagnose.py`.
- Establishes **Python + `uv run --script` as the default scripting language** for this repo. New "Scripting Language Defaults" section in `CLAUDE.md` and a new `python/README.md` explain why (testability, parallelism, uv-based distribution) and point at `diagnose.py` as the worked example. Shell is now explicitly reserved for one-liners and `just` targets.

## Test plan

- [x] `python3 -m unittest test_diagnose.py` — 13/13 green
- [x] `./diagnose.py --pretty` in this repo — produces correct JSON (detects fork workflow, no hygiene issues, behind/ahead = 0)
- [x] `time ./diagnose.py` — 2.6s total (network-bound)
- [ ] Exercise the full skill end-to-end on a feature branch with an open PR
- [ ] Exercise the skill on a single-remote repo (no `upstream`) to confirm `remotes.source == "origin"` path
- [ ] Exercise hygiene detection: add a remote named `fork` and confirm `non_standard_name` issue fires

## Notes

- SKILL.md keeps a "Manual fallback" block with the original shell commands, for the case where `diagnose.py` is missing or errors.
- The `idvorkin` vs `idvorkin-ai-tools` substring trap in `is_fork_url` is covered by an explicit test — the regex anchors on the org segment delimiter to avoid false matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)