### PR TITLE
claude-md: git inner-loop tips + pure-markdown skill default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,11 @@ git push -u origin <branch>
 gh pr create --repo idvorkin/chop-conventions
 ```
 
+## Git Inner-Loop
+
+- **`.git/info/exclude` for local-only ignores.** Ephemeral or per-machine ignore entries (worktree dirs, caches, editor state) that must NOT touch branch history go in `.git/info/exclude`, not `.gitignore`. Untracked, branch-independent, shared across linked worktrees via `git rev-parse --git-common-dir`. `git check-ignore` respects it the same as `.gitignore`.
+- **`git fetch origin` does NOT refresh `refs/remotes/origin/HEAD`.** Run `git remote set-head origin --auto` before reading `git symbolic-ref --short refs/remotes/origin/HEAD` or you'll get stale values when the default branch was renamed (e.g. master → main) since clone. Idempotent no-op if origin/HEAD already matches.
+
 ## Process-Signaling Safety
 
 Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) MUST exclude lifeline processes or risk wedging the VM / locking out the SSH session: `tailscaled`, `etserver`, **`etterminal`**, `tmux` (bare + `"tmux:"*`), `sshd`, init-like (`sh`, `init`, `systemd`), and kernel threads (`kthreadd`, `kworker*`, `ksoftirqd*`, `migration*`, `rcu_*`). Test the exclude list with a unit test before deploying — see `skills/machine-doctor/doctor-guards.md` for an example.
@@ -68,6 +73,7 @@ Skills are Claude Code slash commands that live in `skills/<name>/SKILL.md`.
 
 - Each skill is a directory containing at minimum a `SKILL.md` with YAML frontmatter (`name`, `description`, `allowed-tools`)
 - Skill names must not collide with Claude Code built-in commands (e.g., use `machine-doctor` not `doctor`)
+- **Pure markdown is the default.** Helpers (Python, shell) only earn their place when they (a) parallelize subprocess calls AND (b) need unit-tested classification logic. For "figure out which thing the user means" reasoning, use the markdown prompt. Reference: `up-to-date` earned its `diagnose.py`; `learn-from-session` and most others stay pure markdown.
 - Skills are installed by **symlinking** into Claude Code's skill directories:
   - Machine-level (all projects): `~/.claude/skills/<name>` -> `<chop-conventions>/skills/<name>`
   - Project-level (one project): `<project>/.claude/skills/<name>` -> `<chop-conventions>/skills/<name>`


### PR DESCRIPTION
## Summary

Two lessons from the `/delegate-to-other-repo` session (2026-04-13):

- **`.git/info/exclude`** as the right tool for local-only ignores — eliminates an entire class of "which branch should this ignore entry live on?" complexity.
- **`git fetch origin` does NOT refresh `refs/remotes/origin/HEAD`** — a stale-ref trap when resolving the default branch name programmatically. `git remote set-head origin --auto` is the idempotent fix.
- **Pure markdown is the skill default** — existing Skills convention gets one explicit bullet making the rule unmistakable.

## Why these earn their CLAUDE.md cost

**`.git/info/exclude`:** the delegate-to-other-repo skill originally committed `.worktrees/` to `.gitignore` on the target's default branch. Code review caught that this (a) didn't actually land in the delegated branch base (different merge strategies), (b) required a detached-HEAD guard, (c) required a branch-protection probe, (d) required a must-be-on-default-branch STOP. Switching to `.git/info/exclude` deleted all four of those checks (~40 lines of brittle ceremony) because the exclude is untracked, branch-independent, and per-repo. Future Claude writing similar skills will face the same choice.

**`git fetch` + `origin/HEAD`:** architect review pass 3 caught the stale-ref trap empirically. A repo whose default branch was renamed (master → main) since clone time would yield the old value from `symbolic-ref refs/remotes/origin/HEAD` even after fetch. `set-head --auto` is a one-line fix and idempotent. Any skill that reads the default-branch ref needs to know this.

**Pure markdown default:** user correction in-session: *"use the skill part to figure out the right repo, not the python."* The existing Skills section has conventions (frontmatter, naming, symlink install) but doesn't explicitly say "prefer markdown, not helpers." Making the rule explicit prevents re-derivation.

## What's deliberately NOT added

- **Parent/subagent reflection split** — already codified in `skills/delegate-to-other-repo/SKILL.md` under "Integration with learn-from-session"
- **`gh -R` flag hallucination** — CodeRabbit got this wrong, I pushed back with empirical `gh repo view --help`. The meta-lesson is "verify claims empirically" which is default behavior, not a new rule
- **`||` binds to last pipe segment** + **`gh api` returns 0 on 404** — real gotchas, but niche enough that leaving them in `worktree-recipe.md` comments (where they actually bite) is better than burdening every-turn CLAUDE.md tokens
- **Architect-review pattern** — already codified in the `architect-review` skill

## Test plan

- [ ] CLAUDE.md renders correctly (prettier-clean)
- [ ] New `## Git Inner-Loop` section sits between existing Git Workflow and Process-Signaling Safety
- [ ] New Skills bullet sits in the ### Conventions list between the "name collision" rule and the "symlink install" rule
- [ ] Total addition: 6 lines (2 new bullets + section header + separators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)