### PR TITLE
dev-setup: color statusline ctx by absolute token thresholds

### DIFF
--- a/dev-setup/claude-code-statusline.md
+++ b/dev-setup/claude-code-statusline.md
@@ -12,14 +12,14 @@ Claude Code's `statusLine` setting accepts an inline command, but inline JSON-qu
 user@host ~/path/to/repo [branch] | Opus 4.6 ctx:12% 125k/1000k $0.42
 ```
 
-| Segment            | Source                                                       | Color                              |
-| ------------------ | ------------------------------------------------------------ | ---------------------------------- |
-| `user@host`        | `whoami` / `hostname -s`                                     | default                            |
-| `~/path`           | `cwd` (or `workspace.current_dir`), home shortened           | yellow                             |
-| `[branch]`         | `git symbolic-ref --short HEAD` (skipped if not a repo)      | yellow                             |
-| `Opus 4.6`         | `model.display_name`                                         | default                            |
-| `ctx:NN% Xk/Yk`    | `context_window.{used_percentage, context_window_size}`      | green <20%, blue <50%, red ≥50%    |
-| `$X.XX`            | `cost.total_cost_usd`                                        | default                            |
+| Segment         | Source                                                  | Color                                            |
+| --------------- | ------------------------------------------------------- | ------------------------------------------------ |
+| `user@host`     | `whoami` / `hostname -s`                                | default                                          |
+| `~/path`        | `cwd` (or `workspace.current_dir`), home shortened      | yellow                                           |
+| `[branch]`      | `git symbolic-ref --short HEAD` (skipped if not a repo) | yellow                                           |
+| `Opus 4.6`      | `model.display_name`                                    | default                                          |
+| `ctx:NN% Xk/Yk` | `context_window.{used_percentage, context_window_size}` | green <200k, yellow <400k, pink <600k, red ≥600k |
+| `$X.XX`         | `cost.total_cost_usd`                                   | default                                          |
 
 The token bucket (`Xk`) snaps to the nearest 10k so the number doesn't jitter on every tick. The total (`Yk`) comes from `context_window.context_window_size` directly — no model-string heuristics, so Sonnet (200k) and Opus `[1m]` render correctly without code changes.
 
@@ -60,23 +60,26 @@ echo '{
 }' | sh dev-setup/statusline-command.sh
 ```
 
-Vary `used_percentage` across `5`, `30`, `75` to see all three color tiers.
+Vary `used_percentage` across `15`, `25`, `45`, `65` (on a 1M context window) to see all four color tiers.
 
 ## Customizing the Color Tiers
 
-The thresholds live near the bottom of the script:
+The thresholds live near the bottom of the script and are expressed in **absolute used tokens**, not percentages — so a 400k cutoff means "400k tokens" regardless of whether the model has a 200k or 1M window:
 
 ```sh
-if [ "$pct" -lt 20 ]; then
+used_tokens=$(awk "BEGIN {printf \"%d\", $used * $ctx_size / 100}")
+if [ "$used_tokens" -lt 200000 ]; then
   ctx_color=$GREEN
-elif [ "$pct" -lt 50 ]; then
-  ctx_color=$BLUE
+elif [ "$used_tokens" -lt 400000 ]; then
+  ctx_color=$YELLOW
+elif [ "$used_tokens" -lt 600000 ]; then
+  ctx_color=$PINK
 else
   ctx_color=$RED
 fi
 ```
 
-Adjust the `20` / `50` boundaries to taste. The defaults are tuned so you notice the color change well before `/compact` becomes necessary.
+Adjust the `200000` / `400000` / `600000` boundaries to taste. Absolute thresholds are tuned for the 1M Opus window — on a 200k-context model (Sonnet/Haiku) you'll sit at yellow almost immediately, which is intentional: 200k is actually tight. Switch to percentage-based tiers if you spend most of your time on narrower-context models.
 
 ## Available Fields (Reference)
 

--- a/dev-setup/statusline-command.sh
+++ b/dev-setup/statusline-command.sh
@@ -18,6 +18,7 @@ YELLOW=$(printf '\033[33m')
 GREEN=$(printf '\033[32m')
 BLUE=$(printf '\033[34m')
 RED=$(printf '\033[31m')
+PINK=$(printf '\033[38;5;213m')
 RESET=$(printf '\033[0m')
 
 # Shorten home directory to ~
@@ -35,13 +36,14 @@ if [ -n "$used" ] && [ -n "$ctx_size" ]; then
   total_k=$((ctx_size / 1000))
   # Bucket used tokens to nearest 10k (round half up)
   used_k=$(awk "BEGIN {printf \"%d\", int(($used * $total_k / 100 + 5) / 10) * 10}")
-  # Color: green <20%, blue <50%, red >=50%
-  # Floor of raw used (not the rounded pct) so 19.6% stays green, not blue
-  used_int=$(awk "BEGIN {printf \"%d\", int($used)}")
-  if [ "$used_int" -lt 20 ]; then
+  # Color by absolute used tokens: <200k green, <400k yellow, <600k pink, else red
+  used_tokens=$(awk "BEGIN {printf \"%d\", $used * $ctx_size / 100}")
+  if [ "$used_tokens" -lt 200000 ]; then
     ctx_color=$GREEN
-  elif [ "$used_int" -lt 50 ]; then
-    ctx_color=$BLUE
+  elif [ "$used_tokens" -lt 400000 ]; then
+    ctx_color=$YELLOW
+  elif [ "$used_tokens" -lt 600000 ]; then
+    ctx_color=$PINK
   else
     ctx_color=$RED
   fi


### PR DESCRIPTION
## Summary

- Swap the statusline `ctx:` color logic from percentage-based (green <20% / blue <50% / red ≥50%) to **absolute token thresholds**: green <200k, yellow <400k, pink <600k, red ≥600k.
- Add a hot-pink 256-color (`\033[38;5;213m`) so the middle band is visually distinct from red — bright magenta was too close.
- Update `dev-setup/claude-code-statusline.md` (color-table row, Customizing section, testing values) to match.

## Why

On a 1M-context Opus session the old percentage bands clustered everything near the bottom: you'd sit at green until 200k, then blue until 500k, then red. Absolute thresholds give four evenly-spaced bands across the 1M window, so the color crosses a boundary at every 200k of growth.

On a 200k Sonnet/Haiku window you'll hit yellow almost immediately — intentional, since 200k is actually tight. Users who live on narrow-context models can swap to percentage tiers per the Customizing section.

## Test plan

- [x] Dry-run script at 15% / 25% / 45% / 65% on a 1M window — confirmed green / yellow / pink / red ANSI codes in output.
- [x] Dry-run at 20% (boundary) → yellow. Dry-run at 60% (boundary) → red. Strict `-lt` semantics as documented.
- [x] Prettier + ruff + fast-tests pre-commit hooks pass.
- [ ] Visual check in a real terminal after `cp dev-setup/statusline-command.sh ~/.claude/statusline-command.sh` — reviewer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated status line context-usage color thresholds from percentage-based to absolute token boundaries.
  * New color tier definitions: green <200k tokens, yellow <400k, pink <600k, red ≥600k.
  * Enhanced customization guidance with updated configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->