### PR TITLE
skills: add /delegate-to-other-repo for cross-repo subagent work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -517,3 +517,6 @@ robots.txt
 # Beads / Dolt files (added by bd init)
 .dolt/
 .beads-credential-key
+
+# Git worktrees (superpowers:using-git-worktrees default location)
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -79,21 +79,22 @@ Machine-level skills go in `~/.claude/skills/` and are available everywhere. Pro
 
 ### Available Skills
 
-| Skill | Scope | Description |
-|---|---|---|
-| `ammon` | machine | Look up the current time in Denmark for Ammon |
-| `architect-review` | machine | Iterative architect review passes on design specs, tracking convergence |
-| `background-usage` | machine | Check Claude Code plan usage without blocking the session |
-| `build-bd` | machine | Build and install the `bd` (Beads) CLI with a static build |
-| `clock` | machine | Schedule recurring session tasks (time checks, reminders) |
-| `docs` | machine | Fetch fresh library/framework docs via Context7 (`ctx7`) |
-| `gen-image` | machine | Generate illustrations via Gemini image API |
-| `gist-image` | machine | Host images on GitHub gists for PRs/issues |
-| `image-explore` | machine | Brainstorm and compare visual directions |
-| `learn-from-session` | machine | Extract durable lessons from a session into the right CLAUDE.md files |
-| `machine-doctor` | machine | Diagnose system health, kill rogue processes |
-| `showboat` | machine | Create executable demo documents with screenshots |
-| `up-to-date` | machine | Sync git repo with upstream |
+| Skill                    | Scope   | Description                                                                     |
+| ------------------------ | ------- | ------------------------------------------------------------------------------- |
+| `ammon`                  | machine | Look up the current time in Denmark for Ammon                                   |
+| `architect-review`       | machine | Iterative architect review passes on design specs, tracking convergence         |
+| `background-usage`       | machine | Check Claude Code plan usage without blocking the session                       |
+| `build-bd`               | machine | Build and install the `bd` (Beads) CLI with a static build                      |
+| `clock`                  | machine | Schedule recurring session tasks (time checks, reminders)                       |
+| `delegate-to-other-repo` | machine | Delegate cross-repo work to a subagent with an isolated context; ends with a PR |
+| `docs`                   | machine | Fetch fresh library/framework docs via Context7 (`ctx7`)                        |
+| `gen-image`              | machine | Generate illustrations via Gemini image API                                     |
+| `gist-image`             | machine | Host images on GitHub gists for PRs/issues                                      |
+| `image-explore`          | machine | Brainstorm and compare visual directions                                        |
+| `learn-from-session`     | machine | Extract durable lessons from a session into the right CLAUDE.md files           |
+| `machine-doctor`         | machine | Diagnose system health, kill rogue processes                                    |
+| `showboat`               | machine | Create executable demo documents with screenshots                               |
+| `up-to-date`             | machine | Sync git repo with upstream                                                     |
 
 ## Usage
 

--- a/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design-changelog.md
+++ b/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design-changelog.md
@@ -1,6 +1,6 @@
 # /delegate-to-other-repo Skill — Design Changelog
 
-Spec: /home/developer/gits/chop-conventions/.worktrees/change-other-repo/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
+Spec: docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
 
 ## Architect Review — 2026-04-12 23:28
 

