### PR TITLE
dev-setup: standalone Claude Code status line script

### DIFF
--- a/dev-setup/claude-code-statusline.md
+++ b/dev-setup/claude-code-statusline.md
@@ -1,0 +1,87 @@
+# Claude Code Status Line
+
+A standalone POSIX `sh` script that renders a colored, information-dense status line for Claude Code.
+
+## Why This Exists
+
+Claude Code's `statusLine` setting accepts an inline command, but inline JSON-quoted shell becomes unreadable fast (see `beads.md` § Status Line Configuration for an example). A standalone script is easier to maintain, easier to test (`echo '{...}' | sh statusline-command.sh`), and trivially diff-able when iterating on format.
+
+## What It Shows
+
+```
+user@host ~/path/to/repo [branch] | Opus 4.6 ctx:12% 125k/1000k $0.42
+```
+
+| Segment            | Source                                                       | Color                              |
+| ------------------ | ------------------------------------------------------------ | ---------------------------------- |
+| `user@host`        | `whoami` / `hostname -s`                                     | default                            |
+| `~/path`           | `cwd` (or `workspace.current_dir`), home shortened           | yellow                             |
+| `[branch]`         | `git symbolic-ref --short HEAD` (skipped if not a repo)      | yellow                             |
+| `Opus 4.6`         | `model.display_name`                                         | default                            |
+| `ctx:NN% Xk/Yk`    | `context_window.{used_percentage, context_window_size}`      | green <20%, blue <50%, red ≥50%    |
+| `$X.XX`            | `cost.total_cost_usd`                                        | default                            |
+
+The token bucket (`Xk`) snaps to the nearest 10k so the number doesn't jitter on every tick. The total (`Yk`) comes from `context_window.context_window_size` directly — no model-string heuristics, so Sonnet (200k) and Opus `[1m]` render correctly without code changes.
+
+## Install
+
+```bash
+cp dev-setup/statusline-command.sh ~/.claude/statusline-command.sh
+chmod +x ~/.claude/statusline-command.sh
+```
+
+Then add to `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh $HOME/.claude/statusline-command.sh"
+  }
+}
+```
+
+## Requirements
+
+- `jq` on PATH (every field is read via `jq -r`)
+- POSIX `sh` (no bashisms)
+- Terminal that renders ANSI color escapes (every modern terminal)
+
+## Testing
+
+The script reads JSON from stdin, so it's trivial to exercise without launching Claude Code:
+
+```bash
+echo '{
+  "cwd": "/home/you/project",
+  "model": {"display_name": "Opus 4.6", "id": "claude-opus-4-6[1m]"},
+  "context_window": {"used_percentage": 12.5, "context_window_size": 1000000},
+  "cost": {"total_cost_usd": 0.42}
+}' | sh dev-setup/statusline-command.sh
+```
+
+Vary `used_percentage` across `5`, `30`, `75` to see all three color tiers.
+
+## Customizing the Color Tiers
+
+The thresholds live near the bottom of the script:
+
+```sh
+if [ "$pct" -lt 20 ]; then
+  ctx_color=$GREEN
+elif [ "$pct" -lt 50 ]; then
+  ctx_color=$BLUE
+else
+  ctx_color=$RED
+fi
+```
+
+Adjust the `20` / `50` boundaries to taste. The defaults are tuned so you notice the color change well before `/compact` becomes necessary.
+
+## Available Fields (Reference)
+
+The full JSON schema piped in by Claude Code includes a lot more than this script uses — `session_id`, `transcript_path`, `cost.total_lines_added`, `rate_limits.five_hour.used_percentage`, `agent.name`, `vim.mode`, and more. See https://code.claude.com/docs/en/statusline.md for the complete reference. Drop additional segments into this script as needed.
+
+## Related
+
+- `beads.md` § Status Line Configuration — an inline alternative that surfaces the in-progress beads issue. Prefer this script if you don't need the bd integration; combine the two if you do.

