### PR TITLE
beads: integrate bd issue tracker via bd init

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+	"hooks": {
+		"PreCompact": [
+			{
+				"hooks": [
+					{
+						"command": "bd prime",
+						"type": "command"
+					}
+				],
+				"matcher": ""
+			}
+		],
+		"SessionStart": [
+			{
+				"hooks": [
+					{
+						"command": "bd prime",
+						"type": "command"
+					}
+				],
+				"matcher": ""
+			}
+		]
+	}
+}

--- a/.gitignore
+++ b/.gitignore
@@ -513,3 +513,7 @@ ENV/
 .well-known/
 sitemap.xml
 robots.txt
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+.beads-credential-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,8 @@
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
-
-## Quick Reference
-
-```bash
-bd ready              # Find available work
-bd show <id>          # View issue details
-bd update <id> --status in_progress  # Claim work
-bd close <id>         # Complete work
-bd sync               # Sync with git
-```
-
-## Landing the Plane (Session Completion)
-
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
-
-**MANDATORY WORKFLOW:**
-
-1. **File issues for remaining work** - Create issues for anything that needs follow-up
-2. **Run quality gates** (if code changed) - Tests, linters, builds
-3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
-   ```bash
-   git pull --rebase
-   bd sync
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
-
-**CRITICAL RULES:**
-
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
+Workflow, command reference, and session-completion protocol are in the
+managed `BEADS INTEGRATION` block below. For repo layout and conventions
+see [`CLAUDE.md`](CLAUDE.md).
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,57 @@ bd sync               # Sync with git
 7. **Hand off** - Provide context for next session
 
 **CRITICAL RULES:**
+
 - Work is NOT complete until `git push` succeeds
 - NEVER stop before pushing - that leaves work stranded locally
 - NEVER say "ready to push when you are" - YOU must push
 - If push fails, resolve and retry until it succeeds
 
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ just fast-test    # Quick test pass
 just test         # Full test suite
 ```
 
+Pre-commit hooks (biome, prettier, ruff, dasel, fast tests) run on `git commit`
+and **will reformat staged files in place**. If a commit fails with "files were
+modified by this hook", re-stage and re-commit — don't fight the formatter.
+
 ## Git Workflow
 
 This repo uses fork workflow via `idvorkin-ai-tools`. Check `gh auth status` — if running as `idvorkin-ai-tools`, push to the fork:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,14 +73,66 @@ Agent definitions live in `claude-agents/`. These are markdown files that define
 Marketplace plugins I rely on across projects (user scope). Install with `/plugin install <name>@<marketplace>`.
 
 **`claude-plugins-official`** — `anthropics/claude-plugins-official`
+
 - `superpowers` — core skills framework: brainstorming, TDD, debugging, planning, etc.
 - `claude-md-management` — audit and improve CLAUDE.md files
 - `code-simplifier` — review and simplify changed code
 - `pyright-lsp`, `typescript-lsp`, `rust-analyzer-lsp` — language servers for the LSP tool
 
 **`claude-code-plugins`** — `anthropics/claude-code`
+
 - `frontend-design` — distinctive, production-grade UI generation
 - `pr-review-toolkit` — specialized agents for PR review (comments, tests, silent failures, type design)
 
 **`beads-marketplace`** — `steveyegge/beads`
+
 - `beads` — AI-supervised issue tracker; hooks into `SessionStart` / `PreCompact` to prime context
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->


### PR DESCRIPTION
## Summary
- Wire up **beads (bd)** issue tracker for this repo
- `.claude/settings.json`: `SessionStart` + `PreCompact` hooks run `bd prime` so every Claude Code session loads bd workflow context automatically
- `.gitignore`: ignore `.dolt/` and `.beads-credential-key` (local bd state)
- `CLAUDE.md` / `AGENTS.md`: append managed `<!-- BEGIN/END BEADS INTEGRATION -->` block documenting quick reference + session-completion protocol; delimiters let future `bd init` runs update it in place

## Notes
- `AGENTS.md` already had a hand-written beads section ("Landing the Plane"); the new managed block is mostly redundant with it. Worth a follow-up to either delete the manual section (let the managed block be the source of truth) or reconcile the two — flagged but not done in this PR to keep the diff to what `bd init` produced.
- Hooks (biome, prettier) reformatted `settings.json`, `AGENTS.md`, `CLAUDE.md` on commit; those edits are in the same commit.

## Test plan
- [x] Pre-commit hooks pass (ruff, biome, prettier, dasel, fast tests)
- [ ] After merge: open a fresh Claude Code session in this repo and confirm `bd prime` fires from the `SessionStart` hook
- [ ] Confirm `.dolt/` stays untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development configuration and workflow documentation to improve project setup and developer guidance.
  * Added version control patterns to exclude tool-related artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->