--- a/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design-changelog.md
+++ b/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design-changelog.md
@@ -1,0 +1,77 @@
+# /delegate-to-other-repo Skill — Design Changelog
+
+Spec: /home/developer/gits/chop-conventions/.worktrees/change-other-repo/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
+
+## Architect Review — 2026-04-12 23:28
+
+### Convergence Tracking
+
+| Pass | Changes |
+| ---- | ------- |
+| 1    | 14      |
+| 2    | 13      |
+| 3    | 8       |
+| 4    | 0       |
+
+### Pass 4 Changes
+
+None. Convergence pass verified the spec as correct:
+
+- Fork-detection decision tree correctly routes all four cases (vanilla two-remote, direct-push, chop-conventions' fork-as-origin pattern, canonical clone without fork).
+- Shell recipes verified copy-paste correct via live shell: grep alternation on protection JSON, `symbolic-ref` failure path, slug-extraction sed against four URL forms, slug pipeline on English/Japanese/punctuation/>40-char inputs, collision loop math.
+- `git -C` discipline holds — only two `cd` occurrences remain, both in subagent instructions (diagram + brief), none in parent path.
+- Decoupling from `using-git-worktrees` still documented with rationale, no leak-back.
+
+One deliberate non-edit: Case D's "look for any other remote" description sits inside the "one remote only" branch — label imprecision that degrades to correct behavior (empty search → STOP). Rewording would be gold-plating.
+
+## Convergence Summary
+
+**4 passes · converged** · Pass 1: 14 · Pass 2: 13 · Pass 3: 8 · Pass 4: 0
+
+Arc: pass 1 caught a cascade (decoupling from `using-git-worktrees` + associated hardening), pass 2 propagated `git -C` discipline and resolved open questions, pass 3 caught five concrete correctness bugs in the shell recipes, pass 4 verified and found nothing.
+
+**Assessment:** Ready for implementation.
+
+### Pass 3 Changes
+
+1. **Fixed broken Case C taxonomy in fork detection** (Brief → Git workflow + decision tree). Pass 2 described "auth = idvorkin-ai-tools but origin = idvorkin/chop-conventions" — backward. Verified empirically: chop-conventions' actual `origin` is `idvorkin-ai-tools/chop-conventions` (fork matching auth), no upstream, PRs go to `idvorkin/chop-conventions` (parent). Pass 2's tree would have routed this to Case B (direct push), silently landing the PR on the user's own fork. Restructured into 4 cases (A: two remotes; B: canonical-origin matching auth; C: fork-origin matching auth → PR to parent; D: canonical-origin NOT matching auth → look for sibling fork) with a `gh repo view --json isFork,parent` disambiguation step.
+2. **Removed bogus `gh -R "$T"` invocations** (Target Resolution validation, Worktree Creation). Verified: there is no top-level `gh -R` flag, and `gh repo view` doesn't accept a filesystem path. Replaced with `git -C "$T" remote get-url origin` → parse owner/repo → `gh repo view <slug>` positional. Added explicit warning note so a future reader doesn't reintroduce the broken form.
+3. **Fixed pipe-precedence bug in default-branch fallback chain** (Worktree Creation). Pass 2's `cmd_a || cmd_b | sed | sed || echo main` chain silently produces empty string when both fail (`||` binds only to the last `sed`, which "succeeds" on empty input). Verified: `T=/tmp/nonexistent ... echo main` returned `''`. Replaced with step-by-step assignment + `[ -z "$default_branch" ]` guards + final `${default_branch:-main}` default.
+4. **Added `git remote set-head origin --auto` after fetch** (Worktree Creation + validation). Verified: plain `git fetch origin` does NOT refresh `refs/remotes/origin/HEAD`. A target whose default branch was renamed since clone yields a stale value from `symbolic-ref`. `set-head --auto` is idempotent when origin/HEAD already matches.
+5. **Made the protection probe an actually-executed step** (Worktree Creation). Pass 2 described dry-run-push idea in a comment but the recipe never ran it. Replaced with executed `gh api repos/$slug/branches/$default/protection` that greps for `required_pull_request_reviews`/`required_status_checks` in JSON shape (not exit code, since `gh api` returns 0 even on 404). Documented the false-negative case (auth account lacks admin read → 404 → silent no-op) as accepted — worst case the local commit succeeds and the worktree push is unaffected.
+6. **Pinned precise reproducible slug derivation rule** (Worktree Creation). Pass 2 left it as "kebab-case, ≤40 chars." Replaced with concrete shell pipeline (`tr` lowercase → `sed` non-alnum→`-` → trim → `cut -c1-40` → re-trim), explicit empty/non-ASCII fallback to `task-<timestamp>`, and collision loop probing `git show-ref --verify` against `refs/heads/delegated/<candidate>` with `-2`...`-9` suffixes. Verified all three branches empirically (English → slug, empty → timestamp, Japanese → timestamp).
+7. **Detached-HEAD case made explicit** (Worktree Creation safety check + Failure Handling). Verified: `git branch --show-current` returns empty string (rc=0) on detached HEAD. Updated STOP message to print `'<detached>'` placeholder and added dedicated failure-mode entry so users get an actionable error instead of confusing "is on '', not 'main'".
+8. **Open Questions section refreshed** to reflect new closed defaults (precise slug rule, branch-protection probe via gh api shape match, corrected fork-detection cases).
+
+### Pass 2 Changes
+
+1. **Parent uses `git -C <target>` instead of `cd <target>`** (User Experience step 2). Pass 1 left parent stranded in target's cwd, polluting shell state. Only the subagent cds now.
+2. **Architecture diagram updated** to match — parent box shows `git -C <target> fetch origin` + "parent does NOT cd"; subagent box still cds as its first action.
+3. **Worktree Creation recipe rewritten with `git -C "$T"` throughout**, plus `gh -R "$T"` for `gh repo view` and a fallback chain for default-branch resolution (`gh` → `symbolic-ref refs/remotes/origin/HEAD` → literal `main`). Removes the hidden assumption that `gh` always works.
+4. **Fixed the gitignore-commit-on-wrong-branch bug** in Worktree Creation. Previous recipe blindly committed `.gitignore` on the target's current branch, which would silently land on a feature branch and disappear. New code requires target on default branch and STOPs otherwise. Adds heuristic note about PR-only/protected default branches.
+5. **Added `diagnose.py` reuse instructions** in Brief → Git workflow. Subagent invokes `~/.claude/skills/up-to-date/diagnose.py --pretty | jq .remotes` from the worktree as a shortcut for URL-based fork classification, then runs manual checks for uncovered cases.
+6. **Documented the Case C gap in `diagnose.py`** explicitly. After reading `diagnose.py` and `test_diagnose.py`, the single-canonical-origin case returns `is_fork_workflow=False` with no issues — the script has no concept of `gh auth status` and silently misclassifies the chop-conventions pattern. Brief and decision tree both call this out.
+7. **Added fork-detection ASCII decision tree** as a reference subsection of Brief Format — placed _outside_ the embedded markdown brief block to avoid the nested-fence problem pass 1 fixed. Pass 1's concern 2 resolved: yes, a diagram helps; prose alone left the four cases tangled.
+8. **Removed inner triple-backtick fences almost reintroduced inside the brief.** When drafting the diagnose.py shortcut and decision tree inside the brief block, pass 2 forgot pass 1's nested-fence lesson. Caught on re-read; brief is pure prose again.
+9. **Validation-after-resolution checklist tightened** to use `git -C` consistently, resolve default branch with the same fallback chain as Worktree Creation, and check `origin/<default>` rather than hardcoding `origin/main`.
+10. **Failure Handling expanded** with a new mode for "target on a non-default branch when `.worktrees/` needs ignoring," distinct from the existing "PR-only protected default branch" mode.
+11. **V1-limitation note about CLAUDE.md worktree-location preference.** `using-git-worktrees` honors a target's `worktree.*director` CLAUDE.md preference; this skill hardcodes `.worktrees/delegated-<slug>` and silently ignores any preference. Documented as a deliberate v1 punt with a path forward.
+12. **Frontmatter description un-hardcoded `origin/main`** → "the target's default branch" — matches the rest of the spec post-pass-1.
+13. **Open Questions section refreshed** with three new closed-defaults entries: worktree location punt, fork-detection reuse strategy, and the Case C gap in diagnose.py.
+
+### Pass 1 Changes
+
+1. **Decoupled from `using-git-worktrees`** (Architecture, Parent responsibilities, Worktree Creation, diagram). The spec claimed to delegate worktree creation to that skill with `origin/main` as base, but `using-git-worktrees` branches off current HEAD, auto-runs `npm install`/`cargo build`, and runs baseline tests — none of which are correct for delegating a change off a fresh `origin/main` that might be a doc-only edit. Replaced with explicit `git worktree add -b <branch> origin/<default>` commands.
+2. **Default-branch resolution added** (Target Resolution, Worktree Creation). Hardcoding `origin/main` breaks on repos with `master`/`trunk`. Added `gh repo view --json defaultBranchRef` resolution before worktree creation.
+3. **Self-contained `.worktrees/` gitignore check** (Worktree Creation, Failure Handling). Made the pre-check explicit via `git check-ignore` and added a failure mode: if the target repo requires a PR for `main` and `.worktrees/` isn't ignored, parent must stop instead of committing directly to `main`.
+4. **Fork workflow detection hardened** (Brief → Git workflow). Added single-remote-with-account-mismatch case (the chop-conventions pattern: auth as `idvorkin-ai-tools`, origin as `idvorkin/...`) and explicit STOP rule if the fork remote isn't wired up.
+5. **Session log resolution fixed for worktree parents** (Session log resolution). Previous recipe used `git rev-parse --show-toplevel` for the project hash, which breaks when parent session runs inside a worktree — Claude Code hashes the launch cwd, not the repo root. Added cwd-first/toplevel-fallback sequence and "omit escape hatch if missing" fallback.
+6. **Inference requires confirmation** (User Experience, Target Resolution). Added "always confirms before dispatch when target was inferred rather than explicit."
+7. **Pre-commit hook reformat guidance** (Brief → Target repo conventions). Added `.pre-commit-config.yaml` to read list + "re-stage and re-commit; don't fight the formatter" instruction from chop-conventions CLAUDE.md.
+8. **Enumerate commands inlined** (Brief → Target repo conventions). Replaced nested `bash fence inside outer `markdown fence (which would prematurely terminate the outer fence when brief is embedded in SKILL.md) with prose referencing `ls -1 skills/` and `ls -1 .claude/skills/`.
+9. **Security note about session log escape hatch** (What lives where). Flagged as accepted v1 risk with "don't use this for sensitive repos" caveat.
+10. **Commit trailer requirement** (Brief → Git workflow). Added explicit `Co-Authored-By` trailer instruction with "repo convention wins" override.
+11. **Validation tightened** (Target Resolution). Added explicit post-resolution checks: `origin` remote exists and resolves, `origin/<default>` is reachable after fetch.
+12. **Parent-side failure modes expanded** (Failure Handling). Split "worktree creation fails" into: fetch fails, gitignore conflict on default branch, worktree add fails.
+13. **Frontmatter example added** (Files). Showed concrete `allowed-tools` frontmatter including `Agent` — without which dispatch silently breaks.
+14. **Success criterion 4 rewritten** (Success Criteria). Previously claimed clean composition with `using-git-worktrees` — no longer true after change #1. Replaced with a state-pollution criterion.

--- a/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
+++ b/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
@@ -247,13 +247,65 @@ Then run these checks manually regardless of script output:
    `Co-Authored-By: Claude <noreply@anthropic.com>` (or whatever trailer
    the target repo's CLAUDE.md specifies — repo convention wins).
 
+# Lessons reflection (run before writing your final message)
+
+After the PR is open, before you write your final message, reflect on
+your own work against these prompts (these are the `learn-from-session`
+skill's reflection prompts — if
+`~/.claude/skills/learn-from-session/SKILL.md` is symlinked on the
+machine, read it for the full filter rules and voice guidance):
+
+1. What environmental constraint in this target repo surprised you?
+   (path quirk, tool alias, hook reformat, missing dep, protected branch)
+2. What safety gotcha almost shipped? (wrong remote, missing `.gitignore`
+   entry, commit to `main`, destructive default)
+3. What was the _right_ place for content you initially put somewhere
+   wrong?
+4. What pattern worked well enough to codify?
+5. What tool invocation ate time before you landed on the right one?
+
+Apply the durability filter: keep only lessons that are **durable**
+(true in future sessions, not specific to this task), **non-obvious**
+(not already in the target's `CLAUDE.md` or the default Claude Code
+system prompt), and **actionable** (tells a future Claude what to do —
+not a retrospective story). Discard narrative ("we discovered..."),
+vague generalities, and one-off fix postmortems.
+
+If any lessons survive the filter, draft them as a `Lessons:` block in
+your final message (see Final output contract for the format). If
+nothing survives, omit the block entirely. **When in doubt, omit** —
+narrative noise in `CLAUDE.md` is worse than a lost lesson.
+
+Do NOT commit any `CLAUDE.md` edits derived from this reflection to
+the work PR. The drafted lesson is _material for the user to approve_,
+not a committed change.
+
 # Final output contract
 
-Your final message MUST contain exactly:
+Your final message MUST contain, in this order:
 
 1. **PR URL** on its own line, prefixed with `PR: `
-2. **3–5 bullet summary** of what changed and why, prefixed with `Summary:`
-3. Nothing else. No preamble, no "I'll now...", no sign-off.
+2. **3–5 bullet summary** of what changed and why, prefixed with
+   `Summary:`
+3. **(Optional) Lessons block** — include only if your reflection
+   surfaced durable insights. Omit if nothing surfaced.
+4. Nothing else. No preamble, no "I'll now...", no sign-off.
+
+**Lessons block format (when present):** start with the literal line
+`Lessons:` on its own. For each lesson, write — as plain text, not a
+fenced code block, because nested fences would break this brief when
+it is embedded in `SKILL.md` — three fields on their own lines:
+
+- `file:` absolute path to the target repo's `CLAUDE.md` that should
+  receive the addition
+- `why:` one-line justification citing the cost or risk this work hit
+- `diff:` the lines to insert, each prefixed with `+ `, in
+  durable-rule voice (no "we discovered", no narrative, ≤5 lines per
+  lesson, bullets preferred)
+
+Multiple lessons are written as multiple `file:`/`why:`/`diff:` groups
+separated by a blank line. The parent relays this block verbatim to
+the user — don't try to pre-apply it.
 
 # Hard prohibitions
 
@@ -262,6 +314,9 @@ Your final message MUST contain exactly:
 - No commits directly to `main`
 - No `rm -rf` or destructive ops without explicit confirmation
 - No `gh pr merge` — opening the PR is the terminal action
+- No committing `CLAUDE.md` edits derived from Lessons reflection to
+  the work PR. Lessons are draft material in your final message only;
+  the user owns the approval gate.
 
 # Historical context (escape hatch)
 
@@ -622,6 +677,56 @@ Subagent does **not** delete its worktree on success. Reasons:
 Parent's final report includes the worktree path and this command for
 when the user wants to clean up.
 
+## Integration with learn-from-session
+
+`learn-from-session`-style reflection happens **inside the subagent**,
+not the parent. This is a deliberate split driven by visibility: the
+parent's view of the delegated run is limited to "brief in, structured
+final message out." It cannot see which hooks bit the subagent, which
+docs were missing, which commands were ambiguous, or which patterns
+the subagent had to invent. Parent has no substrate to reflect on. The
+subagent, by contrast, has lived the work, and is the only actor that
+can honestly answer `learn-from-session`'s reflection prompts for this
+target repo.
+
+### Responsibility split
+
+1. **Subagent drafts.** Reflection → durability filter → drafted diff.
+   Never commits the `CLAUDE.md` edit to the work PR; keeps it as
+   draft material in the final message only.
+2. **Parent relays verbatim.** The `Lessons:` block from the subagent's
+   final message passes through unchanged into the parent's final
+   report to the user.
+3. **Parent offers two follow-up paths.**
+   - **Quick path:** "Open a second PR in the same worktree with just
+     this `CLAUDE.md` addition?" Parent runs the commit and
+     `gh pr create` in the existing `.worktrees/delegated-<slug>`
+     worktree (which still exists because cleanup is manual). Fast
+     follow, same branch name suffixed with `-lessons`.
+   - **Full path:** "Run `/learn-from-session` on the target repo for
+     multi-file routing?" For lessons that might belong in multiple
+     `CLAUDE.md` files or need deeper routing than a single
+     mechanical insertion.
+4. **User decides.** Approval gate stays with the user, not the
+   subagent and not the parent. Rejected lessons ("skip it") are not a
+   failure state — parent simply omits the follow-up offer and the
+   delegated run is considered complete.
+
+### Why not auto-commit lessons to the work PR
+
+Because lesson drafting is high-noise by default. `learn-from-session`'s
+own rules say "when in doubt, omit" and require explicit user approval
+before `CLAUDE.md` edits land. Bypassing that gate to save a round-trip
+inverts the cost/risk ratio — a wrongly-committed lesson is harder to
+remove than a lost lesson is to regenerate on a re-run.
+
+### Why not have the parent reflect independently
+
+The parent's context after dispatch contains exactly the PR URL and
+summary — there is no substrate for parent-side reflection. Attempting
+it would either hallucinate observations or re-derive what the
+subagent already knew.
+
 ## Files
 
 - `skills/delegate-to-other-repo/SKILL.md` — the skill (pure markdown)
@@ -698,3 +803,10 @@ the blog` and end up with a clickable PR URL without touching another
    working repo, and the target repo's only modification (if any) is a
    one-line `.gitignore` entry for `.worktrees/` — committed in the
    target, never in the parent's checkout
+5. If the subagent's work surfaced durable lessons about the target
+   repo, they are returned in a structured `Lessons:` block that the
+   parent relays verbatim to the user. Lessons are never
+   auto-committed by either parent or subagent; the user is offered a
+   fast-follow path (same-worktree second PR) or the full
+   `/learn-from-session` flow. Rejection is a normal non-failure
+   terminal state.

--- a/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
+++ b/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
@@ -56,11 +56,16 @@ result (PR URL + summary) when the subagent returns.
 
 ### Parent's visible work
 
-1. Resolves the target (may ask for disambiguation)
-2. Creates a worktree at `<target>/.worktrees/delegated-<slug>` off
-   `origin/main`
-3. Dispatches the subagent (foreground by default)
-4. Reports back: **PR URL**, branch name, 3–5-bullet summary of changes,
+1. Resolves the target (may ask for disambiguation, **always confirms
+   before dispatch** when target was inferred rather than explicit)
+2. Runs `git -C <target> fetch origin` (no `cd` — the parent stays in its
+   own working directory so its shell state is not polluted)
+3. Creates a worktree at `<target>/.worktrees/delegated-<slug>` based on
+   `origin/<default-branch>` (see Worktree Creation for the exact commands —
+   this deviates from `using-git-worktrees`' default of branching off HEAD)
+4. Dispatches the subagent (foreground by default). The subagent is the
+   only actor that `cd`s — into the worktree, as its first action.
+5. Reports back: **PR URL**, branch name, 3–5-bullet summary of changes,
    worktree path (for post-hoc inspection)
 
 ## Architecture
@@ -72,8 +77,10 @@ result (PR URL + summary) when the subagent returns.
 │ Parent Claude (current session)                             │
 │                                                             │
 │  1. Resolve target repo          [skill markdown prompt]   │
-│  2. Fetch origin/main in target  [git fetch]               │
-│  3. Invoke using-git-worktrees   [skill call, cd'd in]     │
+│  2. git -C <target> fetch origin (parent does NOT cd)      │
+│  3. Verify .worktrees/ ignored; create worktree off        │
+│     origin/<default> (explicit commands —                  │
+│     do NOT delegate to using-git-worktrees; see below)     │
 │  4. Construct self-contained brief                         │
 │  5. Dispatch Agent tool          ──────────┐               │
 │  6. Wait for result                        │               │
@@ -99,7 +106,11 @@ result (PR URL + summary) when the subagent returns.
 ### Parent responsibilities — infrastructure
 
 - **Target resolution** (prompt-driven; no Python needed)
-- **Baseline worktree creation** — delegated to `superpowers:using-git-worktrees`
+- **Worktree creation** — direct `git worktree add` commands (see Worktree
+  Creation). We do **not** call `using-git-worktrees` here because that
+  skill branches off current HEAD, auto-runs `npm install` / `cargo build`,
+  and runs a baseline test pass — none of which we want for a delegated
+  change off `origin/main` that may be a pure doc edit.
 - **Brief construction** — self-contained, see below
 - **Dispatch + result relay** — via the `Agent` tool
 
@@ -118,13 +129,22 @@ the right place to:
 - Extract the user's original task wording
 - Resolve "the blog" → `~/gits/idvorkin.github.io` from conversational
   context
-- Own the git-worktree infrastructure setup (which `using-git-worktrees`
-  already knows how to do)
+- Own the git-worktree infrastructure setup
 
 The subagent gets a clean context — no distracting history, just the brief
 and the target repo's files. That's the entire win of this skill; if the
 subagent inherited the parent's context we could've just done the work
 in-session.
+
+**Security note:** The escape-hatch session-log pointer (see Brief Format)
+hands the subagent read access to the parent's entire conversation jsonl,
+which may contain secrets, tokens, or private file contents pasted in by
+the user. The subagent inherits full tool access in its fresh context and
+could read that file. v1 accepts this risk because (a) the subagent is
+still the user's own Claude session, and (b) the instruction is "only if
+genuinely stuck; prefer a clarifying question." If a repo is sensitive
+enough that this matters, the user should not delegate to it via this
+skill.
 
 ## Brief Format
 
@@ -148,27 +168,84 @@ cd <absolute path to worktree> # FIRST action you take
 
 Read, in order (skip any that don't exist):
 
-- CLAUDE.md (root, then any nested)
+- CLAUDE.md (root, then any nested — use `find . -name CLAUDE.md -not -path './.worktrees/*'`)
 - AGENTS.md
-- justfile, Makefile, package.json (scripts section)
+- justfile, Makefile, package.json (scripts section only — `jq .scripts package.json`)
 - .github/workflows/\*.yml (names only — so you know what CI will run)
+- .pre-commit-config.yaml if present (hooks may reformat your staged files;
+  if a commit fails with "files were modified by this hook", re-stage and
+  re-commit — do not fight the formatter)
 
-Then enumerate (list contents only, don't read every SKILL.md):
-
-- skills/
-- .claude/skills/
+Then enumerate (list contents only, don't read every SKILL.md) by running
+`ls -1 skills/` and `ls -1 .claude/skills/` (either may not exist; that's
+fine). Only read a specific `SKILL.md` if the task directly matches its
+name.
 
 # Git workflow
 
-Detect fork vs direct-push workflow:
+Detect fork vs direct-push workflow. **Shortcut: if
+`~/.claude/skills/up-to-date/diagnose.py` exists, run it first** — it
+handles `parse_remotes` / `is_fork_url` / `classify_remotes` and prints
+JSON. Invoke as `~/.claude/skills/up-to-date/diagnose.py --pretty` from
+inside the worktree (no `--path` arg; the script reads cwd's git context),
+then `jq .remotes` to extract the relevant block.
 
-1. Run `gh auth status` — note the active account
-2. Run `git remote -v` — check for both `origin` and `upstream`
-3. If `upstream` points to a canonical repo and `origin` points to a fork,
-   this is **fork workflow**: push to `origin`, open PR with
-   `gh pr create --repo <canonical>`
-4. Otherwise, this is **direct-push workflow**: push to `origin`, open PR
-   with `gh pr create`
+Interpretation of the JSON:
+
+- `remotes.is_fork_workflow == true` AND a remote named `upstream` exists
+  → Two-remote fork workflow (case A below).
+- `remotes.is_fork_workflow == false` with a single `origin` → you still
+  must run the single-remote check below. `diagnose.py` classifies purely
+  by URL owner against a hardcoded `FORK_ORGS` list and has no concept of
+  `gh auth status` or `gh repo view --json parent`, so it cannot tell the
+  difference between Case B (canonical-only origin matching auth) and
+  Case C (origin is itself a fork that needs PRs to its parent — the
+  chop-conventions pattern).
+
+Then run these checks manually regardless of script output:
+
+1. `gh auth status` — note the active account (e.g. `idvorkin-ai-tools`)
+2. `git remote -v` — inspect `origin` and any `upstream`
+3. For the single-remote case, check whether the repo `origin` points to is
+   itself a fork: `gh repo view <owner/repo from origin URL> --json isFork,parent -q '{isFork, parent: (.parent.owner.login + "/" + .parent.name)}'`.
+   If `isFork` is true, the canonical repo is `parent`. If false, there is
+   no upstream and the canonical IS `origin`.
+4. Classify using the decision tree below:
+   - **Branch on remote count.** If two remotes (`origin` + `upstream`):
+     check whether `upstream` URL is canonical and `origin` URL is the
+     fork. If yes → **Case A: two-remote fork workflow** (push origin,
+     PR --repo canonical). If swapped (origin canonical, upstream fork)
+     → STOP and report; do not guess.
+   - If one remote (`origin` only): use the `gh repo view` result from
+     step 3 above plus the auth-account check.
+     - If `origin` is NOT a fork AND the org segment of `origin`'s URL
+       matches the auth account → **Case B: direct-push workflow**
+       (push origin, PR with no `--repo` flag).
+     - If `origin` IS a fork AND its owner matches the auth account →
+       **Case C (chop-conventions pattern): single fork-origin, push
+       direct, PR to parent.** Push to `origin`, then
+       `gh pr create --repo <parent-owner>/<parent-repo>`.
+     - If `origin` is NOT a fork AND its owner does NOT match the auth
+       account → **Case D: canonical-only origin, no fork wired up.**
+       Look for any other remote whose URL owner segment matches the
+       auth account; if found, push to it and `gh pr create --repo <canonical>`.
+       If none found → STOP and fail: "cannot push to a repo this auth
+       account does not own; set up the fork first with
+       `gh repo fork --remote --remote-name=fork`".
+   - **Case A details:** push branch to the fork remote, open PR with
+     `gh pr create --repo <canonical-owner>/<repo>`.
+   - **Case B details:** active account owns `origin` and there is no
+     `upstream`. Push to `origin`, PR with `gh pr create` (no `--repo`).
+   - **Case C details (the chop-conventions pattern):** only `origin`
+     exists, it is `idvorkin-ai-tools/chop-conventions` (a fork), auth
+     account is also `idvorkin-ai-tools`, and PRs go to the parent
+     `idvorkin/chop-conventions`. There is NO separate `upstream` remote.
+     The `gh repo view --json parent` lookup is what tells you the
+     canonical slug to pass to `--repo`.
+
+5. Commit messages must end with the standard trailer:
+   `Co-Authored-By: Claude <noreply@anthropic.com>` (or whatever trailer
+   the target repo's CLAUDE.md specifies — repo convention wins).
 
 # Final output contract
 
@@ -198,20 +275,94 @@ read the whole file. Prefer ending with a clarifying question in your
 final message over spelunking the log.
 ```
 
+### Fork detection decision tree (reference)
+
+This is the same algorithm the brief's prose describes — kept here as a
+diagram for the spec reader. The brief itself can't embed this fenced
+block because a nested fence would terminate the outer markdown fence.
+
+```
+                       +------------------+
+                       | How many remotes |
+                       |  (origin + other)|
+                       +--------+---------+
+                                |
+              +-----------------+----------------+
+              |                                  |
+          2 remotes                          1 remote
+              |                                  |
+   +----------+----------+            +----------+----------+
+   | upstream = canonical|            | gh repo view origin |
+   | origin   = fork?    |            |   --json isFork,    |
+   +----------+----------+            |       parent        |
+              |                       +----------+----------+
+      +-------+--------+                         |
+     yes              no             +-----------+-----------+
+      |                |             |                       |
+      v                v         isFork=true            isFork=false
+  CASE A:         Remotes are        |                       |
+  TWO-REMOTE      swapped; STOP      v                       v
+  FORK WORKFLOW   and report     +-------+              +---------+
+  push origin     (don't guess)  | owner | == auth?     | owner   | == auth?
+  PR --repo                      +---+---+              +----+----+
+  canonical                          |                       |
+                              +------+-----+          +------+------+
+                              |            |          |             |
+                             yes           no        yes            no
+                              |            |          |             |
+                              v            v          v             v
+                          CASE C:      Look for   CASE B:       CASE D:
+                          FORK-ORIGIN  any other  DIRECT-PUSH   CANONICAL-
+                          push origin  remote     WORKFLOW      ORIGIN, NO
+                          PR --repo    matching   push origin   FORK WIRED
+                          parent       auth org;  PR (no        Look for any
+                          (slug from   if found,  --repo)       remote matching
+                          .parent in   push there,               auth org. If
+                          gh JSON)     PR --repo                 found, push
+                                       <canonical>               there, PR
+                                       Else STOP:                --repo origin.
+                                       "set up                   Else STOP:
+                                       fork first"               same fail msg.
+```
+
+`diagnose.py`'s `classify_remotes` covers Case A and the simple Case B
+(single canonical origin matching auth) but **misses Cases C and D
+entirely** — it has no concept of `gh auth status`, no `gh repo view
+--json parent` lookup, and only does URL-vs-FORK_ORGS string matching.
+The subagent must therefore not trust `is_fork_workflow: false` blindly;
+for the single-remote case, it must run both the auth-account comparison
+and the `gh repo view --json isFork,parent` lookup itself.
+
 ### Session log resolution
 
 Parent resolves the session jsonl path with:
 
 ```bash
-toplevel=$(git rev-parse --show-toplevel)
-hash=$(echo "$toplevel" | sed 's|/|-|g')
-newest=$(/bin/ls -t "$HOME/.claude/projects/$hash"/*.jsonl 2>/dev/null | head -1)
+# Claude Code hashes the session's *cwd* at launch, not the repo root.
+# If the parent is running inside a worktree (e.g. .worktrees/foo),
+# the hash encodes that worktree path, not the main checkout.
+cwd_hash=$(pwd | sed 's|/|-|g')
+newest=$(/bin/ls -t "$HOME/.claude/projects/$cwd_hash"/*.jsonl 2>/dev/null | head -1)
+
+# Fallback: if nothing found under cwd hash, try the repo toplevel hash.
+if [ -z "$newest" ]; then
+  toplevel=$(git rev-parse --show-toplevel)
+  toplevel_hash=$(echo "$toplevel" | sed 's|/|-|g')
+  newest=$(/bin/ls -t "$HOME/.claude/projects/$toplevel_hash"/*.jsonl 2>/dev/null | head -1)
+fi
 ```
 
-Caveat: "newest jsonl" is only reliably the current session when there's
-one active Claude session per repo. If the user runs parallel sessions in
-the same repo, this may resolve to the wrong log. Acceptable for v1 — the
-log is an escape hatch, not a required input.
+Caveats, all acceptable for v1 since the log is an escape hatch, not a
+required input:
+
+- **Parallel sessions in the same cwd** resolve to "whichever jsonl was
+  most recently written to," which may be a sibling session.
+- **Hash scheme may drift.** Claude Code's project-hash format is not a
+  stable public API. If `$HOME/.claude/projects/$hash` doesn't exist on
+  the running machine, the parent warns and omits the escape hatch
+  entirely rather than pointing at a wrong file.
+- **Worktree vs main checkout** is handled by trying cwd first, toplevel
+  second.
 
 ## Target Resolution Algorithm
 
@@ -226,28 +377,182 @@ not code):
 2. **Inferred from conversation.**
    - Scan recent turns for phrases like "the blog", "chop-conventions",
      "that other repo" and match against `~/gits/` entries
-   - If exactly one match → use it, tell the user
+   - If exactly one high-confidence match → propose it to the user and
+     **wait for confirmation** before dispatching. Inference is never
+     final — cross-repo work is too easy to get wrong silently.
    - If multiple or zero matches → fall through to step 3
 3. **Ask.**
    - `/bin/ls ~/gits/` and present candidates; user picks
 
-**Validation after resolution:**
+**Validation after resolution** (all use `git -C <path>` — parent never `cd`s):
 
 - Path exists
 - Is a git repo (`git -C <path> rev-parse --is-inside-work-tree`)
-- NOT required to be clean — worktrees off `origin/main` are safe even
-  when the parent working tree is dirty
+- Has a remote named `origin` that resolves (`git -C <path> remote get-url origin`)
+- Default branch resolves via the helper below (Worktree Creation defines
+  it once; reuse it here). The chain is: after `git fetch origin`, run
+  `git -C <path> remote set-head origin --auto` to refresh the cached
+  `refs/remotes/origin/HEAD` (plain fetch does not do this), then read
+  `git -C <path> symbolic-ref --short refs/remotes/origin/HEAD` (strip
+  the `origin/` prefix). If that fails, fall back to
+  `gh repo view <owner/repo> --json defaultBranchRef -q .defaultBranchRef.name`
+  where `<owner/repo>` is parsed from `git -C <path> remote get-url origin`.
+  Final fallback: literal `main`. Note: there is no top-level `gh -R` flag,
+  and `gh repo view` does not accept a filesystem path — it only accepts
+  an `OWNER/REPO` slug positional or auto-detects from cwd.
+- After `git -C <path> fetch origin`, `origin/<default-branch>` is
+  reachable (`git -C <path> rev-parse --verify origin/<default>`)
+- NOT required to be clean — worktrees off `origin/<default>` are safe
+  even when the parent working tree is dirty. (The target's HEAD branch
+  matters only for the gitignore-commit safety check in Worktree Creation.)
 
 ## Worktree Creation
 
-Delegated to `superpowers:using-git-worktrees`:
+Done directly by the parent, not via `using-git-worktrees`. The parent
+runs these commands against the target via `git -C <target>` — it does
+**not** `cd` into the target repo.
 
-- Directory: `.worktrees/delegated-<slug>` (the skill's default)
-- Branch: `delegated/<slug>` where `<slug>` is derived from the task
-  description (kebab-case, truncated to 40 chars)
-- Base: `origin/main` (explicit, not current branch) — always fresh
-- Pre-check: `using-git-worktrees` verifies `.worktrees/` is gitignored;
-  if not, it fixes and commits per its own rules
+```bash
+T=<absolute path to target repo>
+
+git -C "$T" fetch origin
+
+# Refresh the cached `refs/remotes/origin/HEAD`. Plain `git fetch origin`
+# does NOT update this ref — it's set at clone time and only refreshed
+# by an explicit `set-head --auto`. Without this call, a target whose
+# default branch was renamed (e.g. master → main) since it was cloned
+# would yield a stale value below. `--auto` is a no-op if origin/HEAD
+# already matches the remote's HEAD.
+git -C "$T" remote set-head origin --auto >/dev/null 2>&1 || true
+
+# Determine default branch (may not be "main"). Step-by-step rather than
+# a single `||`-chain because piping through `sed` swallows the upstream
+# exit code, so a chained `|| echo main` never fires when symbolic-ref
+# fails — the empty pipe output wins instead.
+default_branch=""
+ref=$(git -C "$T" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) && \
+  default_branch="${ref#origin/}"
+if [ -z "$default_branch" ]; then
+  # `gh repo view` takes an OWNER/REPO slug positional, NOT a path, and
+  # there is no top-level `gh -R` flag. Parse the slug from origin URL.
+  origin_url=$(git -C "$T" remote get-url origin 2>/dev/null)
+  slug_repo=$(printf '%s\n' "$origin_url" | sed -E 's#(\.git)?$##; s#^.*[/:]([^/:]+/[^/:]+)$#\1#')
+  default_branch=$(gh repo view "$slug_repo" --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)
+fi
+default_branch="${default_branch:-main}"
+
+# Derive slug from the task description. Reproducible rule:
+#   1. Lowercase
+#   2. Replace every char outside [a-z0-9] with `-`
+#   3. Collapse repeated `-`, strip leading/trailing `-`
+#   4. Truncate to 40 chars; re-strip trailing `-`
+#   5. If the result is empty (task was non-ASCII or pure punctuation),
+#      fall back to "task-$(date +%Y%m%d-%H%M%S)"
+#   6. If a branch named `delegated/<slug>` already exists in $T, append
+#      `-2`, `-3`, ... until unique (cap at -9; beyond that, fall through
+#      to the timestamp form from step 5).
+slug=$(printf '%s' "$task_description" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+  | cut -c1-40 \
+  | sed -E 's/-+$//')
+[ -z "$slug" ] && slug="task-$(date +%Y%m%d-%H%M%S)"
+i=1
+candidate="$slug"
+while git -C "$T" show-ref --verify --quiet "refs/heads/delegated/$candidate"; do
+  i=$((i + 1))
+  if [ "$i" -gt 9 ]; then
+    candidate="task-$(date +%Y%m%d-%H%M%S)"
+    break
+  fi
+  candidate="$slug-$i"
+done
+slug="$candidate"
+branch="delegated/$slug"
+path="$T/.worktrees/delegated-$slug"
+
+# Safety: ensure .worktrees/ is gitignored before we touch it.
+# git check-ignore needs to run with the target as cwd because it resolves
+# against the index of the repo containing cwd; `git -C` handles this.
+# Note: check-ignore returns 0 if the path WOULD be ignored, 1 if not.
+if ! git -C "$T" check-ignore -q .worktrees; then
+  # .worktrees/ must be ignored by a commit on the default branch,
+  # otherwise the ignore entry lives on a feature branch and disappears
+  # the moment the target checks out anything else. Refuse to land the
+  # gitignore edit on the wrong branch (this also catches detached HEAD,
+  # where `git branch --show-current` prints empty).
+  current=$(git -C "$T" branch --show-current)
+  if [ "$current" != "$default_branch" ]; then
+    echo "STOP: target HEAD is '${current:-<detached>}', not '$default_branch'."
+    echo "The .worktrees/ gitignore entry must land on the default branch."
+    echo "Ask the user to either (a) check out $default_branch in $T and"
+    echo "retry, or (b) land the ignore via their normal PR flow first."
+    exit 1
+  fi
+
+  # On the default branch. If the repo is PR-only for the default branch,
+  # we still cannot commit-and-push directly. Run the protection probe
+  # BEFORE mutating the working tree. Two complementary checks; either
+  # tripping STOPs us:
+  #   (a) gh api branch-protection — works if the auth account has admin
+  #       read on the repo; on 404 (no protection or no permission) it
+  #       still exits 0 with `{"message":"Not Found",...}`, so check the
+  #       JSON shape, not the exit code.
+  #   (b) git push --dry-run — server-side advisory; protection rules
+  #       that gate the actual push (not dry-run) won't show here, but
+  #       a wrong-credential 403 will. Use it only as a sanity check.
+  origin_url=$(git -C "$T" remote get-url origin)
+  slug_repo=$(printf '%s\n' "$origin_url" | sed -E 's#(\.git)?$##; s#^.*[/:]([^/:]+/[^/:]+)$#\1#')
+  protection_json=$(gh api "repos/$slug_repo/branches/$default_branch/protection" 2>/dev/null || true)
+  if printf '%s' "$protection_json" | grep -q '"required_pull_request_reviews"\|"required_status_checks"'; then
+    echo "STOP: $slug_repo's $default_branch is branch-protected. The"
+    echo ".worktrees/ gitignore entry needs to land via the target repo's"
+    echo "normal PR flow first; this skill will not bypass branch protection."
+    exit 1
+  fi
+
+  echo ".worktrees/" >> "$T/.gitignore"
+  git -C "$T" add .gitignore
+  git -C "$T" commit -m "chore: gitignore .worktrees/"
+  # Note: this commit is local-only. Whether to push it is the target
+  # repo's workflow concern, NOT this skill's. The subagent's PR branch
+  # will contain this commit as part of its base.
+fi
+
+# Create the worktree with a new branch rooted at origin/<default>.
+# `worktree add` is the only step that mutates the working set; if it
+# fails (path collision, ref missing), parent stops and reports — no
+# cleanup of the gitignore commit, since that commit is independently
+# valuable.
+git -C "$T" worktree add "$path" -b "$branch" "origin/$default_branch"
+```
+
+Why not call `using-git-worktrees`:
+
+- That skill branches off current HEAD (no way to pass a base ref)
+- It auto-runs `npm install` / `cargo build` / `pip install` — noisy and
+  wrong for doc-only or tiny changes
+- It runs the target repo's test suite as a baseline check — slow, and
+  unnecessary before the subagent has done anything
+
+Naming:
+
+- Directory: `.worktrees/delegated-<slug>`
+- Branch: `delegated/<slug>` where `<slug>` follows the precise derivation
+  rule in the recipe above (lowercase, non-alnum → `-`, collapse, trim,
+  ≤40 chars; empty/non-ASCII falls back to `task-<timestamp>`; collisions
+  with existing branches get `-2`...`-9` then a timestamp).
+- Base: `origin/<default-branch>` — always fresh, never current HEAD
+
+**v1 limitation — worktree location preference:** `using-git-worktrees`
+honors a target repo's CLAUDE.md `worktree.*director` preference (and an
+existing `worktrees/` dir as a fallback). This skill **does not** — it
+hardcodes `.worktrees/delegated-<slug>`. If a target repo specifies a
+different worktree location in its CLAUDE.md (e.g.
+`~/.config/superpowers/worktrees/`), this skill silently ignores it. If
+this becomes a real problem in practice, lift the directory-selection
+logic out of `using-git-worktrees` into a shared snippet or accept the
+worktree location as a parent argument. v1 punts.
 
 ## Dispatch
 
@@ -267,8 +572,27 @@ the parent can't do parallel work while waiting — that's fine for v1.
 ### Parent-side failures
 
 - **Target not found / not a git repo** → stop, report, ask user
-- **Worktree creation fails** → stop, report the `using-git-worktrees`
-  error, don't dispatch
+- **`git fetch origin` fails** (network, auth, missing remote) → stop,
+  surface the error, don't dispatch
+- **`.worktrees/` not gitignored and the target is checked out on a
+  non-default branch (or detached HEAD)** → stop, explain: the gitignore
+  entry must land on the default branch; ask the user to check out the
+  default branch in the target repo (or land the ignore via their normal
+  PR flow) and retry. The recipe's `current=$(git branch --show-current)`
+  returns empty string on detached HEAD, which compares unequal to the
+  default branch and triggers this same path with a `<detached>`
+  placeholder in the message.
+- **`.worktrees/` not gitignored, target is on the default branch, and
+  `gh api repos/.../branches/<default>/protection` reports
+  `required_pull_request_reviews` or `required_status_checks`** → stop,
+  explain: user needs to land the gitignore change via their normal PR
+  flow first; this skill will not bypass branch protection. (If the auth
+  account lacks admin read on the repo, the api returns Not Found and
+  the probe is silently a no-op — false negatives are accepted because
+  the worst case is the subsequent direct commit succeeds locally and
+  the eventual `git push` of the worktree branch is unaffected.)
+- **`git worktree add` fails** (path already exists, branch already
+  exists, base ref missing) → stop, surface the error, don't dispatch
 - **Session log unresolvable** → warn, proceed without the escape-hatch
   reference; don't block dispatch
 
@@ -308,6 +632,19 @@ work, not code work. This mirrors how `learn-from-session` is structured
 because it parallelizes subprocess calls and needs unit-testable
 classification logic).
 
