### PR TITLE
claude-md: diagnostics-in-code + mock-subprocess-in-tests rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ gh pr create --repo idvorkin/chop-conventions
 
 Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) MUST exclude lifeline processes or risk wedging the VM / locking out the SSH session: `tailscaled`, `etserver`, **`etterminal`**, `tmux` (bare + `"tmux:"*`), `sshd`, init-like (`sh`, `init`, `systemd`), and kernel threads (`kthreadd`, `kworker*`, `ksoftirqd*`, `migration*`, `rcu_*`). Test the exclude list with a unit test before deploying — see `skills/machine-doctor/doctor-guards.md` for an example.
 
+**Tests for these signalling functions MUST mock their subprocess/OS calls.** An unmocked "smoke test" that invokes the real `pkill`/`os.kill`/`create_subprocess_exec` against the dev box's real process table will match legitimate running processes and SIGTERM them — this nuked a live Telegram MCP bridge mid-session on 2026-04-12. Patch `asyncio.create_subprocess_exec` / `subprocess.run` / `os.kill` via `monkeypatch` before invoking the target. The test verifies return-type and error-handling, never the real kill path.
+
 ## Scripting Language Defaults
 
 **Default to Python for any non-trivial script, not shell.** Shell is for one-liners and the occasional `just` target. Anything with branching, data structures, or more than ~20 lines should be Python.
@@ -35,6 +37,10 @@ Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) M
 - Stdlib is enough for most helpers. Only add dependencies when they earn their keep (Typer + Rich for user-facing CLIs; plain stdlib for programmatic JSON-emitting helpers).
 - Put pure logic behind functions that can be unit-tested without subprocess mocking. Shell out to external tools (`git`, `gh`, etc.) through a thin wrapper so the business logic stays testable.
 - Working example: [`skills/up-to-date/diagnose.py`](skills/up-to-date/diagnose.py) — stdlib-only, `uv run` shebang, parallelized subprocess calls, unit-tested pure functions.
+
+## Diagnostics: Code Over Prose
+
+**Diagnostic checks belong in scripts, not in skill/doc prose.** Skills describe WHEN to diagnose and HOW to recover; code describes WHAT to check. Paths move — code errors loudly, prose rots silently. Follow the pattern in `~/gits/igor2/telegram-server/telegram_debug.py`: `--doctor` with `ok`/`warn`/`fail`/`note` accumulators, `--paths` that prints a file-map inventory with exists/missing marks, inline log tails so operators don't have to cat a second file. If you catch yourself writing a "check X at path Y" step in a skill, stop and move it to the doctor.
 
 ## Structure
 


### PR DESCRIPTION
## Summary

Two lessons from the 2026-04-12 Telegram two-process migration that are general enough to belong in shared conventions, not project-local memory.

### 1. New section: **Diagnostics: Code Over Prose**

The \`/telegram-debug\` skill had a ~120-line diagnostic walkthrough (file path tables, grep patterns, process checks) that silently rotted when paths moved from \`~/.claude/channels/telegram/*\` to \`~/larry-telegram/*\` during the two-process migration. Moving the checks into \`telegram_debug.py --doctor\` + \`--paths\` made the stale state immediately visible (source/plugin hash drift, missing files, etc.).

Rule: **skills say WHEN to diagnose, code says WHAT to check.** Paths move — code errors loudly, prose rots silently.

### 2. Process-Signaling Safety: companion rule for tests

A subagent-written \"smoke test\" called \`_kill_stale_bun_server()\` unmocked, which \`pgrep\`s \`'bun.*server.ts'\` and SIGTERMs every match. On CI no bun is running so the test passed. On the dev box with a live Telegram MCP bridge, running \`pytest\` nuked the production \`bun\` process mid-session and disconnected the channel.

The existing rule said \"test the exclude list\" but didn't say HOW. Now spelled out: mock \`asyncio.create_subprocess_exec\` / \`subprocess.run\` / \`os.kill\` via \`monkeypatch\` before invoking the target; verify return-type and error-handling, never the real kill path.

## Files changed

- \`CLAUDE.md\` — two additions, total ~5 lines rendered:
  - Companion paragraph under existing **Process-Signaling Safety** section
  - New **Diagnostics: Code Over Prose** section between Scripting Language Defaults and Structure

## Test plan

- [ ] Read both additions end-to-end
- [ ] Confirm the Process-Signaling addition pairs naturally with the existing rule (it extends rather than contradicts)
- [ ] Confirm the Diagnostics section points to the right reference implementation
- [ ] Confirm neither addition duplicates the existing \"Put pure logic behind functions that can be unit-tested without subprocess mocking\" line in Scripting Language Defaults (they complement it — that line is about *avoiding* subprocess mocking by structuring pure functions; mine is about what to do when the function itself IS the subprocess wrapper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines for testing process-signaling functionality with enhanced isolation requirements.
  * Introduced best practice for incorporating diagnostic checks directly into code via CLI patterns rather than documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->