### PR TITLE
CLAUDE.md: offer to link skills added by /up-to-date pulls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Skills are Claude Code slash commands that live in `skills/<name>/SKILL.md`.
   - Machine-level (all projects): `~/.claude/skills/<name>` -> `<chop-conventions>/skills/<name>`
   - Project-level (one project): `<project>/.claude/skills/<name>` -> `<chop-conventions>/skills/<name>`
 - After adding a skill, create the symlink and document it in the README skills table
+- After `/up-to-date` pulls new commits, check the pull delta for newly-added `skills/<name>/` dirs and offer to symlink them into `~/.claude/skills/`. If the delta added no skills, say nothing. Never link automatically.
 
 ### Size Guideline
 


### PR DESCRIPTION
## Summary
- Adds a rule to the Skills > Conventions section telling future Claude sessions that when `/up-to-date` pulls new skill dirs under `skills/`, it should offer to symlink them into `~/.claude/skills/`.
- Silent when the pull added no skills. Never auto-links (some skills are intentionally unlinked per-machine).

## Test plan
- [ ] Next `/up-to-date` that pulls a new skill dir surfaces it and asks before linking
- [ ] Next `/up-to-date` with no new skills stays silent on the subject

🤖 Generated with [Claude Code](https://claude.com/claude-code)