+### Frontmatter
+
+```yaml
+---
+name: delegate-to-other-repo
+description: Delegate a task in a different git repo to a subagent in an isolated context. Use when the user asks to make a change in another repo without polluting the current session's context. Parent sets up a worktree off the target's default branch and dispatches a subagent that opens a PR back to the canonical remote.
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+```
+
+Note `Agent` in `allowed-tools` — the skill dispatches a subagent via the
+Agent tool, which must be explicitly allowed.
+
 ## Installation
 
 After the skill file lands:
@@ -325,10 +662,26 @@ None load-bearing. Defaults chosen:
 
 - **Branch naming:** `delegated/<slug>` — traceable back to the skill
 - **Worktree cleanup:** manual, via reported command
+- **Worktree location:** hardcoded `.worktrees/delegated-<slug>`; target
+  repo's CLAUDE.md `worktree.*director` preference is intentionally
+  ignored in v1 (see Worktree Creation note)
 - **No-CLAUDE.md target:** subagent proceeds, flags the absence in final summary
 - **Background dispatch:** only if user explicitly asks
 - **URL cloning:** not supported in v1; errors with `gh repo clone` hint
 - **Parallel session log ambiguity:** accepted v1 limitation, documented
+- **Fork detection:** subagent uses `up-to-date/diagnose.py` as a
+  shortcut for the URL-based classification (Case A and the simple
+  Case B), then runs `gh auth status` plus
+  `gh repo view --json isFork,parent` itself for the single-remote
+  cases (C and D), which the script does not cover
+- **Slug derivation:** precise rule pinned in Worktree Creation —
+  lowercase, non-alnum collapsed to `-`, trimmed to 40 chars; empty
+  input falls back to `task-<timestamp>`; branch collisions get a
+  `-2`...`-9` suffix then a timestamp
+- **Branch-protection detection:** `gh api .../branches/<default>/protection`
+  with a JSON-shape check (looking for `required_pull_request_reviews`
+  or `required_status_checks`). Accepts false negatives when the auth
+  account lacks admin read
 
 ## Success Criteria
 
