### PR TITLE
dev-setup: fix statusline rounding + color boundary bugs

### DIFF
--- a/dev-setup/claude-code-statusline.md
+++ b/dev-setup/claude-code-statusline.md
@@ -8,7 +8,7 @@ Claude Code's `statusLine` setting accepts an inline command, but inline JSON-qu
 
 ## What It Shows
 
-```
+```text
 user@host ~/path/to/repo [branch] | Opus 4.6 ctx:12% 125k/1000k $0.42
 ```
 

--- a/dev-setup/statusline-command.sh
+++ b/dev-setup/statusline-command.sh
@@ -33,12 +33,14 @@ prompt="${user}@${host} ${YELLOW}${short_dir}${RESET}"
 if [ -n "$used" ] && [ -n "$ctx_size" ]; then
   pct=$(printf '%.0f' "$used")
   total_k=$((ctx_size / 1000))
-  # Bucket used tokens to nearest 10k
-  used_k=$(awk "BEGIN {printf \"%d\", ($used * $total_k / 100 / 10) * 10}")
+  # Bucket used tokens to nearest 10k (round half up)
+  used_k=$(awk "BEGIN {printf \"%d\", int(($used * $total_k / 100 + 5) / 10) * 10}")
   # Color: green <20%, blue <50%, red >=50%
-  if [ "$pct" -lt 20 ]; then
+  # Floor of raw used (not the rounded pct) so 19.6% stays green, not blue
+  used_int=$(awk "BEGIN {printf \"%d\", int($used)}")
+  if [ "$used_int" -lt 20 ]; then
     ctx_color=$GREEN
-  elif [ "$pct" -lt 50 ]; then
+  elif [ "$used_int" -lt 50 ]; then
     ctx_color=$BLUE
   else
     ctx_color=$RED


### PR DESCRIPTION
## Summary

Follow-up to #64 — addresses both CodeRabbit findings.

**Bug 1: Bucketing didn't actually bucket**

The old math was `(x/10)*10` in awk, which is an algebraic identity in floating point — the divide-by-10 and multiply-by-10 cancel before the final ` printf %d`. So 12.5% of 1M emitted **125k**, not the 10k bucket the comment promised. New math: `int((exact + 5) / 10) * 10` — round half up to nearest 10k.

**Bug 2: Color tier compared rounded `pct`, not raw `used`**

Old check was `[ \"$pct\" -lt 20 ]`. With `used=19.6`, `pct=20`, so the < 20 test failed and the cell flipped to blue at 19.6% — one tick early. New check uses `int(used)` (floor of raw value) so 19.6% stays green and only true 20%+ flips to blue. `pct` is still used for display, so the user still sees `ctx:20%` — just rendered green instead of blue at the boundary.

**Doc fix**

`claude-code-statusline.md`: add `text` language identifier to the sample-output fenced block (MD040 lint).

## Test plan

Boundary cases run against the patched script:

- [x] `19.6%` → green (was blue) ✅
- [x] `49.9%` → blue ✅
- [x] `50.0%` → red ✅
- [x] `12.5%` of 1M → 130k bucket (was 125k) ✅
- [x] `12.4%` of 1M → 120k bucket ✅
- [x] `45%` of 200k Sonnet → 90k/200k blue (regression check) ✅

All exercised via `echo '{...}' | sh dev-setup/statusline-command.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated formatting in setup guide documentation

* **Bug Fixes**
  * Enhanced accuracy of color indicators in the status line for context usage display
  * Refined context token usage threshold calculations to better reflect actual usage levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->