### PR TITLE
Add docs skill: fetch fresh library docs via Context7 (ctx7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Machine-level skills go in `~/.claude/skills/` and are available everywhere. Pro
 
 | Skill | Scope | Description |
 |---|---|---|
+| `docs` | machine | Fetch fresh library/framework docs via Context7 (`ctx7`) |
 | `gen-image` | machine | Generate illustrations via Gemini image API |
 | `gist-image` | machine | Host images on GitHub gists for PRs/issues |
 | `image-explore` | machine | Brainstorm and compare visual directions |

--- a/docs/superpowers/plans/2026-04-11-docs-skill.md
+++ b/docs/superpowers/plans/2026-04-11-docs-skill.md
@@ -1,0 +1,330 @@
+# `docs` Skill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a machine-level `docs` skill that wraps `ctx7 library` + `ctx7 docs` so Claude fetches fresh third-party library documentation instead of relying on stale training memory.
+
+**Architecture:** A single `SKILL.md` file under `skills/docs/` in chop-conventions, symlinked to `~/.claude/skills/docs`. No code, no tests — the skill is prose that gets loaded into Claude's context. Verification is a runtime sanity check against the `ctx7` CLI plus a README table update.
+
+**Tech Stack:** Markdown + YAML frontmatter for the skill; `npx` + `ctx7` CLI as the wrapped tool; Bash for symlink + verification.
+
+**Spec:** `docs/superpowers/specs/2026-04-11-docs-skill-design.md`
+
+---
+
+## File Structure
+
+- Create: `skills/docs/SKILL.md` — the new skill file (prose guidance + frontmatter)
+- Create: `~/.claude/skills/docs` — symlink into Claude's machine-level skill directory, pointing at the repo path
+- Modify: `README.md` — add a row to the "Available Skills" table (line 82–90)
+
+No test files. The skill has no executable behavior — it's prose loaded into context. Verification is done by (a) running `ctx7` against a real library to confirm the wrapped tool works, and (b) manually confirming in a future session that Claude fires the skill when expected.
+
+---
+
+### Task 1: Sanity-check that `ctx7 library` and `ctx7 docs` actually work
+
+Before writing documentation that tells future-Claude to trust these commands, run them once against a known library so we're sure they return useful output and the doc examples in our SKILL.md are accurate.
+
+**Files:** none (diagnostic only)
+
+- [ ] **Step 1: Resolve a known library name to a Context7 ID**
+
+Run:
+```bash
+npx ctx7 library react "useEffect cleanup function"
+```
+
+Expected: output that includes a library ID of the form `/facebook/react` (or similar) and a short description. If the command errors out or returns nothing useful, STOP the plan and investigate — the skill cannot exist if the underlying tool is broken.
+
+- [ ] **Step 2: Fetch docs for the resolved ID**
+
+Run:
+```bash
+npx ctx7 docs /facebook/react "useEffect cleanup function"
+```
+
+Expected: prose/code snippets about `useEffect` cleanup functions, several hundred to a few thousand tokens of docs. If this errors or returns junk, STOP and investigate.
+
+- [ ] **Step 3: Confirm a stdlib query is NOT what we want**
+
+Quick mental check: the skill tells Claude to SKIP stdlib questions. Verify that the examples above are actual third-party libraries, not stdlib. (`react` ✓, not stdlib.) No command needed — just confirming we're not accidentally encouraging ctx7 use for built-ins.
+
+No commit in this task — diagnostic only.
+
+---
+
+### Task 2: Create the skill directory and SKILL.md
+
+**Files:**
+- Create: `skills/docs/SKILL.md`
+
+- [ ] **Step 1: Create the directory**
+
+Run:
+```bash
+mkdir -p /home/developer/gits/chop-conventions/skills/docs
+```
+
+Expected: no output, directory now exists.
+
+- [ ] **Step 2: Write SKILL.md with exactly this content**
+
+Create `/home/developer/gits/chop-conventions/skills/docs/SKILL.md`:
+
+````markdown
+---
+name: docs
+description: Use when answering questions about or writing code against a third-party library/framework. Fetches fresh, authoritative documentation via Context7 (`ctx7`) instead of relying on stale training data. Fires both reactively ("how do I X with library Y") and proactively (about to write library code and unsure of current API).
+---
+
+# Docs (Context7 Library Lookup)
+
+Fetch fresh, authoritative third-party library documentation via the `ctx7` CLI instead of guessing from (possibly stale) training memory.
+
+## When to use
+
+**USE when:**
+- The user asks "how do I X with library Y" for a named third-party library or framework.
+- You are about to write code against a named third-party library and are not 100% sure the API still matches your training memory.
+- A question is version-specific ("in the latest FastAPI…", "post-v18 React…").
+
+**SKIP when:**
+- The question is about a language stdlib (Python stdlib, JS built-ins, Go stdlib, etc.) — you already know these and ctx7 is wasted tokens.
+- It's a general CS/programming concept, not a library.
+- The code in question lives in the current repo — read the source directly instead.
+- You've already fetched the same library+topic earlier in this session — reuse that answer.
+
+## Two-step workflow
+
+Context7 splits lookup into a name→ID resolution step and a docs-fetch step.
+
+### Step 1: Resolve library name to a Context7 ID
+
+```bash
+npx ctx7 library <name> "<query>"
+```
+
+The query is optional but strongly recommended — Context7 uses it to rank candidate libraries by relevance to what you're actually asking. Example:
+
+```bash
+npx ctx7 library react "useEffect cleanup function"
+# → /facebook/react (or similar)
+```
+
+### Step 2: Fetch docs for the resolved ID
+
+```bash
+npx ctx7 docs <libraryId> "<query>"
+```
+
+Example:
+
+```bash
+npx ctx7 docs /facebook/react "useEffect cleanup function"
+```
+
+Returns curated doc snippets ranked for the query.
+
+### Shortcut
+
+If you already know the library ID from earlier in the session or from an obvious mapping (`/facebook/react`, `/anthropics/anthropic-sdk-python`), skip step 1 and go straight to `ctx7 docs`.
+
+## Efficiency rules
+
+- **Don't re-query the same library+topic twice in one session.** Reuse the first result from earlier in the conversation.
+- **Prefer specific queries over broad ones.** `"useEffect cleanup"` beats `"hooks"`; `"scan_parquet glob pattern"` beats `"polars io"`.
+- **`--json` is available** on both commands if you need structured output, but plain text is fine for reading into your own context.
+
+## ctx7 vs WebFetch
+
+- Reach for `ctx7` first whenever the target is a **named library** — it returns curated, query-ranked snippets rather than raw HTML.
+- Fall back to `WebFetch` for arbitrary URLs (blog posts, GitHub issues, RFCs, changelogs not yet indexed by Context7).
+
+## Auth / setup
+
+- The first `npx ctx7` invocation auto-installs the package; no manual setup needed.
+- Works anonymously. If you hit rate limits or auth errors, run `npx ctx7 login` and retry.
+
+## Common mistakes
+
+- **Skipping the `library` step and guessing the ID.** IDs are not always predictable (`/pola-rs/polars`, not `/polars/polars`). Resolve first unless you're certain.
+- **Using ctx7 for stdlib questions.** Wasted tokens — you already know `list.sort()`.
+- **Re-running the same query multiple times in one session** instead of reusing the first output.
+- **Forgetting the query argument** on `ctx7 library` — the rankings get noticeably worse without it.
+````
+
+Expected after writing: file exists at `/home/developer/gits/chop-conventions/skills/docs/SKILL.md`, starts with `---\nname: docs\n`, ends with the "Common mistakes" section.
+
+- [ ] **Step 3: Verify the file parses as the expected shape**
+
+Run:
+```bash
+head -5 /home/developer/gits/chop-conventions/skills/docs/SKILL.md
+```
+
+Expected first 5 lines:
+```
+---
+name: docs
+description: Use when answering questions about or writing code against a third-party library/framework. Fetches fresh, authoritative documentation via Context7 (`ctx7`) instead of relying on stale training data. Fires both reactively ("how do I X with library Y") and proactively (about to write library code and unsure of current API).
+---
+
+```
+
+If the frontmatter block is malformed or `name` is wrong, fix the file.
+
+No commit yet — we'll bundle the SKILL.md, symlink verification, and README update into a single commit at the end.
+
+---
+
+### Task 3: Symlink the skill into Claude's machine-level skill directory
+
+**Files:**
+- Create (symlink): `~/.claude/skills/docs` → `/home/developer/gits/chop-conventions/skills/docs`
+
+- [ ] **Step 1: Check for any existing `docs` skill and abort if present**
+
+Run:
+```bash
+ls -la ~/.claude/skills/docs 2>/dev/null
+```
+
+Expected: "No such file or directory" (or equivalent). If anything exists there, STOP and ask the user before proceeding — we might clobber an existing skill.
+
+- [ ] **Step 2: Create the symlink**
+
+Run:
+```bash
+ln -s /home/developer/gits/chop-conventions/skills/docs ~/.claude/skills/docs
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Verify the symlink resolves**
+
+Run:
+```bash
+ls -la ~/.claude/skills/docs && cat ~/.claude/skills/docs/SKILL.md | head -5
+```
+
+Expected:
+- `ls` shows `docs -> /home/developer/gits/chop-conventions/skills/docs`
+- `cat` shows the same frontmatter block from Task 2 Step 3.
+
+If either fails, the symlink is broken — fix before moving on.
+
+No commit — nothing in git changed from the symlink (it's outside the repo).
+
+---
+
+### Task 4: Add the skill to the README skills table
+
+**Files:**
+- Modify: `README.md:82-90`
+
+- [ ] **Step 1: Read the current skills table**
+
+The current table lives at lines 82–90 of `README.md`:
+
+```markdown
+| Skill | Scope | Description |
+|---|---|---|
+| `gen-image` | machine | Generate illustrations via Gemini image API |
+| `gist-image` | machine | Host images on GitHub gists for PRs/issues |
+| `image-explore` | machine | Brainstorm and compare visual directions |
+| `learn-from-session` | machine | Extract durable lessons from a session into the right CLAUDE.md files |
+| `machine-doctor` | machine | Diagnose system health, kill rogue processes |
+| `showboat` | machine | Create executable demo documents with screenshots |
+| `up-to-date` | machine | Sync git repo with upstream |
+```
+
+- [ ] **Step 2: Insert a `docs` row in alphabetical order**
+
+The alphabetical position is between (nothing above `d` currently exists — `gen-image` starts with `g`) — so `docs` goes FIRST in the table, right after the header separator.
+
+Use Edit to replace the line:
+```
+| `gen-image` | machine | Generate illustrations via Gemini image API |
+```
+with:
+```
+| `docs` | machine | Fetch fresh library/framework docs via Context7 (`ctx7`) |
+| `gen-image` | machine | Generate illustrations via Gemini image API |
+```
+
+- [ ] **Step 3: Verify the table renders in order**
+
+Run:
+```bash
+sed -n '80,95p' /home/developer/gits/chop-conventions/README.md
+```
+
+Expected: the table with `docs` as the first data row, `gen-image` second, others unchanged.
+
+---
+
+### Task 5: Final verification and commit
+
+**Files:** (none created/modified in this task — verification + commit only)
+
+- [ ] **Step 1: Verify repo state is clean and contains only the expected changes**
+
+Run:
+```bash
+cd /home/developer/gits/chop-conventions && git status
+```
+
+Expected output includes exactly:
+- `new file: skills/docs/SKILL.md`
+- `modified: README.md`
+
+No other files should appear. If unexpected changes show up, investigate before committing.
+
+- [ ] **Step 2: Diff-check the README change**
+
+Run:
+```bash
+cd /home/developer/gits/chop-conventions && git diff README.md
+```
+
+Expected: exactly one added line, the `docs` row, in the skills table.
+
+- [ ] **Step 3: Run a final sanity check through the symlink**
+
+Run:
+```bash
+head -5 ~/.claude/skills/docs/SKILL.md
+```
+
+Expected: same frontmatter block as Task 2 Step 3. This confirms the symlink + file are both in place and consistent.
+
+- [ ] **Step 4: Commit**
+
+Run:
+```bash
+cd /home/developer/gits/chop-conventions && git add skills/docs/SKILL.md README.md && git commit -m "$(cat <<'EOF'
+docs skill: wrap ctx7 library/docs for fresh library documentation
+
+New machine-level skill that tells Claude to reach for Context7
+(`npx ctx7 library` + `npx ctx7 docs`) when writing code against a
+named third-party library or answering "how do I X with library Y"
+questions. Avoids stale training-data guesses.
+
+Installed via symlink at ~/.claude/skills/docs.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit succeeds, one commit created containing both files.
+
+- [ ] **Step 5: Confirm final state**
+
+Run:
+```bash
+cd /home/developer/gits/chop-conventions && git log -1 --stat
+```
+
+Expected: the new commit, showing `README.md` (1 insertion) and `skills/docs/SKILL.md` (new file).

--- a/docs/superpowers/plans/2026-04-11-docs-skill.md
+++ b/docs/superpowers/plans/2026-04-11-docs-skill.md
@@ -1,5 +1,7 @@
 # `docs` Skill Implementation Plan
 
+> **Post-implementation note:** Task 1's sanity check discovered that `/facebook/react` is NOT the top-ranked Context7 ID for React (it's rank 5 — `/reactjs/react.dev` is rank 1). Several example snippets in this plan still reference `/facebook/react` from the pre-sanity-check assumption. They are preserved as historical context; the shipped `skills/docs/SKILL.md` and the updated spec are the source of truth for the "don't guess IDs" rule.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Ship a machine-level `docs` skill that wraps `ctx7 library` + `ctx7 docs` so Claude fetches fresh third-party library documentation instead of relying on stale training memory.