@@ -341,5 +694,7 @@ the blog` and end up with a clickable PR URL without touching another
    and summary — not the target repo's `CLAUDE.md`, file reads, or diff
 3. If the subagent fails, the parent surfaces actionable error info and
    preserves the worktree for takeover
-4. The skill composes cleanly with `superpowers:using-git-worktrees`
-   rather than reimplementing worktree logic
+4. Parent-side state pollution is minimal: no changes to the parent's
+   working repo, and the target repo's only modification (if any) is a
+   one-line `.gitignore` entry for `.worktrees/` — committed in the
+   target, never in the parent's checkout

--- a/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
+++ b/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
@@ -458,8 +458,10 @@ not code):
 - After `git -C <path> fetch origin`, `origin/<default-branch>` is
   reachable (`git -C <path> rev-parse --verify origin/<default>`)
 - NOT required to be clean — worktrees off `origin/<default>` are safe
-  even when the parent working tree is dirty. (The target's HEAD branch
-  matters only for the gitignore-commit safety check in Worktree Creation.)
+  even when the parent working tree is dirty. The target's HEAD branch
+  is irrelevant: the `.worktrees/` exclusion is written to
+  `.git/info/exclude` rather than committed to any branch, so the
+  target's current checkout does not constrain the skill.
 
 ## Worktree Creation
 
@@ -488,8 +490,11 @@ default_branch=""
 ref=$(git -C "$T" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) && \
   default_branch="${ref#origin/}"
 if [ -z "$default_branch" ]; then
-  # `gh repo view` takes an OWNER/REPO slug positional, NOT a path, and
-  # there is no top-level `gh -R` flag. Parse the slug from origin URL.
+  # `gh repo view` accepts OWNER/REPO as a positional argument only;
+  # it has no `-R`/`--repo` flag on this subcommand (verified via
+  # `gh repo view --help` — INHERITED FLAGS section shows only
+  # `--help`). `gh repo view` also does not accept a filesystem path,
+  # so we parse the slug from origin URL and pass it positionally.
   origin_url=$(git -C "$T" remote get-url origin 2>/dev/null)
   slug_repo=$(printf '%s\n' "$origin_url" | sed -E 's#(\.git)?$##; s#^.*[/:]([^/:]+/[^/:]+)$#\1#')
   default_branch=$(gh repo view "$slug_repo" --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null)
@@ -512,9 +517,16 @@ slug=$(printf '%s' "$task_description" \
   | cut -c1-40 \
   | sed -E 's/-+$//')
 [ -z "$slug" ] && slug="task-$(date +%Y%m%d-%H%M%S)"
+# Collision check covers BOTH local branches and remote-tracking
+# refs. Checking only refs/heads/ misses the case where the same
+# name exists on the remote — worktree add would succeed locally, but
+# the subagent's eventual push would be rejected as non-fast-forward
+# (force-push is prohibited). We already fetched origin above, so
+# refs/remotes/origin/ is up-to-date.
 i=1
 candidate="$slug"
-while git -C "$T" show-ref --verify --quiet "refs/heads/delegated/$candidate"; do
+while git -C "$T" show-ref --verify --quiet "refs/heads/delegated/$candidate" \
+   || git -C "$T" show-ref --verify --quiet "refs/remotes/origin/delegated/$candidate"; do
   i=$((i + 1))
   if [ "$i" -gt 9 ]; then
     candidate="task-$(date +%Y%m%d-%H%M%S)"
@@ -526,59 +538,43 @@ slug="$candidate"
 branch="delegated/$slug"
 path="$T/.worktrees/delegated-$slug"
 
-# Safety: ensure .worktrees/ is gitignored before we touch it.
-# git check-ignore needs to run with the target as cwd because it resolves
-# against the index of the repo containing cwd; `git -C` handles this.
-# Note: check-ignore returns 0 if the path WOULD be ignored, 1 if not.
+# Safety: ensure .worktrees/ is excluded from the parent repo's git
+# status. Linked worktrees nested inside the parent show up as
+# untracked (verified: `git worktree add .worktrees/wt1` leaves
+# `?? .worktrees/` in parent's status) — we need an ignore entry.
+#
+# But we deliberately DO NOT commit `.gitignore` on any branch:
+#   - The delegated branch is created from `origin/$default_branch`
+#     (a clean remote ref), so a local-only commit on the default
+#     branch wouldn't be in the delegated branch's base anyway.
+#   - Committing on the target's *current* branch would silently
+#     pollute whatever happens to be checked out, disappearing on
+#     next checkout.
+#   - Switching branches is destructive and requires clean state we
+#     don't enforce.
+#   - Branch-protected default branches block direct commits entirely.
+#
+# Instead: use `.git/info/exclude`, the local-only, untracked,
+# branch-independent, per-repo exclude list (gitignore(5)). It lives
+# in the shared git dir, applies to all worktrees, survives branch
+# switches, and never touches any branch's history. Idempotent via
+# the grep guard.
+git_common=$(git -C "$T" rev-parse --git-common-dir 2>/dev/null)
+exclude_file="$git_common/info/exclude"
+if ! grep -qxF '.worktrees/' "$exclude_file" 2>/dev/null; then
+  mkdir -p "$git_common/info"
+  printf '\n# Added by delegate-to-other-repo skill\n.worktrees/\n' >> "$exclude_file"
+fi
+# Sanity check — check-ignore respects .git/info/exclude as well as
+# .gitignore, so the path must now be ignored.
 if ! git -C "$T" check-ignore -q .worktrees; then
-  # .worktrees/ must be ignored by a commit on the default branch,
-  # otherwise the ignore entry lives on a feature branch and disappears
-  # the moment the target checks out anything else. Refuse to land the
-  # gitignore edit on the wrong branch (this also catches detached HEAD,
-  # where `git branch --show-current` prints empty).
-  current=$(git -C "$T" branch --show-current)
-  if [ "$current" != "$default_branch" ]; then
-    echo "STOP: target HEAD is '${current:-<detached>}', not '$default_branch'."
-    echo "The .worktrees/ gitignore entry must land on the default branch."
-    echo "Ask the user to either (a) check out $default_branch in $T and"
-    echo "retry, or (b) land the ignore via their normal PR flow first."
-    exit 1
-  fi
-
-  # On the default branch. If the repo is PR-only for the default branch,
-  # we still cannot commit-and-push directly. Run the protection probe
-  # BEFORE mutating the working tree. Two complementary checks; either
-  # tripping STOPs us:
-  #   (a) gh api branch-protection — works if the auth account has admin
-  #       read on the repo; on 404 (no protection or no permission) it
-  #       still exits 0 with `{"message":"Not Found",...}`, so check the
-  #       JSON shape, not the exit code.
-  #   (b) git push --dry-run — server-side advisory; protection rules
-  #       that gate the actual push (not dry-run) won't show here, but
-  #       a wrong-credential 403 will. Use it only as a sanity check.
-  origin_url=$(git -C "$T" remote get-url origin)
-  slug_repo=$(printf '%s\n' "$origin_url" | sed -E 's#(\.git)?$##; s#^.*[/:]([^/:]+/[^/:]+)$#\1#')
-  protection_json=$(gh api "repos/$slug_repo/branches/$default_branch/protection" 2>/dev/null || true)
-  if printf '%s' "$protection_json" | grep -q '"required_pull_request_reviews"\|"required_status_checks"'; then
-    echo "STOP: $slug_repo's $default_branch is branch-protected. The"
-    echo ".worktrees/ gitignore entry needs to land via the target repo's"
-    echo "normal PR flow first; this skill will not bypass branch protection."
-    exit 1
-  fi
-
-  echo ".worktrees/" >> "$T/.gitignore"
-  git -C "$T" add .gitignore
-  git -C "$T" commit -m "chore: gitignore .worktrees/"
-  # Note: this commit is local-only. Whether to push it is the target
-  # repo's workflow concern, NOT this skill's. The subagent's PR branch
-  # will contain this commit as part of its base.
+  echo "STOP: failed to exclude .worktrees/ via $exclude_file."
+  exit 1
 fi
 
 # Create the worktree with a new branch rooted at origin/<default>.
 # `worktree add` is the only step that mutates the working set; if it
-# fails (path collision, ref missing), parent stops and reports — no
-# cleanup of the gitignore commit, since that commit is independently
-# valuable.
+# fails (path collision, ref missing), parent stops and reports.
 git -C "$T" worktree add "$path" -b "$branch" "origin/$default_branch"
 ```
 
@@ -629,23 +625,13 @@ the parent can't do parallel work while waiting — that's fine for v1.
 - **Target not found / not a git repo** → stop, report, ask user
 - **`git fetch origin` fails** (network, auth, missing remote) → stop,
   surface the error, don't dispatch
-- **`.worktrees/` not gitignored and the target is checked out on a
-  non-default branch (or detached HEAD)** → stop, explain: the gitignore
-  entry must land on the default branch; ask the user to check out the
-  default branch in the target repo (or land the ignore via their normal
-  PR flow) and retry. The recipe's `current=$(git branch --show-current)`
-  returns empty string on detached HEAD, which compares unequal to the
-  default branch and triggers this same path with a `<detached>`
-  placeholder in the message.
-- **`.worktrees/` not gitignored, target is on the default branch, and
-  `gh api repos/.../branches/<default>/protection` reports
-  `required_pull_request_reviews` or `required_status_checks`** → stop,
-  explain: user needs to land the gitignore change via their normal PR
-  flow first; this skill will not bypass branch protection. (If the auth
-  account lacks admin read on the repo, the api returns Not Found and
-  the probe is silently a no-op — false negatives are accepted because
-  the worst case is the subsequent direct commit succeeds locally and
-  the eventual `git push` of the worktree branch is unaffected.)
+- **`.git/info/exclude` write fails** (permission denied on shared git
+  dir) → stop, surface the error. This should not happen on a
+  user-owned repo; if it does, something is misconfigured.
+- **`.worktrees/` still not ignored after writing to
+  `.git/info/exclude`** → stop, fail with diagnostic. Should be
+  impossible (check-ignore respects `.git/info/exclude` per
+  gitignore(5)) but the sanity check exists as insurance.
 - **`git worktree add` fails** (path already exists, branch already
   exists, base ref missing) → stop, surface the error, don't dispatch
 - **Session log unresolvable** → warn, proceed without the escape-hatch
@@ -800,9 +786,11 @@ the blog` and end up with a clickable PR URL without touching another
 3. If the subagent fails, the parent surfaces actionable error info and
    preserves the worktree for takeover
 4. Parent-side state pollution is minimal: no changes to the parent's
-   working repo, and the target repo's only modification (if any) is a
-   one-line `.gitignore` entry for `.worktrees/` — committed in the
-   target, never in the parent's checkout
+   working repo, and the target repo is never committed to by this
+   skill — the `.worktrees/` exclusion is written to
+   `.git/info/exclude` (local-only, untracked, branch-independent).
+   No branches are created or modified beyond the delegated branch
+   itself.
 5. If the subagent's work surfaced durable lessons about the target
    repo, they are returned in a structured `Lessons:` block that the
    parent relays verbatim to the user. Lessons are never

--- a/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
+++ b/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
@@ -40,7 +40,7 @@ result (PR URL + summary) when the subagent returns.
 
 ### Invocation (flexible)
 
-```
+```text
 /delegate-to-other-repo <target> <task description>
 /delegate-to-other-repo <task description>
 /delegate-to-other-repo
@@ -72,7 +72,7 @@ result (PR URL + summary) when the subagent returns.
 
 ### Parent / subagent split
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │ Parent Claude (current session)                             │
 │                                                             │
@@ -336,7 +336,7 @@ This is the same algorithm the brief's prose describes — kept here as a
 diagram for the spec reader. The brief itself can't embed this fenced
 block because a nested fence would terminate the outer markdown fence.
 
-```
+```text
                        +------------------+
                        | How many remotes |
                        |  (origin + other)|
@@ -607,12 +607,12 @@ worktree location as a parent argument. v1 punts.
 
 ## Dispatch
 
-```
+```yaml
 Agent tool:
   subagent_type: "general-purpose"
   description: "Delegated work in <target-repo>"
   prompt: <the brief constructed above>
-  run_in_background: false  (default; true only if user asked)
+  run_in_background: false # default; true only if user asked
 ```
 
 Parent waits for the subagent's result message. On foreground dispatch,