--- a/dev-setup/statusline-command.sh
+++ b/dev-setup/statusline-command.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Claude Code status line — mirrors Starship/default prompt style
+# Reads JSON from stdin, outputs a single status line
+
+input=$(cat)
+
+cwd=$(echo "$input" | jq -r '.cwd // .workspace.current_dir // ""')
+model=$(echo "$input" | jq -r '.model.display_name // ""')
+used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')
+ctx_size=$(echo "$input" | jq -r '.context_window.context_window_size // empty')
+cost_usd=$(echo "$input" | jq -r '.cost.total_cost_usd // empty')
+
+user=$(whoami)
+host=$(hostname -s)
+
+# ANSI colors
+YELLOW=$(printf '\033[33m')
+GREEN=$(printf '\033[32m')
+BLUE=$(printf '\033[34m')
+RED=$(printf '\033[31m')
+RESET=$(printf '\033[0m')
+
+# Shorten home directory to ~
+short_dir=$(echo "$cwd" | sed "s|^$HOME|~|")
+
+# Git branch (skip optional locks, ignore errors)
+branch=$(git -C "$cwd" --no-optional-locks symbolic-ref --short HEAD 2>/dev/null)
+
+# Build the prompt segments
+prompt="${user}@${host} ${YELLOW}${short_dir}${RESET}"
+[ -n "$branch" ] && prompt="${prompt} ${YELLOW}[${branch}]${RESET}"
+[ -n "$model" ] && prompt="${prompt} | ${model}"
+if [ -n "$used" ] && [ -n "$ctx_size" ]; then
+  pct=$(printf '%.0f' "$used")
+  total_k=$((ctx_size / 1000))
+  # Bucket used tokens to nearest 10k
+  used_k=$(awk "BEGIN {printf \"%d\", ($used * $total_k / 100 / 10) * 10}")
+  # Color: green <20%, blue <50%, red >=50%
+  if [ "$pct" -lt 20 ]; then
+    ctx_color=$GREEN
+  elif [ "$pct" -lt 50 ]; then
+    ctx_color=$BLUE
+  else
+    ctx_color=$RED
+  fi
+  prompt="${prompt} ${ctx_color}ctx:${pct}% ${used_k}k/${total_k}k${RESET}"
+fi
+[ -n "$cost_usd" ] && prompt="${prompt} \$$(printf '%.2f' "$cost_usd")"
+
+printf '%s' "$prompt"


### PR DESCRIPTION
## Summary

- Adds `dev-setup/statusline-command.sh` — a POSIX `sh` script that renders a colored, info-dense Claude Code status line
- Adds `dev-setup/claude-code-statusline.md` — install instructions, field reference, testing recipe, and customization notes
- Companion to `beads.md` § Status Line Configuration: that one is the inline alternative with bd integration; this one is the standalone, editable, testable version

## What it shows

```
user@host ~/path/to/repo [branch] | Opus 4.6 ctx:12% 125k/1000k $0.42
```

| Segment | Color |
|---|---|
| `~/path` and `[branch]` | yellow |
| `ctx:NN% Xk/Yk` | green <20%, blue <50%, red ≥50% |
| `$X.XX` | session cost from `cost.total_cost_usd` |

The token bucket snaps to nearest 10k so it doesn't jitter. The total comes from `context_window.context_window_size` directly — no model-string heuristics, so Sonnet (200k) and Opus `[1m]` both render correctly.

## Test plan

- [x] `echo '{...}' | sh dev-setup/statusline-command.sh` exercises all three context-color tiers (5%, 30%, 75%)
- [x] Both 200k and 1M `context_window_size` render with the right `Yk` total
- [x] Cost segment renders as `$0.42` with two decimals
- [x] Branch segment is skipped cleanly when run outside a git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a customizable status line script for Claude Code displaying user, host, directory, Git branch, model name, context usage with color-coded indicators, and total cost information.

* **Documentation**
  * Added setup guide with installation steps, configuration instructions, and customization options for status line color thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->