--- a/docs/superpowers/specs/2026-04-11-docs-skill-design.md
+++ b/docs/superpowers/specs/2026-04-11-docs-skill-design.md
@@ -1,0 +1,93 @@
+# Design: `docs` skill (Context7 library docs lookup)
+
+**Date:** 2026-04-11
+**Scope:** Add a new machine-level Claude Code skill that wraps the Context7 (`ctx7`) CLI's library/docs lookup capability, so Claude fetches fresh, authoritative third-party library documentation instead of relying on stale training data.
+
+## Motivation
+
+Claude's training data for third-party libraries (React, FastAPI, Pydantic, LangChain, Polars, SDKs, etc.) drifts out of date. The `ctx7` CLI from context7.com is purpose-built to return curated, query-ranked snippets from library docs. We want a skill whose `description` field triggers Claude to reach for `ctx7` in two situations:
+
+1. **Reactive** — user asks "how do I X with library Y".
+2. **Proactive** — Claude is about to write code against a named third-party library and is uncertain whether the current API matches training memory.
+
+The user explicitly does NOT want this skill to cover `ctx7 skills install` — only the docs lookup (`ctx7 library` and `ctx7 docs`).
+
+## Non-Goals
+
+- Wrapping `ctx7 skills` subcommands (install, search, suggest, list, remove, info, generate).
+- Wrapping `ctx7 login` / `logout` / `whoami` (mentioned only as a troubleshooting footnote).
+- Replacing `WebFetch` for arbitrary URLs — ctx7 is preferred only when the target is a named library.
+- Caching ctx7 output to disk. Session-scoped reuse only (don't re-query the same library+topic twice in one conversation).
+
+## Skill contents
+
+**Path:** `skills/docs/SKILL.md` in chop-conventions, symlinked to `~/.claude/skills/docs`.
+
+**Frontmatter:**
+
+```yaml
+---
+name: docs
+description: Use when answering questions about or writing code against a third-party library/framework. Fetches fresh, authoritative documentation via Context7 (`ctx7`) instead of relying on stale training data. Fires both reactively ("how do I X with library Y") and proactively (about to write library code and unsure of current API).
+---
+```
+
+**Body sections (in order):**
+
+1. **When to use / When NOT to use**
+   - USE: named third-party library (e.g., `react`, `fastapi`, `pydantic`, `polars`, `langchain`, cloud SDKs), version-specific questions, uncertainty about whether an API still exists.
+   - SKIP: language stdlib, general CS/programming concepts, code in the current repo (read it directly), or one-off trivia where you're already confident.
+
+2. **Two-step workflow**
+   - Step 1 — resolve name to Context7 library ID:
+     ```bash
+     npx ctx7 library <name> "<query>"
+     ```
+     The query is optional but strongly recommended — it ranks candidate libraries by relevance to what you're actually asking.
+   - Step 2 — fetch docs for the resolved ID:
+     ```bash
+     npx ctx7 docs <libraryId> "<query>"
+     ```
+   - Shortcut: when the library ID is obvious from prior knowledge (`/facebook/react`, `/anthropics/anthropic-sdk-python`), skip straight to step 2.
+
+3. **Efficiency rules**
+   - Do not re-query the same library+topic twice in one session — reuse the first result from earlier in the conversation.
+   - Prefer specific queries over broad ones (`"useEffect cleanup"` beats `"hooks"`).
+   - `--json` is supported on both commands when structured output helps; plain text is fine for in-context reading.
+
+4. **ctx7 vs WebFetch**
+   - ctx7 returns curated, query-ranked library snippets — reach for it first when the target is a named library.
+   - WebFetch is the fallback for arbitrary URLs (blog posts, GitHub issues, RFCs).
+
+5. **Auth / setup**
+   - The first `npx ctx7` invocation auto-installs the package; no manual setup needed.
+   - Works anonymously. If you hit rate limits or auth errors, run `npx ctx7 login` and re-try.
+
+6. **Common mistakes**
+   - Skipping the `library` step and guessing the Context7 ID.
+   - Using ctx7 for stdlib or general-language questions.
+   - Re-running the same query multiple times in one session instead of reusing the first output.
+
+## Installation
+
+1. Create `skills/docs/SKILL.md` with the contents above.
+2. Symlink machine-level:
+   ```bash
+   ln -s /home/developer/gits/chop-conventions/skills/docs ~/.claude/skills/docs
+   ```
+3. Add a row for `docs` to the skills table in the chop-conventions `README.md`.
+4. Commit everything in a single change.
+
+## Risks / Open questions
+
+- **Name genericity.** `docs` is a broad name. Claude Code has `/doctor` as a built-in (which is why this repo uses `machine-doctor`), but `/docs` is not a current built-in. If a future CC built-in or plugin claims `docs`, rename to e.g. `library-docs` or `fresh-docs`. Accepting this risk for now because the user explicitly chose the short name.
+- **Network + token cost.** Every ctx7 call is a network round-trip and returns 1–5k tokens of doc snippets. The efficiency rules in the skill body are meant to keep this in check; if they prove insufficient we may want a session-scoped cache later.
+
+## Testing
+
+Manual verification after install:
+
+1. Restart session, confirm the `docs` skill appears in the available-skills list.
+2. Ask a reactive question like "how do I use `polars.scan_parquet` with a glob?" — verify Claude invokes the skill and runs `npx ctx7 library polars` then `npx ctx7 docs /pola-rs/polars "scan_parquet glob"`.
+3. Start a coding task that touches a named library (e.g., "write a small FastAPI endpoint with dependency injection") — verify Claude proactively fires the skill before coding.
+4. Ask a stdlib question (e.g., "how do I sort a list in Python") — verify Claude does NOT fire the skill.

--- a/docs/superpowers/specs/2026-04-11-docs-skill-design.md
+++ b/docs/superpowers/specs/2026-04-11-docs-skill-design.md
@@ -43,12 +43,13 @@ description: Use when answering questions about or writing code against a third-
      ```bash
      npx ctx7 library <name> "<query>"
      ```
-     The query is optional but strongly recommended — it ranks candidate libraries by relevance to what you're actually asking.
+     Always pass a query — per `--help` it's positional-optional, but Context7 uses it to rank candidates by relevance and results get noticeably worse without it.
    - Step 2 — fetch docs for the resolved ID:
      ```bash
      npx ctx7 docs <libraryId> "<query>"
      ```
-   - Shortcut: when the library ID is obvious from prior knowledge (`/facebook/react`, `/anthropics/anthropic-sdk-python`), skip straight to step 2.
+     Both arguments are required on `ctx7 docs` (asymmetric with Step 1).
+   - Shortcut: skip Step 1 *only* when you already resolved the ID earlier in the same session. **Don't guess IDs from intuition.** The highest-ranked match is often not what you'd expect — `/reactjs/react.dev` not `/facebook/react`; `/pola-rs/polars` not `/polars/polars`. (Live sanity-check during implementation showed `/facebook/react` is actually the 5th-ranked result, contradicting my initial assumption — this drove the "don't guess" rule.)
 
 3. **Efficiency rules**
    - Do not re-query the same library+topic twice in one session — reuse the first result from earlier in the conversation.

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: docs
 description: Use when answering questions about or writing code against a named third-party library/framework. Fetches fresh, authoritative documentation via Context7 (`ctx7`) instead of relying on stale training data. Fires both reactively ("how do I X with library Y") and proactively (about to write library code and unsure of current API). Skip for language stdlib and general CS concepts.
+allowed-tools: Bash, WebFetch
 ---
 
 # Docs (Context7 Library Lookup)

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: docs
+description: Use when answering questions about or writing code against a third-party library/framework. Fetches fresh, authoritative documentation via Context7 (`ctx7`) instead of relying on stale training data. Fires both reactively ("how do I X with library Y") and proactively (about to write library code and unsure of current API).
+---
+
+# Docs (Context7 Library Lookup)
+
+Fetch fresh, authoritative third-party library documentation via the `ctx7` CLI instead of guessing from (possibly stale) training memory.
+
+## When to use
+
+**USE when:**
+- The user asks "how do I X with library Y" for a named third-party library or framework.
+- You are about to write code against a named third-party library and are not 100% sure the API still matches your training memory.
+- A question is version-specific ("in the latest FastAPI…", "post-v18 React…").
+
+**SKIP when:**
+- The question is about a language stdlib (Python stdlib, JS built-ins, Go stdlib, etc.) — you already know these and ctx7 is wasted tokens.
+- It's a general CS/programming concept, not a library.
+- The code in question lives in the current repo — read the source directly instead.
+- You've already fetched the same library+topic earlier in this session — reuse that answer.
+
+## Two-step workflow
+
+Context7 splits lookup into a name→ID resolution step and a docs-fetch step.
+
+### Step 1: Resolve library name to a Context7 ID
+
+```bash
+npx ctx7 library <name> "<query>"
+```
+
+The query is optional but strongly recommended — Context7 uses it to rank candidate libraries by relevance. The command returns several candidate IDs ranked by benchmark score; pick the top one unless you have a reason not to.
+
+Example:
+```bash
+npx ctx7 library react "useEffect cleanup function"
+# → /reactjs/react.dev  (top-ranked, 90+ benchmark)
+# → /facebook/react      (also valid but lower-ranked)
+```
+
+### Step 2: Fetch docs for the resolved ID
+
+```bash
+npx ctx7 docs <libraryId> "<query>"
+```
+
+Example:
+```bash
+npx ctx7 docs /reactjs/react.dev "useEffect cleanup function"
+```
+
+Returns curated doc snippets ranked for the query, with source URLs.
+
+### When to skip Step 1
+
+Only skip the `library` step when you already resolved the ID **earlier in the current session** and you're reusing it. **Do not guess IDs from intuition** — the highest-ranked match is often not what you'd expect (`/reactjs/react.dev`, not `/facebook/react`; `/pola-rs/polars`, not `/polars/polars`).
+
+## Efficiency rules
+
+- **Don't re-query the same library+topic twice in one session.** Reuse the first result from earlier in the conversation.
+- **Prefer specific queries over broad ones.** `"useEffect cleanup"` beats `"hooks"`; `"scan_parquet glob pattern"` beats `"polars io"`.
+- **`--json` is available** on both commands if you need structured output, but plain text is fine for reading into your own context.
+
+## ctx7 vs WebFetch
+
+- Reach for `ctx7` first whenever the target is a **named library** — it returns curated, query-ranked snippets rather than raw HTML.
+- Fall back to `WebFetch` for arbitrary URLs (blog posts, GitHub issues, RFCs, changelogs not yet indexed by Context7).
+
+## Auth / setup
+
+- The first `npx ctx7` invocation auto-installs the package; no manual setup needed.
+- Works anonymously. If you hit rate limits or auth errors, run `npx ctx7 login` and retry.
+
+## Common mistakes
+
+- **Guessing the library ID instead of running `ctx7 library` first.** IDs are not predictable (`/reactjs/react.dev`, `/pola-rs/polars`). Resolve first unless you already saw the ID earlier in this session.
+- **Using ctx7 for stdlib questions.** Wasted tokens — you already know `list.sort()`.
+- **Re-running the same query multiple times in one session** instead of reusing the first output.
+- **Forgetting the query argument** on `ctx7 library` — rankings get noticeably worse without it.

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs
-description: Use when answering questions about or writing code against a third-party library/framework. Fetches fresh, authoritative documentation via Context7 (`ctx7`) instead of relying on stale training data. Fires both reactively ("how do I X with library Y") and proactively (about to write library code and unsure of current API).
+description: Use when answering questions about or writing code against a named third-party library/framework. Fetches fresh, authoritative documentation via Context7 (`ctx7`) instead of relying on stale training data. Fires both reactively ("how do I X with library Y") and proactively (about to write library code and unsure of current API). Skip for language stdlib and general CS concepts.
 ---
 
 # Docs (Context7 Library Lookup)
@@ -30,13 +30,14 @@ Context7 splits lookup into a name→ID resolution step and a docs-fetch step.
 npx ctx7 library <name> "<query>"
 ```
 
-The query is optional but strongly recommended — Context7 uses it to rank candidate libraries by relevance. The command returns several candidate IDs ranked by benchmark score; pick the top one unless you have a reason not to.
+Always pass a query — per `ctx7 library --help` it's positional-optional, but Context7 uses it to rank candidate libraries by relevance and results get noticeably worse without it. The command returns several candidates; pick the first result unless it's obviously wrong for your query (e.g., a fork, translated mirror, or unrelated namespace match).
 
 Example:
 ```bash
 npx ctx7 library react "useEffect cleanup function"
-# → /reactjs/react.dev  (top-ranked, 90+ benchmark)
-# → /facebook/react      (also valid but lower-ranked)
+# → /reactjs/react.dev  (first result)
+# → /websites/react_dev  (second result)
+# → /facebook/react      (fifth result — canonical repo, but not always top-ranked)
 ```
 
 ### Step 2: Fetch docs for the resolved ID
@@ -44,6 +45,8 @@ npx ctx7 library react "useEffect cleanup function"
 ```bash
 npx ctx7 docs <libraryId> "<query>"
 ```
+
+Unlike `ctx7 library`, **both arguments are required** on `ctx7 docs` — omitting the query produces `error: missing required argument 'query'` and exits 1.
 
 Example:
 ```bash
@@ -77,4 +80,4 @@ Only skip the `library` step when you already resolved the ID **earlier in the c
 - **Guessing the library ID instead of running `ctx7 library` first.** IDs are not predictable (`/reactjs/react.dev`, `/pola-rs/polars`). Resolve first unless you already saw the ID earlier in this session.
 - **Using ctx7 for stdlib questions.** Wasted tokens — you already know `list.sort()`.
 - **Re-running the same query multiple times in one session** instead of reusing the first output.
-- **Forgetting the query argument** on `ctx7 library` — rankings get noticeably worse without it.
+- **Ignoring errors.** `ctx7` exits 1 and prints `✖ …` or `error: …` on bad IDs, missing queries, or unknown names. If the output looks like an error, it IS — don't proceed as if you got docs. Re-run `ctx7 library` with a different name or fall back to `WebFetch`.


### PR DESCRIPTION
## Summary

- New machine-level skill `skills/docs/SKILL.md` that wraps the `ctx7` (Context7) CLI's two-step library docs lookup (`ctx7 library` → `ctx7 docs`), giving Claude a standard way to fetch fresh, authoritative third-party library documentation instead of relying on (potentially stale) training memory.
- Skill fires both reactively (user asks "how do I X with library Y") and proactively (Claude is about to write library code and is unsure of the current API), and skips for language stdlib / general CS concepts.
- Installed via symlink at `~/.claude/skills/docs` → repo path; documented in README skills table.

## Why

Training data for popular libraries (React, FastAPI, Pydantic, Polars, cloud SDKs…) drifts out of date. A concrete example I hit during end-to-end testing of this skill: `polars.scan_parquet` now **disables** `hive_partitioning` by default when passed a glob, and requires you to explicitly re-enable it. Without ctx7 I would have confidently written the old API and silently produced wrong results on partitioned data.

## Changes

- `skills/docs/SKILL.md` — new skill file with frontmatter + body (trigger rules, two-step workflow, efficiency rules, ctx7-vs-WebFetch guidance, common mistakes including an "ignoring errors" bullet).
- `README.md` — new `docs` row in the Available Skills table (alphabetically first).
- `docs/superpowers/specs/2026-04-11-docs-skill-design.md` — spec doc.
- `docs/superpowers/plans/2026-04-11-docs-skill.md` — implementation plan.

## Process

- Brainstormed → spec → plan → executed → code review → review fixes.
- Live sanity check of `ctx7 library react "…"` during execution caught an assumption error: `/facebook/react` is **not** the top-ranked Context7 ID for React (it's rank 5; `/reactjs/react.dev` is rank 1). The shipped skill and spec call this out as a concrete "don't guess IDs" example.
- Code review (superpowers:code-reviewer) flagged five issues; all fixed in commit `d85cc22`. Reviewer's only wrong claim was about exit codes (claimed `ctx7` exits 0 on errors; verified to be 1) — pushed back on that specific claim, kept the underlying "don't ignore errors" concern as a common-mistakes bullet.

## Naming risk

The skill is named `docs`, which is generic. Claude Code has `/doctor` as a built-in (this repo uses `machine-doctor` to avoid that), but `/docs` is not currently a CC built-in. Risk + rename plan (`library-docs` / `fresh-docs` if a collision shows up) is documented in the spec's "Risks / Open questions" section.

## Test plan

- [x] `npx ctx7 library react "useEffect cleanup function"` resolves to a valid ID.
- [x] `npx ctx7 docs /reactjs/react.dev "useEffect cleanup function"` returns useful snippets.
- [x] End-to-end test: skill invoked via `Skill` tool after session reload, `ctx7 library polars "scan_parquet glob"` + `ctx7 docs /pola-rs/polars …` surfaced the real `hive_partitioning` API change.
- [x] Symlink `~/.claude/skills/docs` → repo path resolves and SKILL.md is readable through it.
- [x] Error paths verified: bogus ID, missing query, unknown name all exit 1 with a visible `✖` / `error:` prefix.
- [ ] Future-session verification: confirm Claude auto-fires the skill in a fresh session on a "how do I use X in Y" question about a named library, and does NOT fire for a stdlib question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for a new machine-level "docs" skill to fetch fresh third-party library/framework documentation.
  * Included detailed usage guidelines, step-by-step workflow rules, verification/setup and troubleshooting notes, and clear use/skip criteria.
  * Updated the "Available Skills" table in the README to list the new skill.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->