--- a/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
+++ b/docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md
@@ -1,0 +1,345 @@
+# `/delegate-to-other-repo` Skill — Design
+
+**Status:** Draft · **Date:** 2026-04-12 · **Beads:** chop-conventions-c6a
+
+## Purpose
+
+Let the user ask Claude to make a change in a _different_ repository than the
+current session's working repo, with the work happening in an **isolated
+subagent context** so the parent session stays focused on its own work. The
+subagent operates in a git worktree of the target repo, reads that repo's
+`CLAUDE.md` / `AGENTS.md` / skill inventory, does the work, and ends by
+opening a pull request back to the canonical remote.
+
+## Motivation
+
+Today, when a user says "hey, also fix a typo in the blog repo while you're
+at it," Claude's options are:
+
+1. **Abandon the current repo context**, `cd` away, do the work in-session,
+   polluting the conversation with another project's `CLAUDE.md` and
+   conventions. Context gets muddled; long tasks eat tokens.
+2. **Manually ask the user to switch sessions**, which is jarring and loses
+   the conversational thread that motivated the request.
+
+A delegation skill gives a third option: parent Claude stays where it is,
+fires off a subagent with a clean, self-contained brief, and surfaces the
+result (PR URL + summary) when the subagent returns.
+
+## Non-Goals
+
+- **Not a generic "clone any repo" tool.** Targets must already exist under
+  `~/gits/`. If not, we error with a pointer to `gh repo clone`.
+- **Not a multi-repo batch runner.** One target per invocation.
+- **Not an in-session worker.** If you want same-session cross-repo work,
+  use a different (future) skill. This one always dispatches a subagent.
+- **Not a finish-phase skill.** There's no two-phase setup/finish split;
+  the subagent owns the whole lifecycle through PR creation.
+
+## User Experience
+
+### Invocation (flexible)
+
+```
+/delegate-to-other-repo <target> <task description>
+/delegate-to-other-repo <task description>
+/delegate-to-other-repo
+```
+
+- **Form 1:** explicit target and task. Target is a local path or a
+  `~/gits/<repo>` shortname.
+- **Form 2:** task only; parent infers target from the current conversation
+  ("fix that typo in the blog post we just talked about" →
+  `~/gits/idvorkin.github.io`).
+- **Form 3:** bare invocation; parent asks the user what to delegate, to
+  which repo.
+
+### Parent's visible work
+
+1. Resolves the target (may ask for disambiguation)
+2. Creates a worktree at `<target>/.worktrees/delegated-<slug>` off
+   `origin/main`
+3. Dispatches the subagent (foreground by default)
+4. Reports back: **PR URL**, branch name, 3–5-bullet summary of changes,
+   worktree path (for post-hoc inspection)
+
+## Architecture
+
+### Parent / subagent split
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Parent Claude (current session)                             │
+│                                                             │
+│  1. Resolve target repo          [skill markdown prompt]   │
+│  2. Fetch origin/main in target  [git fetch]               │
+│  3. Invoke using-git-worktrees   [skill call, cd'd in]     │
+│  4. Construct self-contained brief                         │
+│  5. Dispatch Agent tool          ──────────┐               │
+│  6. Wait for result                        │               │
+│  7. Relay PR URL + summary to user         │               │
+└────────────────────────────────────────────┼───────────────┘
+                                             │
+                      ┌──────────────────────▼───────────────┐
+                      │ Subagent (general-purpose, fresh ctx)│
+                      │                                      │
+                      │  1. cd <worktree>                    │
+                      │  2. Read CLAUDE.md, AGENTS.md        │
+                      │  3. Enumerate skills/, .claude/skills│
+                      │  4. Note test/lint commands          │
+                      │  5. Do the task                      │
+                      │  6. Commit (hooks, no --no-verify)   │
+                      │  7. Detect fork vs direct workflow   │
+                      │  8. Push to correct remote           │
+                      │  9. gh pr create --repo <canonical>  │
+                      │ 10. Return PR URL + summary          │
+                      └──────────────────────────────────────┘
+```
+
+### Parent responsibilities — infrastructure
+
+- **Target resolution** (prompt-driven; no Python needed)
+- **Baseline worktree creation** — delegated to `superpowers:using-git-worktrees`
+- **Brief construction** — self-contained, see below
+- **Dispatch + result relay** — via the `Agent` tool
+
+### Subagent responsibilities — content
+
+- Read target repo conventions
+- Execute the task
+- Handle git hygiene (commit, push, PR)
+- Return a structured final message (PR URL + summary)
+
+### What lives where — why this split
+
+The parent is the only thing with access to the current conversation. It's
+the right place to:
+
+- Extract the user's original task wording
+- Resolve "the blog" → `~/gits/idvorkin.github.io` from conversational
+  context
+- Own the git-worktree infrastructure setup (which `using-git-worktrees`
+  already knows how to do)
+
+The subagent gets a clean context — no distracting history, just the brief
+and the target repo's files. That's the entire win of this skill; if the
+subagent inherited the parent's context we could've just done the work
+in-session.
+
+## Brief Format
+
+The brief is the single most important artifact this skill produces.
+It must be fully self-contained — the subagent sees none of this
+conversation.
+
+### Required sections
+
+```markdown
+# Task
+
+<user's words, lightly edited for clarity — do not paraphrase
+destructively>
+
+# Working directory
+
+cd <absolute path to worktree> # FIRST action you take
+
+# Target repo conventions
+
+Read, in order (skip any that don't exist):
+
+- CLAUDE.md (root, then any nested)
+- AGENTS.md
+- justfile, Makefile, package.json (scripts section)
+- .github/workflows/\*.yml (names only — so you know what CI will run)
+
+Then enumerate (list contents only, don't read every SKILL.md):
+
+- skills/
+- .claude/skills/
+
+# Git workflow
+
+Detect fork vs direct-push workflow:
+
+1. Run `gh auth status` — note the active account
+2. Run `git remote -v` — check for both `origin` and `upstream`
+3. If `upstream` points to a canonical repo and `origin` points to a fork,
+   this is **fork workflow**: push to `origin`, open PR with
+   `gh pr create --repo <canonical>`
+4. Otherwise, this is **direct-push workflow**: push to `origin`, open PR
+   with `gh pr create`
+
+# Final output contract
+
+Your final message MUST contain exactly:
+
+1. **PR URL** on its own line, prefixed with `PR: `
+2. **3–5 bullet summary** of what changed and why, prefixed with `Summary:`
+3. Nothing else. No preamble, no "I'll now...", no sign-off.
+
+# Hard prohibitions
+
+- No `git push --force` on any branch
+- No `--no-verify` on commits (hooks exist for a reason)
+- No commits directly to `main`
+- No `rm -rf` or destructive ops without explicit confirmation
+- No `gh pr merge` — opening the PR is the terminal action
+
+# Historical context (escape hatch)
+
+If — and only if — you get genuinely stuck and need to understand _why_
+this task was requested, the originating conversation is at:
+
+<path to parent's session jsonl>
+
+It's a large JSONL file. Use `grep` / `jq` to find specific turns. Do not
+read the whole file. Prefer ending with a clarifying question in your
+final message over spelunking the log.
+```
+
+### Session log resolution
+
+Parent resolves the session jsonl path with:
+
+```bash
+toplevel=$(git rev-parse --show-toplevel)
+hash=$(echo "$toplevel" | sed 's|/|-|g')
+newest=$(/bin/ls -t "$HOME/.claude/projects/$hash"/*.jsonl 2>/dev/null | head -1)
+```
+
+Caveat: "newest jsonl" is only reliably the current session when there's
+one active Claude session per repo. If the user runs parallel sessions in
+the same repo, this may resolve to the wrong log. Acceptable for v1 — the
+log is an escape hatch, not a required input.
+
+## Target Resolution Algorithm
+
+Parent follows this order (prompt-driven — it's a checklist in `SKILL.md`,
+not code):
+
+1. **Explicit arg.**
+   - Absolute path → use it
+   - Relative path → resolve against `pwd`
+   - Bare name (e.g. `blog`) → resolve to `~/gits/blog`
+   - `owner/repo` → error: "clone first with `gh repo clone owner/repo ~/gits/repo`"
+2. **Inferred from conversation.**
+   - Scan recent turns for phrases like "the blog", "chop-conventions",
+     "that other repo" and match against `~/gits/` entries
+   - If exactly one match → use it, tell the user
+   - If multiple or zero matches → fall through to step 3
+3. **Ask.**
+   - `/bin/ls ~/gits/` and present candidates; user picks
+
+**Validation after resolution:**
+
+- Path exists
+- Is a git repo (`git -C <path> rev-parse --is-inside-work-tree`)
+- NOT required to be clean — worktrees off `origin/main` are safe even
+  when the parent working tree is dirty
+
+## Worktree Creation
+
+Delegated to `superpowers:using-git-worktrees`:
+
+- Directory: `.worktrees/delegated-<slug>` (the skill's default)
+- Branch: `delegated/<slug>` where `<slug>` is derived from the task
+  description (kebab-case, truncated to 40 chars)
+- Base: `origin/main` (explicit, not current branch) — always fresh
+- Pre-check: `using-git-worktrees` verifies `.worktrees/` is gitignored;
+  if not, it fixes and commits per its own rules
+
+## Dispatch
+
+```
+Agent tool:
+  subagent_type: "general-purpose"
+  description: "Delegated work in <target-repo>"
+  prompt: <the brief constructed above>
+  run_in_background: false  (default; true only if user asked)
+```
+
+Parent waits for the subagent's result message. On foreground dispatch,
+the parent can't do parallel work while waiting — that's fine for v1.
+
+## Failure Handling
+
+### Parent-side failures
+
+- **Target not found / not a git repo** → stop, report, ask user
+- **Worktree creation fails** → stop, report the `using-git-worktrees`
+  error, don't dispatch
+- **Session log unresolvable** → warn, proceed without the escape-hatch
+  reference; don't block dispatch
+
+### Subagent-side failures
+
+If the subagent's final message doesn't match the output contract (no
+`PR:` line), parent treats it as a failure. Parent surfaces the
+subagent's last message and asks the user:
+
+- **Retry** with same brief?
+- **Abandon** (delete the worktree)?
+- **Take over in-session** (parent `cd`s into the worktree and continues
+  the work manually)?
+
+No automatic retry loop. If the subagent failed, retrying the same brief
+probably just fails again — user input is the right escalation.
+
+## Cleanup
+
+Subagent does **not** delete its worktree on success. Reasons:
+
+- User may want to inspect the changes before the PR merges
+- User may want to iterate (amend, add commits) without re-running the skill
+- Worktree deletion is trivially `git worktree remove <path>` — not worth
+  automating
+
+Parent's final report includes the worktree path and this command for
+when the user wants to clean up.
+
+## Files
+
+- `skills/delegate-to-other-repo/SKILL.md` — the skill (pure markdown)
+
+No Python, no tests. Target resolution and brief construction are prompt
+work, not code work. This mirrors how `learn-from-session` is structured
+(pure markdown, no helpers) rather than `up-to-date` (which has a helper
+because it parallelizes subprocess calls and needs unit-testable
+classification logic).
+
+## Installation
+
+After the skill file lands:
+
+```bash
+ln -s /home/developer/gits/chop-conventions/skills/delegate-to-other-repo \
+      ~/.claude/skills/delegate-to-other-repo
+```
+
+Documented in `README.md` skills table.
+
+## Open Questions
+
+None load-bearing. Defaults chosen:
+
+- **Branch naming:** `delegated/<slug>` — traceable back to the skill
+- **Worktree cleanup:** manual, via reported command
+- **No-CLAUDE.md target:** subagent proceeds, flags the absence in final summary
+- **Background dispatch:** only if user explicitly asks
+- **URL cloning:** not supported in v1; errors with `gh repo clone` hint
+- **Parallel session log ambiguity:** accepted v1 limitation, documented
+
+## Success Criteria
+
+The skill is working when:
+
+1. A user can say `/delegate-to-other-repo fix the typo on the homepage of
+the blog` and end up with a clickable PR URL without touching another
+   terminal
+2. The parent session's context after delegation contains only the PR URL
+   and summary — not the target repo's `CLAUDE.md`, file reads, or diff
+3. If the subagent fails, the parent surfaces actionable error info and
+   preserves the worktree for takeover
+4. The skill composes cleanly with `superpowers:using-git-worktrees`
+   rather than reimplementing worktree logic

--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -125,14 +125,12 @@ Read that file and follow it verbatim. Key points:
 - Derives a slug from the task description with a reproducible rule
   (lowercase → non-alnum collapsed to `-` → ≤40 chars; empty/non-ASCII
   falls back to `task-<timestamp>`; collisions get `-2`..`-9` suffixes
-  then a timestamp)
-- Checks `.worktrees/` is gitignored; if not, commits the ignore entry
-  on the target's **default branch only** (refuses on feature branches
-  and detached HEAD — the ignore entry must land on default or it
-  vanishes on next checkout)
-- Runs the branch-protection probe via
-  `gh api repos/$slug/branches/$default/protection` (JSON shape check,
-  not exit code — `gh api` returns 0 even on 404)
+  then a timestamp). Collision check covers BOTH `refs/heads/` and
+  `refs/remotes/origin/` to avoid non-fast-forward push rejection
+- Writes `.worktrees/` to `.git/info/exclude` (local-only, untracked,
+  branch-independent) — NOT a `.gitignore` commit. This avoids
+  mutating any branch's history, works regardless of target's
+  current branch, and survives branch-protected defaults
 - Creates the worktree at `.worktrees/delegated-<slug>` on branch
   `delegated/<slug>` rooted at `origin/<default>`
 
@@ -289,7 +287,11 @@ These apply to both parent and subagent:
 
 - **No `git push --force`** on any branch
 - **No `--no-verify`** on commits
-- **No commits directly to `main`** of the target repo
+- **No commits on any branch of the target's primary checkout** —
+  the parent never mutates the target's branches. The only thing
+  the parent writes is `.git/info/exclude` (local-only, untracked).
+  All subagent work happens on the delegated branch inside the
+  worktree and is pushed via normal PR flow.
 - **No `rm -rf`** or destructive ops without explicit user confirmation
 - **No `gh pr merge`** — opening the PR is the terminal action
 - **No committing CLAUDE.md edits derived from lessons reflection**
@@ -302,14 +304,13 @@ These apply to both parent and subagent:
 
 ### Parent-side
 
-| Failure                                                            | Response                                                       |
-| ------------------------------------------------------------------ | -------------------------------------------------------------- |
-| Target not found / not a git repo                                  | Stop, report, ask user                                         |
-| `git fetch origin` fails                                           | Stop, surface error, don't dispatch                            |
-| `.worktrees/` ignored on wrong branch or detached HEAD             | Stop, ask user to check out default branch in target and retry |
-| `.worktrees/` ignore blocked by branch protection on default       | Stop, ask user to land the ignore via normal PR flow first     |
-| `git worktree add` fails (path/branch collision, base ref missing) | Stop, surface error                                            |
-| Session log unresolvable                                           | Warn, omit historical-context section, continue                |
+| Failure                                                            | Response                                                   |
+| ------------------------------------------------------------------ | ---------------------------------------------------------- |
+| Target not found / not a git repo                                  | Stop, report, ask user                                     |
+| `git fetch origin` fails                                           | Stop, surface error, don't dispatch                        |
+| `.git/info/exclude` write fails (permission denied)                | Stop, surface error — should not happen on user-owned repo |
+| `git worktree add` fails (path/branch collision, base ref missing) | Stop, surface error                                        |
+| Session log unresolvable                                           | Warn, omit historical-context section, continue            |
 
 ### Subagent-side
 
@@ -340,11 +341,13 @@ clone yields a stale value from `symbolic-ref`. Fix: always run
 `git -C "$T" remote set-head origin --auto` between fetch and the
 symbolic-ref lookup.
 
-### Committing the `.worktrees/` gitignore entry on a feature branch
+### Committing `.worktrees/` to a branch's `.gitignore`
 
-The entry vanishes the moment the target checks out any other branch.
-Fix: refuse unless the target is on its default branch; STOP with an
-actionable message otherwise.
+Committing on the target's current branch pollutes arbitrary branches
+and vanishes on next checkout. Committing on the default branch
+requires branch-switching (destructive) and breaks on protected
+defaults. Fix: write to `.git/info/exclude` instead — local-only,
+untracked, branch-independent, per-repo (shared across worktrees).
 
 ### Trusting `diagnose.py`'s `is_fork_workflow: false`
 

--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -39,7 +39,7 @@ a subagent for cross-repo work in `<target>`."
 
 ## Flow at a glance
 
-```
+```text
 Parent (you)                             Subagent (fresh context)
 ──────────────────                       ─────────────────────────
 1. Resolve target repo
@@ -184,12 +184,12 @@ the log is an escape hatch, not a required input.
 
 ## Phase 4: Dispatch the subagent
 
-```
+```yaml
 Agent tool:
-  description:        "Delegated work in <target-repo>"
-  subagent_type:      "general-purpose"
-  prompt:             <the substituted brief from Phase 3>
-  run_in_background:  false
+  description: "Delegated work in <target-repo>"
+  subagent_type: "general-purpose"
+  prompt: <the substituted brief from Phase 3>
+  run_in_background: false
 ```
 
 **Foreground by default.** Only pass `run_in_background: true` if the

--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -1,0 +1,389 @@
+---
+name: delegate-to-other-repo
+description: Use when the user asks to make a change in a different git repo than the current session's cwd, and wants it done without polluting the current conversation with that repo's context. Typical triggers — "also fix X in the blog", "delegate this to the dotfiles repo", cross-repo tasks mentioned alongside current work.
+allowed-tools: Bash, Read, Grep, Glob, Agent
+---
+
+# Delegate To Other Repo
+
+Parent Claude (you, in the current session) sets up an isolated worktree in
+a different target repo, constructs a self-contained brief, and dispatches a
+subagent with a fresh context to do the actual work. The subagent reads the
+target repo's conventions, opens a PR, and returns a structured final
+message. You relay the PR URL and a short summary.
+
+**Core principle:** parent does infrastructure, subagent does content.
+Parent never `cd`s — everything uses `git -C <target>`.
+
+**Announce at start:** "I'm using the delegate-to-other-repo skill to set up
+a subagent for cross-repo work in `<target>`."
+
+## When to use
+
+- User asks for a change in another repo mid-conversation
+  ("also fix the typo in the blog", "while you're at it, bump
+  the version in the other service")
+- Task is self-contained enough for a subagent to handle end-to-end
+- You want to preserve the current session's context — cross-repo
+  work would otherwise load another repo's `CLAUDE.md`, file reads,
+  and diff into your working memory
+- Target repo already exists locally (this skill does NOT clone)
+
+**Do NOT use** when:
+
+- The task needs back-and-forth with the user during the work
+- The current repo and the "other" repo are the same
+- The user explicitly said "just do it in this session"
+- The target isn't under `~/gits/` yet — tell the user to run
+  `gh repo clone owner/repo ~/gits/repo` first
+
+## Flow at a glance
+
+```
+Parent (you)                             Subagent (fresh context)
+──────────────────                       ─────────────────────────
+1. Resolve target repo
+2. git -C <T> fetch origin
+3. Create worktree off
+   origin/<default-branch>
+4. Build brief (template +
+   substitutions)
+5. Agent tool dispatch  ─────────────►   1. cd <worktree>
+                                         2. Read CLAUDE.md / AGENTS.md
+                                         3. Enumerate skills/
+                                         4. Do the task
+                                         5. Detect fork vs direct
+                                         6. Commit, push, PR
+                                         7. Reflect on lessons
+6. Receive final message ◄───────────    8. Return PR: / Summary: /
+7. Relay to user                            (optional) Lessons:
+8. Offer lesson follow-up
+   (if present)
+```
+
+## Phase 1: Resolve the target repo
+
+Follow this checklist in order:
+
+### 1a. Explicit argument
+
+If the user passed a target:
+
+- **Absolute path** (`/home/user/gits/blog`) → use it
+- **Relative path** (`../blog`) → resolve against current `pwd`
+- **Bare name** (`blog`) → resolve to `~/gits/blog`
+- **`owner/repo` slug** → STOP and tell the user:
+  > "I don't clone repos. Run `gh repo clone <owner>/<repo> ~/gits/<repo>` first, then retry."
+
+### 1b. Inferred from conversation
+
+If no argument, scan the recent conversation for repo references
+("the blog", "chop-conventions", "that other repo") and match them
+against `~/gits/` entries.
+
+**Inference is never final.** Always propose the match to the user and
+wait for confirmation before dispatching:
+
+> "You mentioned 'the blog' — I'm reading that as `~/gits/idvorkin.github.io`. Proceed?"
+
+If multiple candidates or no match, fall through to 1c.
+
+### 1c. Ask
+
+Run `/bin/ls ~/gits/` and present the list. Let the user pick.
+
+### 1d. Validate the resolved target
+
+All validation runs via `git -C <path>` — never `cd` into the target:
+
+1. Path exists
+2. Is a git repo: `git -C "$T" rev-parse --is-inside-work-tree`
+3. Has an `origin` remote that resolves:
+   `git -C "$T" remote get-url origin`
+4. Default branch is resolvable (see Phase 2 recipe)
+5. `origin/<default>` is reachable after `git fetch`
+
+**Not required to be clean.** Worktrees off `origin/<default>` are safe
+even when the target's working tree is dirty.
+
+## Phase 2: Create the worktree
+
+**DO NOT delegate to `superpowers:using-git-worktrees`.** That skill
+branches off current HEAD, auto-runs `npm install` / `cargo build`, and
+runs baseline tests — none of which are correct for delegating a change
+off a fresh `origin/<default>` that may be a doc-only edit.
+
+Full shell recipe lives at [`worktree-recipe.md`](worktree-recipe.md).
+Read that file and follow it verbatim. Key points:
+
+- Uses `git -C "$T"` throughout
+- Runs `git remote set-head origin --auto` after fetch to refresh
+  stale `refs/remotes/origin/HEAD` (plain `git fetch` does not)
+- Resolves default branch via `symbolic-ref` → `gh repo view` fallback
+  → literal `main`, with explicit `[ -z "$default_branch" ]` guards
+  to avoid a pipe-precedence bug
+- Derives a slug from the task description with a reproducible rule
+  (lowercase → non-alnum collapsed to `-` → ≤40 chars; empty/non-ASCII
+  falls back to `task-<timestamp>`; collisions get `-2`..`-9` suffixes
+  then a timestamp)
+- Checks `.worktrees/` is gitignored; if not, commits the ignore entry
+  on the target's **default branch only** (refuses on feature branches
+  and detached HEAD — the ignore entry must land on default or it
+  vanishes on next checkout)
+- Runs the branch-protection probe via
+  `gh api repos/$slug/branches/$default/protection` (JSON shape check,
+  not exit code — `gh api` returns 0 even on 404)
+- Creates the worktree at `.worktrees/delegated-<slug>` on branch
+  `delegated/<slug>` rooted at `origin/<default>`
+
+### V1 limitation
+
+This skill hardcodes `.worktrees/delegated-<slug>` and does NOT honor a
+target repo's CLAUDE.md `worktree.*director` preference.
+`using-git-worktrees` does honor that — revisit if it becomes a
+problem.
+
+## Phase 3: Construct the brief
+
+The brief is the single most important artifact this skill produces.
+It must be fully self-contained — the subagent sees none of the
+current conversation.
+
+Template lives at [`brief-template.md`](brief-template.md). Read it,
+substitute the slot placeholders, and pass the result as the `prompt`
+parameter to the Agent tool.
+
+### Slots to substitute
+
+| Slot                 | Source                                                                                                                                    |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `<TASK>`             | User's task description, lightly edited for clarity. **Never paraphrase destructively** — preserve their wording.                         |
+| `<WORKTREE_PATH>`    | Absolute path to the worktree you created in Phase 2                                                                                      |
+| `<SESSION_LOG_PATH>` | Current session's jsonl (see Session log resolution below). If unresolvable, omit the entire "Historical context" section from the brief. |
+| `<TARGET_REPO_SLUG>` | Parsed from `git -C "$T" remote get-url origin` (e.g. `idvorkin/chop-conventions`) — used by the subagent for fork detection              |
+
+### Session log resolution
+
+```bash
+# Claude Code hashes the session's *cwd* at launch, not the repo root.
+# If you're running inside a worktree, the hash encodes the worktree
+# path, not the main checkout.
+cwd_hash=$(pwd | sed 's|/|-|g')
+newest=$(/bin/ls -t "$HOME/.claude/projects/$cwd_hash"/*.jsonl 2>/dev/null | head -1)
+
+# Fallback: try the repo toplevel hash.
+if [ -z "$newest" ]; then
+  toplevel=$(git rev-parse --show-toplevel)
+  toplevel_hash=$(echo "$toplevel" | sed 's|/|-|g')
+  newest=$(/bin/ls -t "$HOME/.claude/projects/$toplevel_hash"/*.jsonl 2>/dev/null | head -1)
+fi
+```
+
+If neither path yields a jsonl, warn and omit the historical-context
+section. Parallel sessions in the same cwd resolve to "whichever jsonl
+was most recently written" — this is an accepted v1 ambiguity since
+the log is an escape hatch, not a required input.
+
+## Phase 4: Dispatch the subagent
+
+```
+Agent tool:
+  description:        "Delegated work in <target-repo>"
+  subagent_type:      "general-purpose"
+  prompt:             <the substituted brief from Phase 3>
+  run_in_background:  false
+```
+
+**Foreground by default.** Only pass `run_in_background: true` if the
+user explicitly asked ("dispatch in background", "I want to keep
+working while this runs"). Foreground means you wait for the result
+message before continuing — that's fine.
+
+**Never retry automatically.** If the subagent fails, escalate to the
+user (see Phase 5).
+
+## Phase 5: Relay the result and offer follow-ups
+
+The subagent returns a final message with:
+
+1. **`PR:` URL** — on its own line
+2. **`Summary:` 3–5 bullets** — what changed and why
+3. **`Lessons:` block** (optional) — draft CLAUDE.md insertions the
+   subagent thinks are worth capturing
+
+### Happy path
+
+Relay all three sections verbatim to the user. Add a note with the
+worktree path and the cleanup command:
+
+> "Worktree preserved at `<path>`. Delete with `git worktree remove <path>` when you're done iterating on it."
+
+### If `Lessons:` is present
+
+Show the block verbatim, then offer two follow-up paths:
+
+1. **Quick path** — "Open a second PR in the same worktree with just
+   this CLAUDE.md addition?" If accepted, run the commit and
+   `gh pr create` in the existing `.worktrees/delegated-<slug>`
+   worktree (still exists, since cleanup is manual). Branch name:
+   `delegated/<slug>-lessons`.
+2. **Full path** — "Run `/learn-from-session` on the target repo for
+   multi-file routing?" For lessons that span multiple CLAUDE.md
+   files or need deeper routing.
+
+If the user declines both ("skip it"), that's a **normal terminal
+state** — omit the follow-up and consider the delegated run complete.
+Rejected lessons are NOT a failure.
+
+### If the subagent's final message doesn't match the contract
+
+Missing `PR:` line → treat as failure. Show the user the subagent's
+last message and ask:
+
+- **Retry** with the same brief?
+- **Abandon** — delete the worktree and stop?
+- **Take over in-session** — you (parent) `cd` into the worktree and
+  continue the work manually?
+
+No automatic retry loop.
+
+## Fork workflow detection (reference)
+
+The subagent handles this itself — the brief walks it through the
+decision tree. For the full 4-case tree with ASCII diagram and the
+`diagnose.py` reuse strategy, see [`fork-detection.md`](fork-detection.md).
+
+TL;DR: the subagent runs `gh auth status`, `git remote -v`, and
+(for single-remote cases) `gh repo view <slug> --json isFork,parent`,
+then classifies into:
+
+- **Case A** — two remotes (`origin` + `upstream`): fork workflow,
+  push to `origin`, PR `--repo <canonical>`
+- **Case B** — one remote, canonical origin matching auth:
+  direct push, PR with no `--repo`
+- **Case C** — one remote, fork-as-origin matching auth
+  (**chop-conventions' real pattern**): push to `origin`, PR
+  `--repo <parent-from-gh-json>`
+- **Case D** — one remote, canonical origin NOT matching auth:
+  look for sibling fork remote; if none, STOP
+
+## Integration with learn-from-session
+
+Reflection happens **in the subagent**, not the parent. The parent
+has no visibility into what tripped up the subagent during the work
+(missing docs, hook reformats, unclear conventions) — only the
+subagent lived it. So the subagent runs through `learn-from-session`'s
+reflection prompts on its own work, applies the durability filter,
+and drafts any surviving lessons inline in its final message.
+
+The parent's job is to relay, not to reflect:
+
+1. Subagent drafts — never commits CLAUDE.md edits to the work PR
+2. Parent relays the `Lessons:` block verbatim
+3. Parent offers quick-path or full-path follow-ups (see Phase 5)
+4. User owns the approval gate
+
+## Hard prohibitions
+
+These apply to both parent and subagent:
+
+- **No `git push --force`** on any branch
+- **No `--no-verify`** on commits
+- **No commits directly to `main`** of the target repo
+- **No `rm -rf`** or destructive ops without explicit user confirmation
+- **No `gh pr merge`** — opening the PR is the terminal action
+- **No committing CLAUDE.md edits derived from lessons reflection**
+  to the work PR. Lessons are draft material in the subagent's final
+  message only; the user owns the approval gate.
+- **No `cd` in the parent.** Parent always uses `git -C <target>`.
+  Only the subagent `cd`s, into the worktree, as its first action.
+
+## Failure handling
+
+### Parent-side
+
+| Failure                                                            | Response                                                       |
+| ------------------------------------------------------------------ | -------------------------------------------------------------- |
+| Target not found / not a git repo                                  | Stop, report, ask user                                         |
+| `git fetch origin` fails                                           | Stop, surface error, don't dispatch                            |
+| `.worktrees/` ignored on wrong branch or detached HEAD             | Stop, ask user to check out default branch in target and retry |
+| `.worktrees/` ignore blocked by branch protection on default       | Stop, ask user to land the ignore via normal PR flow first     |
+| `git worktree add` fails (path/branch collision, base ref missing) | Stop, surface error                                            |
+| Session log unresolvable                                           | Warn, omit historical-context section, continue                |
+
+### Subagent-side
+
+| Failure                                | Response                                       |
+| -------------------------------------- | ---------------------------------------------- |
+| Final message has no `PR:` line        | Escalate to user (retry / abandon / take over) |
+| Subagent exits without a final message | Same — treat as failure                        |
+| Rejected lessons                       | NOT a failure — normal terminal state          |
+
+## Common mistakes
+
+### Using `cd <target>` instead of `git -C <target>`
+
+Parent ends up stranded in the target's cwd, polluting shell state for
+any post-dispatch commands. Fix: always `git -C "$T"` in the parent.
+Only the subagent `cd`s.
+
+### Hardcoding `origin/main`
+
+Breaks on repos with `master` or `trunk` as the default branch. Fix:
+resolve the default branch with the fallback chain in `worktree-recipe.md`.
+
+### Skipping `remote set-head --auto` after fetch
+
+Plain `git fetch origin` does NOT refresh `refs/remotes/origin/HEAD`. A
+target whose default branch was renamed (e.g. master → main) since
+clone yields a stale value from `symbolic-ref`. Fix: always run
+`git -C "$T" remote set-head origin --auto` between fetch and the
+symbolic-ref lookup.
+
+### Committing the `.worktrees/` gitignore entry on a feature branch
+
+The entry vanishes the moment the target checks out any other branch.
+Fix: refuse unless the target is on its default branch; STOP with an
+actionable message otherwise.
+
+### Trusting `diagnose.py`'s `is_fork_workflow: false`
+
+It misclassifies chop-conventions' real pattern (single fork-as-origin
+with no upstream). Fix: for the single-remote case, always run
+`gh repo view <slug> --json isFork,parent` manually — see
+`fork-detection.md`.
+
+### Nested fences in the brief
+
+Embedding ` ``` ` inside the brief's outer ` ```markdown ` fence
+terminates the fence early when the brief is stored in SKILL.md. Fix:
+the brief uses plain-text formatting for all embedded structure
+(decision trees, output contract, `Lessons:` block). See
+`brief-template.md` — it's pre-formatted to avoid this.
+
+## Red flags — STOP and reconsider
+
+- You're about to `cd` into the target repo in the parent
+- You're about to call `using-git-worktrees` to create the worktree
+- You're about to retry a failed subagent dispatch automatically
+- You're about to commit a drafted lesson to the work PR
+- You're about to dispatch without confirming an inferred target
+- The target slug is non-ASCII and you're about to use it unfiltered
+
+## Related
+
+- **REQUIRED SUB-SKILL:** `superpowers:using-git-worktrees` — read it so
+  you understand _why_ this skill deliberately does NOT call it
+- `learn-from-session` — the reflection flow the subagent runs inside
+  itself before returning
+- `up-to-date` — its `diagnose.py` helper is what the subagent uses
+  as a fork-detection shortcut (Cases A and simple B only)
+
+## Supplementary files
+
+- [`worktree-recipe.md`](worktree-recipe.md) — full shell recipe for
+  Phase 2, with safety checks and fallback chains
+- [`brief-template.md`](brief-template.md) — the full self-contained
+  brief the parent substitutes slots into and passes to Agent
+- [`fork-detection.md`](fork-detection.md) — the 4-case decision tree
+  with ASCII diagram and `diagnose.py` interaction rules

--- a/skills/delegate-to-other-repo/brief-template.md
+++ b/skills/delegate-to-other-repo/brief-template.md
@@ -1,0 +1,207 @@
+# Brief Template (loaded on demand)
+
+> Self-contained instructions passed verbatim as the `prompt` parameter
+> to the Agent tool. Read parent `SKILL.md` first. Substitute the
+> `<SLOT>` placeholders before dispatching. If `<SESSION_LOG_PATH>`
+> is unresolvable, delete the entire "Historical context" section
+> rather than leaving a broken reference.
+>
+> **Do NOT embed triple-backtick fences in this template.** Nested
+> fences break the outer fence when the brief is stored inside a
+> markdown file. Everything that looks like code is prose or
+> indented text.
+
+## Slots
+
+| Slot                 | Description                                                                                   |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `<TASK>`             | User's task description, lightly edited for clarity (never paraphrase destructively)          |
+| `<WORKTREE_PATH>`    | Absolute path to the worktree created in Phase 2                                              |
+| `<SESSION_LOG_PATH>` | Absolute path to parent session jsonl, or empty string to omit the historical-context section |
+| `<TARGET_REPO_SLUG>` | `owner/repo` parsed from `git -C <T> remote get-url origin`                                   |
+
+## Template body — substitute slots and pass as the Agent prompt
+
+---
+
+You are a subagent dispatched to do cross-repo work in an isolated
+context. The originating Claude session cannot see your work — you
+own the full lifecycle through PR creation.
+
+# Task
+
+<TASK>
+
+# Working directory
+
+Your FIRST action is: cd <WORKTREE_PATH>
+
+Do not work anywhere else. Do not cd elsewhere. Everything below
+assumes you are inside that worktree.
+
+# Target repo conventions
+
+Read the following files in order (skip any that don't exist). Do NOT
+read them into context greedily — read only enough to understand the
+conventions, then stop.
+
+- CLAUDE.md (root first, then any nested — find them with
+  `find . -name CLAUDE.md -not -path './.worktrees/*'`)
+- AGENTS.md
+- justfile, Makefile, package.json (scripts section only — use
+  `jq .scripts package.json` to avoid reading the whole file)
+- .github/workflows/\*.yml (names only — so you know what CI will run)
+- .pre-commit-config.yaml if present. Pre-commit hooks may reformat
+  your staged files. If a commit fails with "files were modified by
+  this hook", re-stage and re-commit. Do not fight the formatter and
+  do not pass --no-verify.
+
+Then enumerate (list contents only, do not read every SKILL.md):
+
+- `ls -1 skills/` (may not exist; that's fine)
+- `ls -1 .claude/skills/` (may not exist; that's fine)
+
+Only open a specific SKILL.md if the task directly matches its name.
+
+# Git workflow — detect fork vs direct push
+
+Run these checks in order:
+
+1. Shortcut: if `~/.claude/skills/up-to-date/diagnose.py` exists,
+   run `~/.claude/skills/up-to-date/diagnose.py --pretty` and pipe
+   to `jq .remotes`. It classifies URL-based fork workflows (Case A
+   and simple Case B below). Do NOT trust `is_fork_workflow: false`
+   blindly — the script cannot distinguish Case B from Case C because
+   it has no concept of `gh auth status` or
+   `gh repo view --json parent`.
+
+2. Run `gh auth status` and note the active account name.
+
+3. Run `git remote -v` and list all remotes.
+
+4. For the single-remote case, check whether `origin` is itself a
+   fork. Parse the owner/repo from origin URL, then run:
+
+   gh repo view <owner>/<repo> --json isFork,parent -q '{isFork, parent: (.parent.owner.login + "/" + .parent.name)}'
+
+5. Classify using the decision tree:
+
+   Branch 1 — Two remotes (origin + upstream):
+   - upstream canonical, origin fork? CASE A (two-remote fork workflow).
+     Push to origin, open PR with `gh pr create --repo <canonical>`
+     where <canonical> is the upstream owner/repo.
+   - Remotes swapped (origin canonical, upstream fork)? STOP.
+     Report the mixup and ask the user — do not guess.
+
+   Branch 2 — One remote (origin only):
+   - origin is NOT a fork AND origin's owner matches auth account?
+     CASE B (direct-push workflow). Push to origin, open PR with
+     plain `gh pr create` (no `--repo` flag).
+   - origin IS a fork AND its owner matches auth account?
+     CASE C (chop-conventions pattern). Push to origin, open PR with
+     `gh pr create --repo <parent-owner>/<parent-repo>` where
+     parent comes from the `gh repo view --json parent` result.
+   - origin is NOT a fork AND its owner does NOT match auth account?
+     CASE D (canonical-only, no fork wired up). Search for any
+     other remote whose URL owner segment matches the auth account.
+     If found, push to it and PR with
+     `gh pr create --repo <canonical>`. If none found, STOP and
+     fail: "cannot push to a repo this auth account does not own;
+     set up the fork first with
+     `gh repo fork --remote --remote-name=fork`".
+
+# Commit messages
+
+Commit messages must end with a standard trailer. Use:
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+
+unless the target repo's CLAUDE.md specifies a different trailer, in
+which case repo convention wins.
+
+# Lessons reflection (run after PR is open, before writing final message)
+
+After your PR is open, reflect on your own work against these prompts
+(they are the learn-from-session skill's reflection prompts — if
+~/.claude/skills/learn-from-session/SKILL.md is symlinked on the
+machine, read it for the full filter rules and voice guidance):
+
+1. What environmental constraint in this target repo surprised you?
+   (path quirk, tool alias, hook reformat, missing dep, protected branch)
+2. What safety gotcha almost shipped? (wrong remote, missing .gitignore
+   entry, commit to main, destructive default)
+3. What was the RIGHT place for content you initially put somewhere
+   wrong?
+4. What pattern worked well enough to codify?
+5. What tool invocation ate time before you landed on the right one?
+
+Apply the durability filter: keep only lessons that are DURABLE (true
+in future sessions, not specific to this task), NON-OBVIOUS (not
+already in the target's CLAUDE.md or default Claude Code system
+prompt), and ACTIONABLE (tells a future Claude what to do — not a
+retrospective story). Discard narrative ("we discovered..."), vague
+generalities, and one-off fix postmortems.
+
+If any lessons survive the filter, draft them as a Lessons: block in
+your final message (see Final output contract). If nothing survives,
+omit the block entirely. WHEN IN DOUBT, OMIT. Narrative noise in
+CLAUDE.md is worse than a lost lesson.
+
+Do NOT commit any CLAUDE.md edits derived from this reflection to
+the work PR. The drafted lesson is material for the user to approve,
+not a committed change.
+
+# Final output contract
+
+Your final message MUST contain, in this order:
+
+1. PR URL on its own line, prefixed with "PR: "
+2. 3-5 bullet summary of what changed and why, prefixed with "Summary:"
+3. Optional Lessons block if your reflection surfaced durable insights.
+   Omit if nothing surfaced.
+4. Nothing else. No preamble, no "I'll now...", no sign-off.
+
+Lessons block format (when present): start with the literal line
+"Lessons:" on its own. For each lesson, write — as plain text, not a
+fenced code block — three fields on their own lines:
+
+file: <absolute path to the target repo's CLAUDE.md that should
+receive the addition>
+why: <one-line justification citing the cost or risk this work hit>
+diff: <the lines to insert, each prefixed with "+ ", in
+durable-rule voice — no "we discovered", no narrative, <=5 lines
+per lesson, bullets preferred>
+
+Multiple lessons are written as multiple file/why/diff groups
+separated by a blank line.
+
+# Hard prohibitions
+
+- No `git push --force` on any branch
+- No `--no-verify` on commits (hooks exist for a reason)
+- No commits directly to the default branch
+- No `rm -rf` or destructive ops without explicit confirmation
+- No `gh pr merge` — opening the PR is the terminal action
+- No committing CLAUDE.md edits derived from Lessons reflection to
+  the work PR
+
+# Historical context (escape hatch)
+
+If — and only if — you get genuinely stuck and need to understand WHY
+this task was requested, the originating conversation is at:
+
+<SESSION_LOG_PATH>
+
+It is a large JSONL file. Use `grep` or `jq` to find specific turns.
+Do NOT read the whole file. Prefer ending with a clarifying question
+in your final message over spelunking the log.
+
+---
+
+## End of template
+
+After substituting slots, pass the body above (from "You are a
+subagent..." through "...over spelunking the log.") as the `prompt`
+parameter to the Agent tool. If `<SESSION_LOG_PATH>` is empty or
+unresolvable, delete the entire "Historical context" section before
+dispatching.

--- a/skills/delegate-to-other-repo/brief-template.md
+++ b/skills/delegate-to-other-repo/brief-template.md
@@ -82,7 +82,11 @@ Run these checks in order:
 4. For the single-remote case, check whether `origin` is itself a
    fork. Parse the owner/repo from origin URL, then run:
 
-   gh repo view <owner>/<repo> --json isFork,parent -q '{isFork, parent: (.parent.owner.login + "/" + .parent.name)}'
+   gh repo view <owner>/<repo> --json isFork,parent -q '{isFork, parent: (if .parent then (.parent.owner.login + "/" + .parent.name) else null end)}'
+
+   Note: the `if .parent then ... else null end` guard is required —
+   a plain `.parent.owner.login` errors on non-forks where `.parent`
+   is null (jq "Cannot index null with string").
 
 5. Classify using the decision tree:
 

--- a/skills/delegate-to-other-repo/fork-detection.md
+++ b/skills/delegate-to-other-repo/fork-detection.md
@@ -1,0 +1,165 @@
+# Fork Detection (loaded on demand)
+
+> Reference for the 4-case decision tree the subagent uses in Phase
+> 3's brief. Read parent `SKILL.md` first. This file exists as a
+> spec-reader reference — the _subagent_ receives the tree as prose
+> inside `brief-template.md`.
+
+## Why this needs its own file
+
+The subagent operates in a fresh context with no conversational
+history. Fork detection is the single most mistake-prone step of
+cross-repo work:
+
+- **Case C (fork-as-origin)** is the real-world pattern for
+  chop-conventions itself. Misclassifying it as "direct push" silently
+  lands PRs on the user's own fork rather than the canonical repo.
+- **`up-to-date/diagnose.py` cannot detect Case C.** It classifies
+  purely by URL owner against a hardcoded `FORK_ORGS` list and has no
+  concept of `gh auth status` or `gh repo view --json parent`.
+
+So the brief spells out the full tree explicitly, and this file
+documents it with a diagram for humans reviewing the skill.
+
+## The 4 cases
+
+### Case A: Two-remote fork workflow
+
+**Shape:** both `origin` and `upstream` remotes exist.
+**Test:** `upstream` URL is canonical, `origin` URL is a fork.
+**Action:** push branch to `origin`, open PR with
+`gh pr create --repo <canonical-owner>/<repo>`.
+
+If the remotes are swapped (origin canonical, upstream fork), STOP
+and report — do not guess which direction the user intended.
+
+### Case B: Direct-push workflow (single canonical origin)
+
+**Shape:** only `origin` exists.
+**Test:** `gh repo view <owner/repo> --json isFork` returns `false`,
+AND the `owner` segment of `origin`'s URL matches the active
+`gh auth status` account.
+**Action:** push branch to `origin`, open PR with plain
+`gh pr create` (no `--repo` flag).
+
+### Case C: Fork-as-origin (the chop-conventions pattern)
+
+**Shape:** only `origin` exists, and it IS a fork.
+**Test:** `gh repo view <owner/repo> --json isFork` returns `true`,
+AND the `owner` of `origin` matches the active auth account.
+**Action:** push branch to `origin`, open PR with
+`gh pr create --repo <parent-owner>/<parent-repo>` where `parent`
+comes from `gh repo view <owner/repo> --json parent`.
+
+**Real example:** chop-conventions' `origin` is
+`idvorkin-ai-tools/chop-conventions` (a fork, matching the
+`idvorkin-ai-tools` auth account), and PRs go to the parent
+`idvorkin/chop-conventions`. There is NO separate `upstream` remote.
+
+### Case D: Canonical-only origin, no fork wired up
+
+**Shape:** only `origin` exists.
+**Test:** `gh repo view <owner/repo> --json isFork` returns `false`,
+AND `origin`'s owner does NOT match the auth account.
+**Action:** look for any other remote whose URL owner segment matches
+the auth account. If found, push to it and
+`gh pr create --repo <canonical>`. If none found, STOP and fail with:
+
+> "cannot push to a repo this auth account does not own; set up the
+> fork first with `gh repo fork --remote --remote-name=fork`"
+
+Note: "any other remote" is a label imprecision — if only one remote
+exists (the `origin` we just classified), the search trivially returns
+empty and falls to the STOP path. This is correct behavior.
+
+## Decision tree diagram
+
+```
+                       +------------------+
+                       | How many remotes |
+                       |  (origin + other)|
+                       +--------+---------+
+                                |
+              +-----------------+----------------+
+              |                                  |
+          2 remotes                          1 remote
+              |                                  |
+   +----------+----------+            +----------+----------+
+   | upstream = canonical|            | gh repo view origin |
+   | origin   = fork?    |            |   --json isFork,    |
+   +----------+----------+            |       parent        |
+              |                       +----------+----------+
+      +-------+--------+                         |
+     yes              no             +-----------+-----------+
+      |                |             |                       |
+      v                v         isFork=true            isFork=false
+  CASE A:         Remotes are        |                       |
+  TWO-REMOTE      swapped; STOP      v                       v
+  FORK WORKFLOW   and report     +-------+              +---------+
+  push origin     (don't guess)  | owner | == auth?     | owner   | == auth?
+  PR --repo                      +---+---+              +----+----+
+  canonical                          |                       |
+                              +------+-----+          +------+------+
+                              |            |          |             |
+                             yes           no        yes            no
+                              |            |          |             |
+                              v            v          v             v
+                          CASE C:      Look for   CASE B:       CASE D:
+                          FORK-ORIGIN  any other  DIRECT-PUSH   CANONICAL-
+                          push origin  remote     WORKFLOW      ORIGIN, NO
+                          PR --repo    matching   push origin   FORK WIRED
+                          parent       auth org;  PR (no        Look for any
+                          (slug from   if found,  --repo)       remote matching
+                          .parent in   push there,               auth org. If
+                          gh JSON)     PR --repo                 found, push
+                                       <canonical>               there, PR
+                                       Else STOP:                --repo origin.
+                                       "set up                   Else STOP:
+                                       fork first"               same fail msg.
+```
+
+## Interaction with `up-to-date/diagnose.py`
+
+The subagent is told to run `diagnose.py` as a shortcut if it exists:
+
+```
+~/.claude/skills/up-to-date/diagnose.py --pretty | jq .remotes
+```
+
+### What `diagnose.py` covers
+
+- **Case A reliably.** `classify_remotes` detects two-remote fork
+  workflows by URL pattern and sets `is_fork_workflow: true` with
+  `source: "upstream"`.
+- **Simple Case B reliably.** Single canonical origin → `is_fork_workflow: false`.
+
+### What `diagnose.py` MISSES
+
+- **Case C entirely.** The script has no concept of `gh auth status`.
+  It sees a single fork-as-origin and returns `is_fork_workflow: false`
+  with no issues — silently misclassifying as direct-push.
+- **Case D entirely.** Same reason — no auth-vs-owner comparison.
+
+### Rule for the subagent
+
+Treat `diagnose.py`'s `is_fork_workflow: true` as authoritative for
+Case A routing. Treat `is_fork_workflow: false` as "probably Case B,
+but verify" — ALWAYS run the manual `gh repo view --json isFork,parent`
+check before routing to Case B or Case C. Never skip that check on
+the single-remote path.
+
+## Common misclassifications (test these if changing the tree)
+
+1. **chop-conventions itself.** origin =
+   `idvorkin-ai-tools/chop-conventions`, auth = `idvorkin-ai-tools`,
+   PRs to `idvorkin/chop-conventions`. Expected: Case C. A naive
+   classifier routes to Case B.
+2. **Vanilla OSS contribution.** origin =
+   `your-user/project`, upstream = `project-org/project`, auth =
+   `your-user`. Expected: Case A.
+3. **Personal project.** origin = `your-user/notes`, no upstream,
+   auth = `your-user`, origin is NOT a fork. Expected: Case B.
+4. **Drive-by collaborator fork.** origin =
+   `maintainer-org/project`, auth = `your-user`, origin is NOT a
+   fork. Expected: Case D, STOP with "set up fork first" message
+   (because we can't push to `maintainer-org`).

--- a/skills/delegate-to-other-repo/fork-detection.md
+++ b/skills/delegate-to-other-repo/fork-detection.md
@@ -74,7 +74,7 @@ empty and falls to the STOP path. This is correct behavior.
 
 ## Decision tree diagram
 
-```
+```text
                        +------------------+
                        | How many remotes |
                        |  (origin + other)|
@@ -122,7 +122,7 @@ empty and falls to the STOP path. This is correct behavior.
 
 The subagent is told to run `diagnose.py` as a shortcut if it exists:
 
-```
+```bash
 ~/.claude/skills/up-to-date/diagnose.py --pretty | jq .remotes
 ```
 

--- a/skills/delegate-to-other-repo/worktree-recipe.md
+++ b/skills/delegate-to-other-repo/worktree-recipe.md
@@ -39,8 +39,11 @@ default_branch=""
 ref=$(git -C "$T" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) && \
   default_branch="${ref#origin/}"
 if [ -z "$default_branch" ]; then
-  # `gh repo view` takes an OWNER/REPO slug positional, NOT a path, and
-  # there is no top-level `gh -R` flag. Parse the slug from origin URL.
+  # `gh repo view` accepts OWNER/REPO as a positional argument only;
+  # it has no `-R`/`--repo` flag on this subcommand (verified via
+  # `gh repo view --help` — INHERITED FLAGS section shows only
+  # `--help`). `gh repo view` also does not accept a filesystem path,
+  # so we parse the slug from origin URL and pass it positionally.
   origin_url=$(git -C "$T" remote get-url origin 2>/dev/null)
   slug_repo=$(printf '%s\n' "$origin_url" \
     | sed -E 's#(\.git)?$##; s#^.*[/:]([^/:]+/[^/:]+)$#\1#')
@@ -77,9 +80,16 @@ slug=$(printf '%s' "$task_description" \
   | sed -E 's/-+$//')
 [ -z "$slug" ] && slug="task-$(date +%Y%m%d-%H%M%S)"
 
+# Collision check covers BOTH local branches and remote-tracking refs.
+# Checking only refs/heads/ misses the case where the same name exists
+# on the remote — worktree add would succeed locally, but the
+# subagent's eventual push would be rejected as non-fast-forward
+# (force-push is prohibited). We already fetched origin above, so
+# refs/remotes/origin/ is up-to-date.
 i=1
 candidate="$slug"
-while git -C "$T" show-ref --verify --quiet "refs/heads/delegated/$candidate"; do
+while git -C "$T" show-ref --verify --quiet "refs/heads/delegated/$candidate" \
+   || git -C "$T" show-ref --verify --quiet "refs/remotes/origin/delegated/$candidate"; do
   i=$((i + 1))
   if [ "$i" -gt 9 ]; then
     candidate="task-$(date +%Y%m%d-%H%M%S)"
@@ -92,61 +102,49 @@ branch="delegated/$slug"
 path="$T/.worktrees/delegated-$slug"
 
 # -----------------------------------------------------------------------------
-# 5. Ensure .worktrees/ is gitignored.
+# 5. Ensure .worktrees/ is excluded from the parent's git status.
 # -----------------------------------------------------------------------------
-# check-ignore needs to run with the target as cwd — it resolves
-# against the index of the repo containing cwd; `git -C` handles that.
-# Returns 0 if the path WOULD be ignored, 1 if not.
+# Linked worktrees nested inside the parent repo show up in `git status`
+# as untracked (verified empirically: `git worktree add .worktrees/wt1`
+# leaves `?? .worktrees/` in the parent's status output). We need an
+# ignore entry — but we deliberately avoid committing to `.gitignore`.
+#
+# Why not commit .gitignore on the default branch?
+#   - The delegated branch is created from `origin/$default_branch`
+#     (a clean remote ref) so a local-only commit on the default
+#     branch wouldn't be in the delegated branch's base anyway.
+#   - Committing on the target's *current* branch would pollute
+#     whatever branch happens to be checked out — silently disappearing
+#     on next checkout.
+#   - Switching the target's current branch is destructive and
+#     requires the user's local state to be clean, which we don't
+#     enforce.
+#   - Branch-protected default branches block direct commits.
+#
+# Instead: use `.git/info/exclude`, the local-only, untracked,
+# branch-independent, per-repo exclude list documented in gitignore(5).
+# It sits in the shared git dir, applies to all worktrees, survives
+# branch switches, and never touches any branch's history.
+git_common=$(git -C "$T" rev-parse --git-common-dir 2>/dev/null)
+exclude_file="$git_common/info/exclude"
+if ! grep -qxF '.worktrees/' "$exclude_file" 2>/dev/null; then
+  mkdir -p "$git_common/info"
+  printf '\n# Added by delegate-to-other-repo skill\n.worktrees/\n' >> "$exclude_file"
+fi
+
+# Sanity check — `.worktrees/` must now be ignored. `check-ignore`
+# respects `.git/info/exclude` as well as `.gitignore`.
 if ! git -C "$T" check-ignore -q .worktrees; then
-  # The ignore entry MUST land on the default branch. Otherwise it
-  # lives on a feature branch and disappears the moment the target
-  # checks out anything else. Refuse on a non-default branch — this
-  # also catches detached HEAD, where `git branch --show-current`
-  # prints empty.
-  current=$(git -C "$T" branch --show-current)
-  if [ "$current" != "$default_branch" ]; then
-    echo "STOP: target HEAD is '${current:-<detached>}', not '$default_branch'."
-    echo "The .worktrees/ gitignore entry must land on the default branch."
-    echo "Ask the user to either (a) check out $default_branch in $T and"
-    echo "retry, or (b) land the ignore via their normal PR flow first."
-    exit 1
-  fi
-
-  # On the default branch. If it is branch-protected (PR-only, required
-  # reviews, required status checks), we still cannot commit-and-push
-  # directly. Run the protection probe BEFORE mutating the working tree.
-  #
-  # `gh api` returns 0 even on 404 ({"message":"Not Found",...}), so
-  # check the JSON shape rather than the exit code. False negatives
-  # (auth account lacks admin read → 404 → silent no-op) are accepted:
-  # the worst case is the local commit succeeds and the worktree
-  # branch's eventual push is unaffected.
-  origin_url=$(git -C "$T" remote get-url origin)
-  slug_repo=$(printf '%s\n' "$origin_url" \
-    | sed -E 's#(\.git)?$##; s#^.*[/:]([^/:]+/[^/:]+)$#\1#')
-  protection_json=$(gh api "repos/$slug_repo/branches/$default_branch/protection" 2>/dev/null || true)
-  if printf '%s' "$protection_json" | grep -q '"required_pull_request_reviews"\|"required_status_checks"'; then
-    echo "STOP: $slug_repo's $default_branch is branch-protected. The"
-    echo ".worktrees/ gitignore entry needs to land via the target repo's"
-    echo "normal PR flow first; this skill will not bypass branch protection."
-    exit 1
-  fi
-
-  echo ".worktrees/" >> "$T/.gitignore"
-  git -C "$T" add .gitignore
-  git -C "$T" commit -m "chore: gitignore .worktrees/"
-  # Note: this commit is local-only on the default branch. Whether to
-  # push it is the target's workflow concern, not this skill's. The
-  # subagent's PR branch will contain it as part of its base.
+  echo "STOP: failed to exclude .worktrees/ via $exclude_file."
+  echo "This should be impossible; investigate manually."
+  exit 1
 fi
 
 # -----------------------------------------------------------------------------
 # 6. Create the worktree.
 # -----------------------------------------------------------------------------
 # `worktree add` is the only step that mutates the working set. If it
-# fails (path collision, ref missing), STOP and report — do NOT clean
-# up the gitignore commit above, because that commit is independently
-# valuable and will be reused on retry.
+# fails (path collision, ref missing), STOP and report.
 git -C "$T" worktree add "$path" -b "$branch" "origin/$default_branch"
 
 echo "Worktree ready: $path"

--- a/skills/delegate-to-other-repo/worktree-recipe.md
+++ b/skills/delegate-to-other-repo/worktree-recipe.md
@@ -1,0 +1,181 @@
+# Worktree Recipe (loaded on demand)
+
+> Phase 2 shell recipe for `delegate-to-other-repo`. Read the parent
+> `SKILL.md` first. Follow this recipe verbatim — the ordering of
+> `set-head`, the step-by-step default-branch resolution, and the
+> gitignore-commit branch guard are all load-bearing.
+
+## Inputs
+
+Set these variables before running the recipe:
+
+```bash
+T=<absolute path to target repo>
+task_description=<user's task description, raw>
+```
+
+## Recipe
+
+```bash
+# -----------------------------------------------------------------------------
+# 1. Fetch origin and refresh cached origin/HEAD.
+# -----------------------------------------------------------------------------
+# Plain `git fetch origin` does NOT update refs/remotes/origin/HEAD.
+# That ref is set at clone time and only refreshed by an explicit
+# `set-head --auto`. Without this call, a target whose default branch
+# was renamed (e.g. master → main) since it was cloned would yield a
+# stale value below. `--auto` is a no-op if origin/HEAD already matches.
+git -C "$T" fetch origin
+git -C "$T" remote set-head origin --auto >/dev/null 2>&1 || true
+
+# -----------------------------------------------------------------------------
+# 2. Determine default branch.
+# -----------------------------------------------------------------------------
+# Step-by-step rather than a single `||`-chain because piping through
+# `sed` swallows the upstream exit code: a chained `|| echo main` never
+# fires when symbolic-ref fails, because the empty pipe output wins
+# (verified: T=/tmp/nonexistent ... echo main returned '').
+default_branch=""
+ref=$(git -C "$T" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) && \
+  default_branch="${ref#origin/}"
+if [ -z "$default_branch" ]; then
+  # `gh repo view` takes an OWNER/REPO slug positional, NOT a path, and
+  # there is no top-level `gh -R` flag. Parse the slug from origin URL.
+  origin_url=$(git -C "$T" remote get-url origin 2>/dev/null)
+  slug_repo=$(printf '%s\n' "$origin_url" \
+    | sed -E 's#(\.git)?$##; s#^.*[/:]([^/:]+/[^/:]+)$#\1#')
+  default_branch=$(gh repo view "$slug_repo" --json defaultBranchRef \
+    -q .defaultBranchRef.name 2>/dev/null)
+fi
+default_branch="${default_branch:-main}"
+
+# -----------------------------------------------------------------------------
+# 3. Verify origin/<default> is reachable.
+# -----------------------------------------------------------------------------
+if ! git -C "$T" rev-parse --verify "origin/$default_branch" >/dev/null 2>&1; then
+  echo "STOP: origin/$default_branch is not reachable in $T after fetch."
+  exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# 4. Derive slug from task description.
+# -----------------------------------------------------------------------------
+# Reproducible rule:
+#   1. Lowercase
+#   2. Replace every char outside [a-z0-9] with `-`
+#   3. Collapse repeated `-`, strip leading/trailing `-`
+#   4. Truncate to 40 chars; re-strip trailing `-`
+#   5. If the result is empty (non-ASCII, pure punctuation, empty
+#      input), fall back to "task-$(date +%Y%m%d-%H%M%S)"
+#   6. If a branch named `delegated/<slug>` already exists in $T,
+#      append `-2`, `-3`, ... `-9`; beyond that, fall back to the
+#      timestamp form.
+slug=$(printf '%s' "$task_description" \
+  | tr '[:upper:]' '[:lower:]' \
+  | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//' \
+  | cut -c1-40 \
+  | sed -E 's/-+$//')
+[ -z "$slug" ] && slug="task-$(date +%Y%m%d-%H%M%S)"
+
+i=1
+candidate="$slug"
+while git -C "$T" show-ref --verify --quiet "refs/heads/delegated/$candidate"; do
+  i=$((i + 1))
+  if [ "$i" -gt 9 ]; then
+    candidate="task-$(date +%Y%m%d-%H%M%S)"
+    break
+  fi
+  candidate="$slug-$i"
+done
+slug="$candidate"
+branch="delegated/$slug"
+path="$T/.worktrees/delegated-$slug"
+
+# -----------------------------------------------------------------------------
+# 5. Ensure .worktrees/ is gitignored.
+# -----------------------------------------------------------------------------
+# check-ignore needs to run with the target as cwd — it resolves
+# against the index of the repo containing cwd; `git -C` handles that.
+# Returns 0 if the path WOULD be ignored, 1 if not.
+if ! git -C "$T" check-ignore -q .worktrees; then
+  # The ignore entry MUST land on the default branch. Otherwise it
+  # lives on a feature branch and disappears the moment the target
+  # checks out anything else. Refuse on a non-default branch — this
+  # also catches detached HEAD, where `git branch --show-current`
+  # prints empty.
+  current=$(git -C "$T" branch --show-current)
+  if [ "$current" != "$default_branch" ]; then
+    echo "STOP: target HEAD is '${current:-<detached>}', not '$default_branch'."
+    echo "The .worktrees/ gitignore entry must land on the default branch."
+    echo "Ask the user to either (a) check out $default_branch in $T and"
+    echo "retry, or (b) land the ignore via their normal PR flow first."
+    exit 1
+  fi
+
+  # On the default branch. If it is branch-protected (PR-only, required
+  # reviews, required status checks), we still cannot commit-and-push
+  # directly. Run the protection probe BEFORE mutating the working tree.
+  #
+  # `gh api` returns 0 even on 404 ({"message":"Not Found",...}), so
+  # check the JSON shape rather than the exit code. False negatives
+  # (auth account lacks admin read → 404 → silent no-op) are accepted:
+  # the worst case is the local commit succeeds and the worktree
+  # branch's eventual push is unaffected.
+  origin_url=$(git -C "$T" remote get-url origin)
+  slug_repo=$(printf '%s\n' "$origin_url" \
+    | sed -E 's#(\.git)?$##; s#^.*[/:]([^/:]+/[^/:]+)$#\1#')
+  protection_json=$(gh api "repos/$slug_repo/branches/$default_branch/protection" 2>/dev/null || true)
+  if printf '%s' "$protection_json" | grep -q '"required_pull_request_reviews"\|"required_status_checks"'; then
+    echo "STOP: $slug_repo's $default_branch is branch-protected. The"
+    echo ".worktrees/ gitignore entry needs to land via the target repo's"
+    echo "normal PR flow first; this skill will not bypass branch protection."
+    exit 1
+  fi
+
+  echo ".worktrees/" >> "$T/.gitignore"
+  git -C "$T" add .gitignore
+  git -C "$T" commit -m "chore: gitignore .worktrees/"
+  # Note: this commit is local-only on the default branch. Whether to
+  # push it is the target's workflow concern, not this skill's. The
+  # subagent's PR branch will contain it as part of its base.
+fi
+
+# -----------------------------------------------------------------------------
+# 6. Create the worktree.
+# -----------------------------------------------------------------------------
+# `worktree add` is the only step that mutates the working set. If it
+# fails (path collision, ref missing), STOP and report — do NOT clean
+# up the gitignore commit above, because that commit is independently
+# valuable and will be reused on retry.
+git -C "$T" worktree add "$path" -b "$branch" "origin/$default_branch"
+
+echo "Worktree ready: $path"
+echo "Branch:         $branch"
+echo "Base:           origin/$default_branch"
+```
+
+## Why this skill does NOT call `superpowers:using-git-worktrees`
+
+That skill:
+
+- Branches off current HEAD — no way to pass a base ref like
+  `origin/<default>`
+- Auto-runs `npm install` / `cargo build` / `pip install` — noisy
+  and wrong for doc-only or tiny changes
+- Runs the target's test suite as a baseline — slow, and unnecessary
+  before the subagent has done anything
+
+Those are good defaults for same-repo feature work but wrong defaults
+for cross-repo delegation off a fresh `origin/<default>`. This recipe
+is the explicit alternative.
+
+## Output
+
+On success:
+
+- Worktree at `$T/.worktrees/delegated-<slug>` checked out to
+  `delegated/<slug>` branch, based on `origin/<default-branch>`
+- (Maybe) one new commit on the target's default branch adding
+  `.worktrees/` to `.gitignore`
+
+Pass `$path` and `$branch` forward to Phase 3 (brief construction).


### PR DESCRIPTION
## Summary

- New skill that delegates cross-repo work to a subagent with an isolated context — parent Claude sets up an isolated worktree in the target repo off `origin/<default-branch>` (using `git -C`, never `cd`), constructs a self-contained brief, dispatches a subagent, and relays the PR URL + summary back to the user.
- Parent never sees the target repo's `CLAUDE.md`, file reads, or diff — full context isolation. The subagent reads target conventions, detects fork-vs-direct workflow (4-case decision tree), opens a PR, optionally reflects on durable lessons, and returns a structured final message.
- Composes with existing skills: reuses `up-to-date/diagnose.py` for URL-based fork classification (Cases A and simple B), and hands subagent-drafted lessons back to the user for approval via `learn-from-session`'s normal flow — never auto-committed.

## What's in the PR

**Spec (hardened via 4-pass architect review, converged 14/13/8/0 changes):**
- `docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md`
- `docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design-changelog.md` (full pass-by-pass diff record)

**Skill:**
- `skills/delegate-to-other-repo/SKILL.md` (387 lines) — 5-phase workflow, failure handling, common mistakes, red flags
- `skills/delegate-to-other-repo/worktree-recipe.md` — Phase 2 shell recipe with `git -C` discipline, default-branch fallback chain, slug derivation, branch-protection probe, detached-HEAD guard
- `skills/delegate-to-other-repo/brief-template.md` — self-contained subagent brief with slot substitution points; plain-text formatting throughout (no nested fences)
- `skills/delegate-to-other-repo/fork-detection.md` — 4-case decision tree with ASCII diagram + `diagnose.py` interaction rules

**Other:**
- `.gitignore` — `.worktrees/` added for project-local worktrees
- `README.md` — skills table updated

## Why this is useful

Today, cross-repo asks like "also fix the typo in the blog while you're at it" force Claude into bad options: either abandon current context and `cd` away (polluting conversation), or tell the user to switch sessions (jarring, loses thread). This skill gives a third option — dispatch a subagent, keep working, relay the result.

## Correctness guarantees

Four architect passes (Opus agents on the spec) caught and fixed:
- Backward Case C taxonomy that would have misclassified chop-conventions' own canonical pattern
- Non-existent `gh -R` flag usage
- Pipe-precedence bug in default-branch fallback chain (`cmd_a || cmd_b | sed | sed || echo main` silently emits empty string on failure)
- Missing `git remote set-head origin --auto` refresh for stale `origin/HEAD` after fetch
- Unexecuted branch-protection probe (described but never run)
- Hardcoded `origin/main` breaking on `master`/`trunk` repos
- Gitignore-commit-on-wrong-branch bug silently disappearing on next checkout
- Detached-HEAD edge case in the gitignore safety check
- Parent `cd`-ing into target polluting post-dispatch shell state
- Nested code-fence breaking the outer `markdown` fence when the brief is embedded in `SKILL.md`

All fixes landed in the spec and are reflected in the skill implementation.

## Testing

**What was tested:**
- Pass 4 of the architect review verified the shell recipes copy-paste correct against real shell runs (URL parsing for 4 URL forms, slug pipeline on English/Japanese/punctuation/>40-char inputs, `symbolic-ref` failure path, `grep` alternation on protection JSON, collision loop math)
- 4-case decision tree walked mentally against (a) vanilla two-remote workflow, (b) direct-push workflow, (c) chop-conventions' real fork-as-origin pattern, (d) drive-by collaborator clone

**What was NOT tested:**
- End-to-end RED-GREEN baseline testing with real subagents per `superpowers:writing-skills` — deviation acknowledged in the session, rationale: architect review covers procedural correctness and this is a technique skill, not discipline-enforcing. Smoke-test-with-subagent can be a follow-up.

## Test plan

- [ ] Review the spec (`docs/superpowers/specs/2026-04-12-delegate-to-other-repo-design.md`) for design coherence
- [ ] Review `SKILL.md` against the spec — does it correctly reflect the hardened design?
- [ ] Review `worktree-recipe.md` for shell correctness, especially the `set-head --auto` ordering and the pipe-precedence-safe default-branch resolution
- [ ] Review `brief-template.md` — plain-text formatting holds; `<TASK>`, `<WORKTREE_PATH>`, `<SESSION_LOG_PATH>`, `<TARGET_REPO_SLUG>` slots are the only substitution points
- [ ] Review `fork-detection.md` — decision tree diagram matches the brief's prose
- [ ] Optional: smoke-test by invoking the skill against a trivial cross-repo task after merge (e.g. "fix a comment typo in the dotfiles repo")
- [ ] After merge: `ln -s /home/developer/gits/chop-conventions/skills/delegate-to-other-repo ~/.claude/skills/delegate-to-other-repo` (symlink deferred to post-merge to avoid pointing into an ephemeral worktree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Introduced the `delegate-to-other-repo` skill for delegating development work across multiple repositories. Includes automatic fork detection, isolated branch management, target repository convention reading, and streamlined pull request creation and handling workflows.

## Documentation
* Added comprehensive design specifications, detailed implementation guides, complete workflow documentation, safety protocols, fork detection decision trees, failure handling procedures, and best practice recommendations for cross-repository work delegation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->