### PR TITLE
skills: add harden-telegram + vendor tools + durable-telegram design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,11 @@ Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) M
 
 ## Diagnostics: Code Over Prose
 
-**Diagnostic checks belong in scripts, not in skill/doc prose.** Skills describe WHEN to diagnose and HOW to recover; code describes WHAT to check. Paths move — code errors loudly, prose rots silently. Follow the pattern in `~/gits/igor2/telegram-server/telegram_debug.py`: `--doctor` with `ok`/`warn`/`fail`/`note` accumulators, `--paths` that prints a file-map inventory with exists/missing marks, inline log tails so operators don't have to cat a second file. If you catch yourself writing a "check X at path Y" step in a skill, stop and move it to the doctor.
+**Diagnostic checks belong in scripts, not in skill/doc prose.** Skills describe WHEN to diagnose and HOW to recover; code describes WHAT to check. Paths move — code errors loudly, prose rots silently. Reference implementation: `skills/harden-telegram/tools/telegram_debug.py` (`--doctor` with `ok`/`warn`/`fail`/`note` accumulators, `--paths` file-map inventory, inline log tails). **Vendor the doctor *into* the skill** (`skills/<name>/tools/`), never into a source repo it diagnoses — source-repo coupling kills portability on any machine without that repo checked out. Parameterize runtime/source paths via env vars (e.g. `LARRY_TELEGRAM_DIR`, `TELEGRAM_SOURCE_DIR`), not constants. If you catch yourself writing "check X at path Y" prose in a skill, stop and move it to the doctor.
+
+## Abstractions: Wait for N=2
+
+**Don't generalize a pattern into templates or a framework until you have at least two concrete instances.** One-instance abstractions are copy-paste bait — they fork on day one, rot, and rediscover the same bugs on every downstream consumer. When a single instance is all you've got, write it directly and point at it as a *reference implementation*, not a template to clone. Extract at N=2 minimum.
 
 ## GitHub Actions + Claude Code SDK
 

--- a/skills/durable-telegram/SKILL.md
+++ b/skills/durable-telegram/SKILL.md
@@ -13,7 +13,7 @@ Read this before:
 - Designing a similar durable bridge somewhere else and wondering if the shape fits
 - Debugging a failure that the doctor doesn't recognize (the invariants here tell you what *should* be true)
 
-Full design spec: `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md`.
+Full design spec (on Igor's box): `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md` — the canonical long-form version of this skill's content lives there for historical traceability.
 
 ---
 
@@ -144,7 +144,7 @@ Free-tier reactions **replace** rather than **stack** — a second `setMessageRe
 
 ## Plugin-cache deploy: `cp`, never symlink
 
-bun resolves imports **relative to the real file path**. If you symlink `~/gits/igor2/telegram-server/server.ts` into `~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.5/server.ts`, bun follows the symlink, starts resolving imports from `~/gits/igor2/telegram-server/`, and fails with `Cannot find module '@modelcontextprotocol/sdk'` because the MCP SDK only lives in the plugin cache's `node_modules`.
+bun resolves imports **relative to the real file path**. If you symlink `$TELEGRAM_SOURCE_DIR/server.ts` into `~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.5/server.ts`, bun follows the symlink, starts resolving imports from your source directory, and fails with `Cannot find module '@modelcontextprotocol/sdk'` because the MCP SDK only lives in the plugin cache's `node_modules`.
 
 Always `cp`. Doctor catches source/plugin drift via sha256 compare — if the source and deployed copy diverge, the doctor reports it and harden-telegram walks the redeploy.
 
@@ -173,8 +173,8 @@ Always `cp`. Doctor catches source/plugin drift via sha256 compare — if the so
 ## Related
 
 - [`harden-telegram`](../harden-telegram/SKILL.md) — operator runbook (doctor, reload, recovery)
-- `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md` — full design spec
-- `~/gits/igor2/docs/superpowers/plans/2026-04-12-telegram-two-process-migration.md` — migration plan
+- Igor's canonical design doc: `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md`
+- Igor's migration plan: `~/gits/igor2/docs/superpowers/plans/2026-04-12-telegram-two-process-migration.md`
 
 ## Related beads
 

--- a/skills/durable-telegram/SKILL.md
+++ b/skills/durable-telegram/SKILL.md
@@ -1,0 +1,192 @@
+---
+name: durable-telegram
+description: Design reference for the two-process Telegram MCP architecture — why it's split the way it is, what the SQLite queue guarantees, how the flock singleton and 409 retry work, and what invariants hold across crashes. Read this when designing changes to telegram_bot.py or server.ts, or when answering "why is Telegram built this way?". For break/fix use harden-telegram instead.
+allowed-tools: Read, Glob, Grep
+---
+
+# Durable Telegram — Design Reference
+
+This skill is the **architectural** counterpart to [`harden-telegram`](../harden-telegram/SKILL.md). harden-telegram answers "what do I do when it breaks?"; durable-telegram answers "why is it built this way and what does it guarantee?".
+
+Read this before:
+- Modifying `telegram_bot.py` or `server.ts` in a way that touches the queue, the socket, the singleton, or the reaction protocol
+- Designing a similar durable bridge somewhere else and wondering if the shape fits
+- Debugging a failure that the doctor doesn't recognize (the invariants here tell you what *should* be true)
+
+Full design spec: `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md`.
+
+---
+
+## The problem the split solves
+
+Telegram's Bot API has no message-history endpoint. Once `getUpdates` returns a batch and the poller advances its cursor, those messages are gone. If the poller dies mid-batch — or between batches — anything received in the gap is lost forever.
+
+Old design: one bun process held `getUpdates` *and* served MCP over stdio. When Claude restarted (for any reason — MCP disconnect, crash, user-initiated), the bun process died with it. Every message that arrived during the Claude restart window was dropped on the floor.
+
+New design: separate **who polls Telegram** from **who talks to Claude**.
+
+```
+Telegram API
+    │
+    ▼
+┌────────────────────────────────────────┐
+│  telegram_bot.py  (persistent)         │
+│  • Owns getUpdates forever             │
+│  • Writes every event → inbound.db     │
+│  • Singleton via PID + flock           │
+│  • Survives Claude restarts            │
+└────────┬───────────────┬───────────────┘
+         │ SQLite WAL    │ bot.sock (wakeup)
+         │ (durable)     │ (bare "\n")
+┌────────▼───────────────▼───────────────┐
+│  server.ts  (ephemeral)                │
+│  • Reads undelivered rows              │
+│  • Emits MCP notifications             │
+│  • Dies with the Claude session        │
+│  • Never polls Telegram                │
+└────────────────┬───────────────────────┘
+                 ▼
+             Claude Code
+```
+
+---
+
+## Durability contract
+
+**At-least-once delivery.** If server.ts crashes after sending the MCP notification but before committing `delivered=1`, the row is re-delivered on the next catch-up pass. Claude seeing a duplicate is better than losing a message; `message_id` in the meta lets Claude dedupe if it matters.
+
+### What survives what
+
+| Event | Messages in flight | Recovery |
+|---|---|---|
+| Claude restart / MCP disconnect | Queued in `inbound.db` with `delivered=0` | server.ts catches up on reconnect via `SELECT WHERE delivered=0` |
+| server.ts crash | Same as above | Same |
+| telegram_bot.py crash | **Anything received between last successful write and crash** | Only real gap in the system. Telegram will re-send once the next poll cycle starts, since the cursor isn't advanced until the write commits. |
+| OS crash / power loss | Rows in WAL but not checkpointed | SQLite WAL replays on next open. Writes that hadn't synced are lost — unavoidable without `PRAGMA synchronous=FULL`, which we don't use for throughput reasons. |
+| Plugin cache auto-update overwrites `server.ts` | Queue keeps accumulating. Claude stops seeing new messages until server.ts is redeployed. | Doctor catches this via source/plugin sha256 drift. See harden-telegram Tier 2a. |
+
+The important invariant: **telegram_bot.py advances the Telegram cursor only after the row is written and committed to WAL.** A crash mid-`INSERT` means Telegram re-delivers the same update on the next `getUpdates` call. This is the one place where the "lose a message" window exists, and it's bounded to a single in-flight write.
+
+### Why at-least-once and not exactly-once
+
+Exactly-once would require a distributed-transaction-equivalent protocol between telegram_bot.py's write and Telegram's cursor advance — not possible with the Bot API. At-least-once with client-side dedupe on `message_id` is the industry default for this shape.
+
+---
+
+## Why SQLite WAL + Unix socket
+
+**SQLite WAL mode** is the queue:
+- `PRAGMA journal_mode=WAL` — writer (telegram_bot.py INSERT) doesn't block readers (server.ts SELECT)
+- `PRAGMA busy_timeout=5000` on both connections — lets concurrent writes (telegram_bot.py INSERT, server.ts UPDATE `delivered=1`) resolve without SQLITE_BUSY errors at the Python/TS layer
+- `BEGIN IMMEDIATE` for the INSERT and the UPDATE so lock conflicts surface at `BEGIN` time, not at `COMMIT`
+- Single file on local disk. No broker, no port, no daemon. Survives everything short of OS crash + corrupt FS.
+
+**Why not a real queue (RabbitMQ/NATS/Redis)?** Overkill for one writer + one reader on the same host. A broker adds a whole new process to supervise, fail-over, and patch. SQLite is already there.
+
+**Unix socket (`bot.sock`)** is the wakeup signal, not the data channel:
+- telegram_bot.py writes `\n` (bare newline, one byte) to every connected client after each commit
+- server.ts treats `\n` as "go re-query the DB"; the row content is never on the socket
+- This separates durability (SQLite) from latency (socket push). If the socket dies, server.ts falls back to 2s `setInterval` polling — degraded latency but zero message loss.
+- Why push at all if polling is the fallback? Latency. A tight loop polling every 100ms burns CPU; a 2s poll feels laggy. The push gives sub-100ms delivery in the happy path.
+
+---
+
+## Singleton via `flock` + PID file
+
+telegram_bot.py must be a singleton — two instances calling `getUpdates` on the same bot token is a 409 Conflict loop.
+
+The pattern:
+1. `open(bot.pid, 'w+')` and `fcntl.flock(fd, LOCK_EX | LOCK_NB)`
+2. If the flock fails, another instance owns it; exit cleanly
+3. If it succeeds, write the PID and hold the lock for the process lifetime
+4. `flock` releases automatically on process exit (normal or crash) — no stale-lock cleanup needed
+5. The PID file is advisory; the real guard is `flock`
+
+**Why `flock` and not just a PID file?** A PID file without a lock is racy: process A writes its PID and dies, process B reads the file, sees "alive" from a stale PID, refuses to start, manual intervention needed. `flock` releases at process death regardless of how the process died, so the next start always succeeds.
+
+**Stale `bot.sock` handling:** on startup, telegram_bot.py tries to `connect()` to `bot.sock`; if the connect fails (nobody listening), it `unlink()`s the stale socket file before `bind()`ing its own. This is necessary because a hard crash leaves the socket file on disk.
+
+---
+
+## 409 Conflict retry semantics
+
+The polite-failure case: telegram_bot.py calls `getUpdates`, Telegram responds 409 because another poller is still holding the cursor. Causes:
+1. A stale telegram_bot.py that the flock didn't catch (very rare — only if flock is broken or user disabled it)
+2. A second machine running the same bot token (the user forgot to disable the old box)
+3. During migration — the legacy bun `server.ts` hadn't stopped yet
+
+telegram_bot.py's response: exponential backoff (1, 2, 4, 8, 16, 30, 30, 30, …) and keep retrying forever. No manual intervention needed — Telegram drops the stale poller on its own once the holding cursor times out, typically within 60 seconds.
+
+**Historical gotcha (bgt.3.1):** an earlier version of the retry loop also did `pkill -f 'bun.*server.ts'` on every 409 to clear out the legacy bun poller during migration. Post-migration, that kill was *still* there — and it couldn't distinguish the new MCP-only `server.ts` from the legacy polling one (same process name, same plugin cache cwd). Any transient 409 (or any bot restart) would SIGTERM Claude's live MCP bridge. Removed in commit `317031a`. **Lesson: don't kill by process name when the names are identical across roles.** Kill by `/proc/<pid>/cwd`, a role-specific env var, or just let Telegram's own timeout resolve the conflict.
+
+---
+
+## Dual-reaction liveness protocol
+
+Each delivered message gets two reactions, stamped by two different processes:
+
+| Reaction | Stamped by | Proves |
+|---|---|---|
+| 👀 (inner) | `telegram_bot.py` | Message was received, passed the allowlist gate, written to SQLite |
+| 🫡 (outer) | `server.ts` | Row was read from SQLite, MCP notification was emitted to Claude |
+
+Seeing both 👀 and 🫡 on a message is a visual "both halves of the pipeline ran" signal. Seeing only 👀 means server.ts never picked it up (dead? disconnected? stuck?). Seeing only 🫡 shouldn't happen — server.ts can't deliver a row that telegram_bot.py didn't ingest.
+
+### Reaction whitelist gotcha
+
+Telegram's **free-tier bot reaction whitelist** is fixed. `✅` is *not* on it — the initial design tried to use ✅ and got `400 REACTION_INVALID` in production. `👀 🫡 👍 👎 🔥 🎉 🤝 ❤️ 😁 🤔 🤩 🙏 👌 🏆 💯 ⚡` are. Full list: https://core.telegram.org/bots/api#reactiontypeemoji
+
+### Permission-reply outcome (bgt.3.3)
+
+Free-tier reactions **replace** rather than **stack** — a second `setMessageReaction` call clobbers the first. For `permission_reply` rows, telegram_bot.py stamps ✔️ or ✖️ (matching the y/n outcome) instead of the generic ack 👀. server.ts must skip the outer 🫡 stamp for `message_type === 'permission_reply'`, or the outcome glyph gets clobbered. The guard lives in `server.ts:deliverRow` — gate the outer reaction on `row.message_type === 'message'`.
+
+---
+
+## Plugin-cache deploy: `cp`, never symlink
+
+bun resolves imports **relative to the real file path**. If you symlink `~/gits/igor2/telegram-server/server.ts` into `~/.claude/plugins/cache/claude-plugins-official/telegram/0.0.5/server.ts`, bun follows the symlink, starts resolving imports from `~/gits/igor2/telegram-server/`, and fails with `Cannot find module '@modelcontextprotocol/sdk'` because the MCP SDK only lives in the plugin cache's `node_modules`.
+
+Always `cp`. Doctor catches source/plugin drift via sha256 compare — if the source and deployed copy diverge, the doctor reports it and harden-telegram walks the redeploy.
+
+---
+
+## Invariants & edge cases
+
+**Invariants that must hold:**
+- Exactly one telegram_bot.py process per bot token per host (enforced by flock)
+- `inbound.db.delivered` is monotonic: once 1, never back to 0
+- `telegram_bot.py` never reads `delivered` — only writes `delivered=0` on INSERT
+- `server.ts` never writes rows — only reads rows and UPDATEs `delivered=1`
+- The Telegram cursor advance happens *after* the SQLite commit, not before
+- `assertSendable` always runs before any file upload (see `server.ts:150`)
+- `ATTACHMENTS_DIR` is in the `assertSendable` allowlist; `STATE_DIR` (credential store) is not
+
+**Known edge cases:**
+- **`catchup()` re-entry while in flight** (bgt.3.4): wakeups that arrive during an in-flight pass set `pendingCatchup=true` so the in-flight loop re-queries `selectUndelivered` before returning. Without this, rows inserted between the snapshot SELECT and the end of the pass wait for the next wakeup — fine for bursty traffic, visible delay for isolated messages.
+- **Regex drift between Python and JS** (bgt.3.5): `deliverPermissionReply` used to silently drop rows whose text didn't re-match server.ts's regex after telegram_bot.py's did. Now falls back to delivering as a regular message + hex-dump log. Long-term fix: store parsed groups in explicit columns so server.ts doesn't re-match.
+- **Attachment path guard** (bgt.3.2): `download_attachment` fallback writes under `ATTACHMENTS_DIR/inbox/`, not `STATE_DIR/inbox/`, so `assertSendable` allows the returned path back through `reply(files=…)`.
+- **PEP-723 Python version pin**: `requires-python = ">=3.11,<3.14"` — without the upper bound, `uv` picks Python 3.14, and `python-telegram-bot` doesn't ship 3.14 wheels yet. The script starts but crashes at import.
+- **python-telegram-bot manual lifecycle**: `Application.post_init()` only fires from `run_polling()`/`run_webhook()`. A manual `initialize → start → updater.start_polling` must call `await _post_init(app)` explicitly — without it, `bot.sock` is never bound and the socket-push path silently fails.
+
+---
+
+## Related
+
+- [`harden-telegram`](../harden-telegram/SKILL.md) — operator runbook (doctor, reload, recovery)
+- `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md` — full design spec
+- `~/gits/igor2/docs/superpowers/plans/2026-04-12-telegram-two-process-migration.md` — migration plan
+
+## Related beads
+
+- `igor2-bgt` — (EPIC) Two-process Telegram Infrastructure
+- `igor2-u8b` — Build telegram_bot.py persistent poller
+- `igor2-vdi` — Modify server.ts to SQLite reader + MCP bridge
+- `igor2-bgt.1` — Dual-reaction liveness
+- `igor2-bgt.2` — Integration kill-test
+- `igor2-bgt.3` — Post-cutover code review findings (all 5 closed)
+- `igor2-bgt.3.1` — `_kill_stale_bun_server` removal (the kill-by-name footgun)
+- `igor2-bgt.3.3` — Permission-reply reaction clobber fix
+- `igor2-bgt.3.4` — `pendingCatchup` for mid-pass inserts
+- `igor2-bgt.3.5` — Permission-reply regex-drift fallback
+- `igor2-bgt.4` — harden-telegram skill (operator runbook)
+- `igor2-bgt.3.6` — This skill

--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -48,19 +48,11 @@ Runs every check, prints ✅/⚠️/❌ per section, tails `server.log`, shows s
 
 Read the output top-to-bottom. If everything is green, say so and stop. If anything is red, proceed to Tier 2 for redeploys or Tier 3 for known failure modes.
 
-### Architecture recap (two-process split, 2026-04)
+### Architecture (one-paragraph recap)
 
-Two processes share the Telegram MCP responsibility:
+Two processes share the Telegram MCP responsibility. `telegram_bot.py` is the persistent Python poller — owns `getUpdates`, writes every event to `~/larry-telegram/inbound.db` (SQLite WAL), survives Claude restarts, singleton via `flock`. `server.ts` is the ephemeral bun MCP bridge — reads undelivered rows, emits MCP notifications, dies with the Claude session. Flow: `Telegram → telegram_bot.py → inbound.db → bot.sock wakeup → server.ts catchup → MCP → Claude`. Dual-reaction liveness: 👀 (inner, bot.py) + 🫡 (outer, server.ts). Both glyphs on a message means both halves of the pipeline ran.
 
-- **`telegram_bot.py`** — persistent Python poller. Owns the Telegram `getUpdates` loop, writes inbound events to `~/larry-telegram/inbound.db` (SQLite WAL), handles commands + pairing + attachments, emits the 👀 inner reaction. Singleton via PID file + `flock`. Survives Claude restarts.
-- **`server.ts`** — ephemeral MCP bridge (bun). Reads undelivered rows from `inbound.db`, delivers them via MCP stdio notifications, emits the 🫡 outer reaction. Dies with the Claude session.
-
-Message flow: `Telegram → telegram_bot.py → inbound.db → bot.sock wakeup → server.ts catchup → MCP notification → Claude`.
-
-**Dual-reaction liveness signal:** 👀 proves the inner process received + queued, 🫡 proves the outer bridge delivered. If you see both on a message, the full chain is healthy.
-
-Full design: `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md`.
-Migration plan: `~/gits/igor2/docs/superpowers/plans/2026-04-12-telegram-two-process-migration.md`.
+**For the full design rationale** — durability contract, why SQLite WAL + Unix socket, flock semantics, 409 retry logic, invariants across crashes — read the [`durable-telegram`](../durable-telegram/SKILL.md) skill. That's the design reference; this skill is the operator runbook.
 
 ---
 

--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -24,24 +24,28 @@ Full principle in [`../../CLAUDE.md`](../../CLAUDE.md) §"Diagnostics: Code Over
 
 ## Tool locations
 
-The Python tooling this skill drives lives in `~/gits/igor2/telegram-server/` (Igor's personal knowledge repo — that's where the two-process design was built). The skill is checked into chop-conventions so it is available from any repo via the auto-discovery symlink, but the actual `telegram_debug.py` and `watchdog.py` scripts stay with the Telegram state/paths they inspect.
+The Python tooling this skill drives ships with the skill itself under `tools/`. All paths are discoverable from any repo via the chop-conventions auto-link.
 
 | Tool | Path |
 |---|---|
-| Doctor / diagnostics | `~/gits/igor2/telegram-server/telegram_debug.py` |
-| Plugin-reload watchdog | `~/gits/igor2/telegram-server/watchdog.py` |
-| `telegram_bot.py` source | `~/gits/igor2/telegram-server/telegram_bot.py` |
-| `server.ts` source | `~/gits/igor2/telegram-server/server.ts` |
-| Runtime state dir | `~/larry-telegram/` |
+| Doctor / diagnostics | `~/.claude/skills/harden-telegram/tools/telegram_debug.py` |
+| Plugin-reload watchdog | `~/.claude/skills/harden-telegram/tools/watchdog.py` |
+| Runtime state dir | `$LARRY_TELEGRAM_DIR` (default `~/larry-telegram/`) |
+| Canonical source dir | `$TELEGRAM_SOURCE_DIR` (optional — enables deploy-drift check) |
 
-If the doctor tool is missing (`ENOENT`), igor2 isn't checked out on this box — tell the user and stop. This skill only helps on machines running the Telegram MCP plugin with the two-process architecture.
+Two env vars parameterize the tool:
+
+- **`LARRY_TELEGRAM_DIR`** — runtime state directory (`bot.pid`, `bot.sock`, `inbound.db`, `server.log`, `attachments/`). Defaults to `~/larry-telegram/` if unset. The telegram_bot.py production process reads the same variable.
+- **`TELEGRAM_SOURCE_DIR`** — directory containing the canonical `server.ts` + `telegram_bot.py` source you deploy from. Required if you want the doctor to verify the plugin-cache copy matches your upstream. If unset, the drift check degrades to a note ("plugin cache: &lt;hash&gt; — set TELEGRAM_SOURCE_DIR to enable drift check").
+
+This skill only helps on machines running the Telegram MCP plugin with the two-process architecture. If you don't have a `telegram_bot.py` process alongside the MCP `server.ts`, the doctor will report the whole chain as missing.
 
 ---
 
 ## Tier 1: Doctor (`/harden-telegram doctor`)
 
 ```bash
-python3 ~/gits/igor2/telegram-server/telegram_debug.py --doctor
+python3 ~/.claude/skills/harden-telegram/tools/telegram_debug.py --doctor
 ```
 
 Runs every check, prints ✅/⚠️/❌ per section, tails `server.log`, shows source/plugin hash drift, exits non-zero on failure. JSON mode: `--json`. Legacy human-readable summary (pre-doctor): plain invocation with no flags.
@@ -66,13 +70,13 @@ bun resolves imports relative to the real file path. Symlinking `server.ts` into
 # Find the active plugin version (may be 0.0.4 or 0.0.5 — don't guess):
 cat ~/.claude/plugins/installed_plugins.json | python3 -c "import json,sys;print(json.load(sys.stdin)['telegram@claude-plugins-official'][0]['installPath'])"
 
-# Deploy:
-cp ~/gits/igor2/telegram-server/server.ts <that-path>/server.ts
+# Deploy (TELEGRAM_SOURCE_DIR points at your canonical source tree):
+cp "$TELEGRAM_SOURCE_DIR/server.ts" <that-path>/server.ts
 ```
 
 Always back up first: `cp server.ts server.ts.backup-$(date +%Y%m%d-%H%M%S)`.
 
-Doctor catches source/plugin drift automatically via sha256 compare.
+Doctor catches source/plugin drift automatically via sha256 compare when `TELEGRAM_SOURCE_DIR` is set.
 
 ### 2b. `/reload-plugins` doesn't pick up new server.ts code
 
@@ -91,7 +95,7 @@ pkill -TERM -f 'bun.*server.ts'
 
 ```bash
 # %25 → your pane id (tmux display-message -p '#{pane_id}')
-python3 ~/gits/igor2/telegram-server/watchdog.py reload --pane %25 \
+python3 ~/.claude/skills/harden-telegram/tools/watchdog.py reload --pane %25 \
   2>/tmp/watchdog_reload.log &
 disown
 ```
@@ -108,9 +112,9 @@ Flags:
 ### 2d. telegram_bot.py died or never started
 
 ```bash
-nohup ~/gits/igor2/telegram-server/telegram_bot.py \
-  --base-dir ~/larry-telegram \
-  >>~/larry-telegram/startup.log 2>&1 &
+nohup "$TELEGRAM_SOURCE_DIR/telegram_bot.py" \
+  --base-dir "${LARRY_TELEGRAM_DIR:-$HOME/larry-telegram}" \
+  >>"${LARRY_TELEGRAM_DIR:-$HOME/larry-telegram}/startup.log" 2>&1 &
 disown
 ```
 
@@ -118,7 +122,7 @@ The `flock` singleton inside the script prevents double-launch — safe to run w
 
 ### 2e. Full restart (nuclear)
 
-Exit the Claude session, run `~/gits/igor2/larry_start.sh`. `larry_start.sh` launches `telegram_bot.py` before starting Claude (singleton-safe), then Claude's MCP loader spawns `server.ts` from the plugin cache.
+Exit the Claude session, then re-launch via whatever script bootstraps `telegram_bot.py` on your setup. Whatever launcher you use should start `telegram_bot.py` *before* starting Claude (singleton-safe), then let Claude's MCP loader spawn `server.ts` from the plugin cache.
 
 ---
 

--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: harden-telegram
+description: Diagnose and recover the two-process Telegram MCP chain — run the doctor, hot-redeploy server.ts, reload plugins without bouncing MCP, restart telegram_bot.py, and walk through known failure modes. Use when Telegram stops working mid-session, messages aren't arriving, or the bot is silent.
+allowed-tools: Bash, Read, Glob, Grep
+---
+
+# Harden Telegram
+
+Diagnose and repair the two-process Telegram MCP channel. Three tiers:
+
+| Invocation | Scope |
+|---|---|
+| `/harden-telegram doctor` | Quick health check via `telegram_debug.py --doctor` |
+| `/harden-telegram reload` | Hot redeploy + reload plugins without dropping MCP |
+| `/harden-telegram deep` | Walk known failure modes if the doctor is clean but the channel is still broken |
+
+## 🧭 Principle: diagnostics live in code, not here
+
+**Before adding any "check X, grep Y" prose to this skill, ask: can it go in `telegram_debug.py` instead?**
+
+Skills describe **WHEN** to run diagnostics and **HOW** to recover. Code describes **WHAT** to check. Paths move — code errors loudly, prose rots silently. If you catch yourself listing file paths, grep patterns, or "does process X exist" checks here, STOP and add them to `telegram_debug.py --doctor` instead, then run it from this skill.
+
+Full principle in [`../../CLAUDE.md`](../../CLAUDE.md) §"Diagnostics: Code Over Prose".
+
+## Tool locations
+
+The Python tooling this skill drives lives in `~/gits/igor2/telegram-server/` (Igor's personal knowledge repo — that's where the two-process design was built). The skill is checked into chop-conventions so it is available from any repo via the auto-discovery symlink, but the actual `telegram_debug.py` and `watchdog.py` scripts stay with the Telegram state/paths they inspect.
+
+| Tool | Path |
+|---|---|
+| Doctor / diagnostics | `~/gits/igor2/telegram-server/telegram_debug.py` |
+| Plugin-reload watchdog | `~/gits/igor2/telegram-server/watchdog.py` |
+| `telegram_bot.py` source | `~/gits/igor2/telegram-server/telegram_bot.py` |
+| `server.ts` source | `~/gits/igor2/telegram-server/server.ts` |
+| Runtime state dir | `~/larry-telegram/` |
+
+If the doctor tool is missing (`ENOENT`), igor2 isn't checked out on this box — tell the user and stop. This skill only helps on machines running the Telegram MCP plugin with the two-process architecture.
+
+---
+
+## Tier 1: Doctor (`/harden-telegram doctor`)
+
+```bash
+python3 ~/gits/igor2/telegram-server/telegram_debug.py --doctor
+```
+
+Runs every check, prints ✅/⚠️/❌ per section, tails `server.log`, shows source/plugin hash drift, exits non-zero on failure. JSON mode: `--json`. Legacy human-readable summary (pre-doctor): plain invocation with no flags.
+
+Read the output top-to-bottom. If everything is green, say so and stop. If anything is red, proceed to Tier 2 for redeploys or Tier 3 for known failure modes.
+
+### Architecture recap (two-process split, 2026-04)
+
+Two processes share the Telegram MCP responsibility:
+
+- **`telegram_bot.py`** — persistent Python poller. Owns the Telegram `getUpdates` loop, writes inbound events to `~/larry-telegram/inbound.db` (SQLite WAL), handles commands + pairing + attachments, emits the 👀 inner reaction. Singleton via PID file + `flock`. Survives Claude restarts.
+- **`server.ts`** — ephemeral MCP bridge (bun). Reads undelivered rows from `inbound.db`, delivers them via MCP stdio notifications, emits the 🫡 outer reaction. Dies with the Claude session.
+
+Message flow: `Telegram → telegram_bot.py → inbound.db → bot.sock wakeup → server.ts catchup → MCP notification → Claude`.
+
+**Dual-reaction liveness signal:** 👀 proves the inner process received + queued, 🫡 proves the outer bridge delivered. If you see both on a message, the full chain is healthy.
+
+Full design: `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md`.
+Migration plan: `~/gits/igor2/docs/superpowers/plans/2026-04-12-telegram-two-process-migration.md`.
+
+---
+
+## Tier 2: Reload (`/harden-telegram reload`)
+
+### 2a. Deploy: cp, NEVER symlink
+
+bun resolves imports relative to the real file path. Symlinking `server.ts` into the plugin cache breaks module resolution (`Cannot find module '@modelcontextprotocol/sdk'`).
+
+```bash
+# Find the active plugin version (may be 0.0.4 or 0.0.5 — don't guess):
+cat ~/.claude/plugins/installed_plugins.json | python3 -c "import json,sys;print(json.load(sys.stdin)['telegram@claude-plugins-official'][0]['installPath'])"
+
+# Deploy:
+cp ~/gits/igor2/telegram-server/server.ts <that-path>/server.ts
+```
+
+Always back up first: `cp server.ts server.ts.backup-$(date +%Y%m%d-%H%M%S)`.
+
+Doctor catches source/plugin drift automatically via sha256 compare.
+
+### 2b. `/reload-plugins` doesn't pick up new server.ts code
+
+**Symptom:** Changed `server.ts`, ran `cp` to plugin cache, ran `/reload-plugins`, but doctor shows the same bun PID.
+
+**Cause:** `/reload-plugins` re-reads skills/hooks/agents/plugin config but leaves running MCP server processes alone. The existing bun process keeps serving the old code.
+
+**Fix:** kill the old bun first, then reload — the next MCP request respawns from the plugin cache:
+
+```bash
+pkill -TERM -f 'bun.*server.ts'
+# Then run /reload-plugins from another context (or via the watchdog below).
+```
+
+### 2c. Watchdog reload (from a background shell — NEVER foreground)
+
+```bash
+# %25 → your pane id (tmux display-message -p '#{pane_id}')
+python3 ~/gits/igor2/telegram-server/watchdog.py reload --pane %25 \
+  2>/tmp/watchdog_reload.log &
+disown
+```
+
+**Must be backgrounded.** The watchdog sends an `Escape` to your pane before `/reload-plugins`, and foreground invocation cancels the current Claude agent turn.
+
+Result log: `cat /tmp/watchdog_reload.log`.
+
+Flags:
+- `--pane %N` — target pane
+- `--pid <n>` — auto-detect pane from bun pid
+- `-m "message"` — follow-up text to send after reload lands
+
+### 2d. telegram_bot.py died or never started
+
+```bash
+nohup ~/gits/igor2/telegram-server/telegram_bot.py \
+  --base-dir ~/larry-telegram \
+  >>~/larry-telegram/startup.log 2>&1 &
+disown
+```
+
+The `flock` singleton inside the script prevents double-launch — safe to run when already alive. Verify with `telegram_debug.py --doctor`.
+
+### 2e. Full restart (nuclear)
+
+Exit the Claude session, run `~/gits/igor2/larry_start.sh`. `larry_start.sh` launches `telegram_bot.py` before starting Claude (singleton-safe), then Claude's MCP loader spawns `server.ts` from the plugin cache.
+
+---
+
+## Tier 3: Known Failure Modes (`/harden-telegram deep`)
+
+Run the doctor first. If it's clean but Telegram is still misbehaving, walk this list.
+
+### REACTION_INVALID on emoji reaction
+
+**Symptom:** `outer reaction failed: 400 Bad Request: REACTION_INVALID` in `server.log`, or a raw API call with `{"type":"emoji","emoji":"X"}` is rejected.
+**Cause:** Telegram's free-tier bot reaction whitelist is fixed. `✅` is NOT on it. `🦝` is NOT on it. `👀 🫡 👍 👎 🔥 🎉 🤝 ❤️ 😁 🤔 🤩 🙏 👌 🏆 💯 ⚡` ARE.
+**Fix:** Pick from the whitelist. Full list: https://core.telegram.org/bots/api#reactiontypeemoji
+
+### python-telegram-bot post_init skipped in manual lifecycle
+
+**Symptom:** Bot process running but no `bot.sock`, no DB connection, no `polling as @...` line in log.
+**Cause:** `Application.post_init()` callback is only auto-fired by `run_polling()` / `run_webhook()`. A manual lifecycle (`initialize → start → updater.start_polling`) must invoke it explicitly.
+**Fix:** `await _post_init(app)` between `initialize()` and `start()`.
+
+### REACTION dict vs ReactionTypeEmoji
+
+**Symptom:** `[bot] reaction failed: unhashable type: 'dict'`.
+**Cause:** Passing raw `{"type": "emoji", "emoji": "X"}` to `set_message_reaction()` — python-telegram-bot hashes reactions internally for dedup and plain dicts aren't hashable.
+**Fix:** Use `telegram.ReactionTypeEmoji(emoji="X")`.
+
+### PEP-723 script picks wrong Python on host
+
+**Symptom:** Running `telegram_bot.py` directly fails with missing `telegram` module, or crashes at runtime despite `uv run` succeeding.
+**Cause:** Host default Python is 3.14, but `python-telegram-bot` hasn't released 3.14-compatible wheels. `requires-python = ">=3.11"` lets uv pick 3.14 silently.
+**Fix:** Pin the upper bound: `requires-python = ">=3.11,<3.14"`.
+
+### Zombie telegram_bot.py steals updates (409 Conflict)
+
+**Symptom:** `409 Conflict` in log, messages don't arrive.
+**Cause:** Two instances polling the same bot token. `flock` should prevent this in steady state, but a crashed singleton can leave a dangling PID file.
+**Fix:** `pkill -f telegram_bot.py`, verify only one comes back, check doctor. The 409 retry loop in `telegram_bot.py` uses exponential backoff — Telegram drops the stale poller on its own once a fresh `getUpdates` arrives.
+
+### Plugin auto-update overwrites deployed server.ts
+
+**Symptom:** After a plugin update, dual-reaction stops, `server.ts` doesn't connect to `bot.sock`.
+**Cause:** Plugin cache was overwritten with the upstream copy, which doesn't have Igor's two-process code.
+**Fix:** Redeploy via `cp` (Tier 2a). Doctor catches this via source/plugin hash drift check.
+
+### Inbound messages arrive at telegram_bot.py but never reach Claude
+
+**Symptom:** `inbound.db` has rows with `delivered = 0`, but Claude sees nothing.
+
+Diagnosis order:
+
+1. Run the doctor — confirm `bot.sock` accepts connections and `server.ts` is running.
+2. If `server.ts` is dead: `/reload-plugins` may not respawn it (see Tier 2b). Kill bun and retry.
+3. If `server.ts` is alive but not delivering: check `server.log` for `[mcp]` errors. The fallback path uses 2s `setInterval` polling when `bot.sock` is missing.
+
+### Permission-reply outcome reaction gets clobbered
+
+**Symptom:** User replied `y abcde` or `n abcde` to a permission request, but the reaction on their reply is 🫡 instead of ✔️/✖️.
+**Cause:** `server.ts`'s `deliverRow` stamped the outer 🫡 on every delivered row. Free-tier reactions *replace* rather than *stack*, so the outer 🫡 clobbered `telegram_bot.py`'s outcome glyph.
+**Fix:** Gate the outer reaction on `row.message_type === 'message'` in `deliverRow`. (Closed: igor2-bgt.3.3.)
+
+---
+
+## Safety Rules
+
+- **Never `pkill -f 'bun.*server.ts'` against a live session without a plan to respawn it.** That disconnects Claude's MCP bridge mid-turn. Pair every kill with a `/reload-plugins` dispatched from a background shell via the watchdog.
+- **Tests that signal processes must mock their subprocess/OS calls.** An unmocked test of `_kill_stale_bun_server`-style code against the real process table SIGTERMs the live bridge — this happened on 2026-04-12. See [`../../CLAUDE.md`](../../CLAUDE.md) §"Process-Signaling Safety".
+- **Never redeploy `server.ts` via symlink.** bun module resolution breaks. Use `cp`.
+- **Never edit the Telegram bot token or `access.json` from this skill.** Those are the credential store — editing is what `/telegram:configure` and `/telegram:access` are for.
+
+## Related beads
+
+- `igor2-bgt` — (EPIC) Two-process Telegram Infrastructure
+- `igor2-u8b` — Build telegram_bot.py persistent poller
+- `igor2-vdi` — Modify server.ts to SQLite reader + MCP bridge
+- `igor2-bgt.1` — Dual-reaction liveness
+- `igor2-bgt.2` — Integration kill-test
+- `igor2-bgt.3` — Post-cutover code review findings
+- `igor2-bgt.4` — This skill's migration from igor2 to chop-conventions
+- `igor2-cr1` — telegram_debug.py --doctor mode
+- `igor2-ddn` — Telegram watchdog auto-recover via tmux send-keys

--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -56,7 +56,7 @@ Read the output top-to-bottom. If everything is green, say so and stop. If anyth
 
 Two processes share the Telegram MCP responsibility. `telegram_bot.py` is the persistent Python poller — owns `getUpdates`, writes every event to `~/larry-telegram/inbound.db` (SQLite WAL), survives Claude restarts, singleton via `flock`. `server.ts` is the ephemeral bun MCP bridge — reads undelivered rows, emits MCP notifications, dies with the Claude session. Flow: `Telegram → telegram_bot.py → inbound.db → bot.sock wakeup → server.ts catchup → MCP → Claude`. Dual-reaction liveness: 👀 (inner, bot.py) + 🫡 (outer, server.ts). Both glyphs on a message means both halves of the pipeline ran.
 
-**For the full design rationale** — durability contract, why SQLite WAL + Unix socket, flock semantics, 409 retry logic, invariants across crashes — read the [`durable-telegram`](../durable-telegram/SKILL.md) skill. That's the design reference; this skill is the operator runbook.
+**For the full design rationale** — durability contract, why SQLite WAL + Unix socket, flock semantics, 409 retry logic, invariants across crashes — read [`design.md`](./design.md) in this skill directory. That's the architectural reference, loaded on demand; this file is the operator runbook.
 
 ---
 

--- a/skills/harden-telegram/design.md
+++ b/skills/harden-telegram/design.md
@@ -1,12 +1,6 @@
----
-name: durable-telegram
-description: Design reference for the two-process Telegram MCP architecture — why it's split the way it is, what the SQLite queue guarantees, how the flock singleton and 409 retry work, and what invariants hold across crashes. Read this when designing changes to telegram_bot.py or server.ts, or when answering "why is Telegram built this way?". For break/fix use harden-telegram instead.
-allowed-tools: Read, Glob, Grep
----
+# Harden Telegram — Design Reference
 
-# Durable Telegram — Design Reference
-
-This skill is the **architectural** counterpart to [`harden-telegram`](../harden-telegram/SKILL.md). harden-telegram answers "what do I do when it breaks?"; durable-telegram answers "why is it built this way and what does it guarantee?".
+> **Loaded on demand.** This file is not a skill entry point — it's supplementary reading for the [`harden-telegram`](./SKILL.md) skill. SKILL.md is the operator runbook ("what do I do when it breaks?"); this file is the architectural reference ("why is it built this way and what does it guarantee?").
 
 Read this before:
 - Modifying `telegram_bot.py` or `server.ts` in a way that touches the queue, the socket, the singleton, or the reaction protocol
@@ -172,7 +166,7 @@ Always `cp`. Doctor catches source/plugin drift via sha256 compare — if the so
 
 ## Related
 
-- [`harden-telegram`](../harden-telegram/SKILL.md) — operator runbook (doctor, reload, recovery)
+- [`SKILL.md`](./SKILL.md) — operator runbook (doctor, reload, recovery tiers)
 - Igor's canonical design doc: `~/gits/igor2/docs/superpowers/specs/2026-04-12-telegram-two-process-design.md`
 - Igor's migration plan: `~/gits/igor2/docs/superpowers/plans/2026-04-12-telegram-two-process-migration.md`
 
@@ -189,4 +183,5 @@ Always `cp`. Doctor catches source/plugin drift via sha256 compare — if the so
 - `igor2-bgt.3.4` — `pendingCatchup` for mid-pass inserts
 - `igor2-bgt.3.5` — Permission-reply regex-drift fallback
 - `igor2-bgt.4` — harden-telegram skill (operator runbook)
-- `igor2-bgt.3.6` — This skill
+- `igor2-bgt.3.6` — This file (originally shipped as a separate durable-telegram skill)
+- `igor2-bgt.6` — Folded into harden-telegram/design.md (this file's current home)

--- a/skills/harden-telegram/tools/telegram_debug.py
+++ b/skills/harden-telegram/tools/telegram_debug.py
@@ -1,0 +1,1054 @@
+#!/usr/bin/env python3
+"""
+Telegram MCP diagnostic tool — gathers all logs and system state at once.
+
+Usage:
+    python3 telegram_debug.py                # Full diagnostic report
+    python3 telegram_debug.py --json         # JSON output (pipe to jq)
+    python3 telegram_debug.py --tail 50      # More log lines (default 20)
+    python3 telegram_debug.py --json --tail 100 | jq '.server_log[-5:]'
+    python3 telegram_debug.py --doctor       # Validate two-process chain end-to-end
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import socket
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+STATE_DIR = Path(os.environ.get("HOME", "/tmp")) / ".claude" / "channels" / "telegram"
+PLUGIN_DIR = (
+    Path(os.environ.get("HOME", "/tmp"))
+    / ".claude"
+    / "plugins"
+    / "cache"
+    / "claude-plugins-official"
+    / "telegram"
+)
+LOG_DB = Path(os.environ.get("HOME", "/tmp")) / ".claude" / "telegram_log.db"
+
+
+def run(cmd: list[str], timeout: int = 5) -> str:
+    """Run a command and return stdout, or error string."""
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        return f"ERROR: {e}"
+
+
+TELEGRAM_PLUGIN_MARKER = "claude-plugins-official/telegram"
+
+
+def check_bun_processes() -> list[dict]:
+    """Find all bun server.ts processes, distinguishing Telegram bot from other bun."""
+    output = run(["bash", "-c", r"\ps -eo pid,ppid,tty,args"])
+    if output.startswith("ERROR"):
+        output = run(["/usr/bin/ps", "-eo", "pid,ppid,tty,args"])
+    processes = []
+    for line in output.splitlines():
+        if "bun" in line and "server.ts" in line and "grep" not in line:
+            parts = line.split(None, 3)  # pid, ppid, tty, cmd
+            if len(parts) < 4:
+                continue
+            pid = parts[0].strip()
+            ppid = parts[1].strip()
+            tty = parts[2].strip()
+            cmd = parts[3].strip()
+            # Check /proc/<pid>/cwd to confirm this is the telegram plugin
+            cwd = _proc_cwd(pid)
+            is_telegram = TELEGRAM_PLUGIN_MARKER in (cwd or "")
+            processes.append(
+                {
+                    "pid": pid,
+                    "ppid": ppid,
+                    "tty": tty,
+                    "cmd": cmd,
+                    "cwd": cwd,
+                    "is_telegram": is_telegram,
+                }
+            )
+    return processes
+
+
+def _proc_cwd(pid: str) -> str | None:
+    """Read /proc/<pid>/cwd symlink to get the process working directory."""
+    try:
+        return os.readlink(f"/proc/{pid}/cwd")
+    except (OSError, ValueError):
+        return None
+
+
+def check_claude_sessions() -> list[dict]:
+    """Find all Claude Code sessions."""
+    output = run(["bash", "-c", r"\ps -ef | grep -v grep | grep claude.*dangerously"])
+    sessions = []
+    for line in output.splitlines():
+        if not line or "ERROR" in line:
+            continue
+        parts = line.split()
+        sessions.append(
+            {
+                "pid": parts[1] if len(parts) > 1 else "?",
+                "tty": parts[5] if len(parts) > 5 else "?",
+                "has_channels": "--channels" in line,
+                "cmd": " ".join(parts[7:]) if len(parts) > 7 else line,
+            }
+        )
+    return sessions
+
+
+def check_pid_file(_name: str, path: Path) -> dict:
+    """Check a PID file and whether the process is alive."""
+    result = {"file": str(path), "exists": path.exists()}
+    if path.exists():
+        try:
+            pid = int(path.read_text().strip())
+            result["pid"] = pid
+            try:
+                os.kill(pid, 0)
+                result["alive"] = True
+            except ProcessLookupError:
+                result["alive"] = False
+            except PermissionError:
+                result["alive"] = True
+        except (ValueError, OSError):
+            result["pid"] = None
+            result["alive"] = False
+    return result
+
+
+def check_server_log(n: int = 20) -> list[str]:
+    """Read last N lines of server.log."""
+    log_file = STATE_DIR / "server.log"
+    if not log_file.exists():
+        return ["(no server.log)"]
+    try:
+        lines = log_file.read_text().strip().splitlines()
+        return lines[-n:]
+    except OSError:
+        return ["(error reading server.log)"]
+
+
+def check_inbound_log(n: int = 20) -> list[dict]:
+    """Read last N inbound.jsonl entries."""
+    log_file = STATE_DIR / "inbound.jsonl"
+    if not log_file.exists():
+        return []
+    try:
+        lines = log_file.read_text().strip().splitlines()
+        entries = []
+        for line in lines[-n:]:
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                entries.append({"raw": line})
+        return entries
+    except OSError:
+        return []
+
+
+def check_telegram_db(n: int = 10) -> dict:
+    """Check telegram_log.db for recent messages."""
+    if not LOG_DB.exists():
+        return {"exists": False}
+    try:
+        conn = sqlite3.connect(str(LOG_DB))
+        cur = conn.cursor()
+        cur.execute("SELECT count(*) FROM messages")
+        total = cur.fetchone()[0]
+        cur.execute(
+            "SELECT count(*) FROM messages WHERE timestamp >= datetime('now', '-24 hours')"
+        )
+        recent = cur.fetchone()[0]
+        cur.execute(
+            "SELECT timestamp, direction, tool_name, chat_id, substr(text,1,120) "
+            "FROM messages ORDER BY timestamp DESC LIMIT ?",
+            (n,),
+        )
+        last_n = [
+            {"ts": r[0], "dir": r[1], "tool": r[2], "chat_id": r[3], "text": r[4]}
+            for r in cur.fetchall()
+        ]
+        conn.close()
+        return {
+            "exists": True,
+            "total": total,
+            "recent_24h": recent,
+            "last_messages": last_n,
+        }
+    except Exception as e:
+        return {"exists": True, "error": str(e)}
+
+
+def check_access_config() -> dict:
+    """Read access.json summary."""
+    access_file = STATE_DIR / "access.json"
+    if not access_file.exists():
+        return {"exists": False}
+    try:
+        data = json.loads(access_file.read_text())
+        return {
+            "exists": True,
+            "dmPolicy": data.get("dmPolicy", "?"),
+            "allowFrom_count": len(data.get("allowFrom", [])),
+            "groups_count": len(data.get("groups", {})),
+            "pending_count": len(data.get("pending", {})),
+        }
+    except (json.JSONDecodeError, OSError) as e:
+        return {"exists": True, "error": str(e)}
+
+
+def _source_dir() -> Path | None:
+    """Canonical server.ts source directory (for hash-drift check).
+
+    Set TELEGRAM_SOURCE_DIR to the dir containing server.ts. If unset, drift
+    checks degrade to a note — the doctor still runs, it just can't tell you
+    whether the plugin-cache copy matches an upstream source.
+    """
+    env = os.environ.get("TELEGRAM_SOURCE_DIR")
+    return Path(env).expanduser() if env else None
+
+
+def _source_server_ts() -> Path | None:
+    d = _source_dir()
+    return d / "server.ts" if d else None
+
+
+def _file_hash(path: Path) -> str | None:
+    """SHA-256 of a file, or None if unreadable."""
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
+    except OSError:
+        return None
+
+
+def check_plugin_deploy() -> dict:
+    """Check if our custom server.ts is deployed and matches source."""
+    # Find the version dir
+    if not PLUGIN_DIR.exists():
+        return {"installed": False}
+    versions = sorted(
+        [d for d in PLUGIN_DIR.iterdir() if d.is_dir() and d.name[0].isdigit()],
+        reverse=True,
+    )
+    if not versions:
+        return {"installed": False}
+    version_dir = versions[0]  # newest version
+    deployed_file = version_dir / "server.ts"
+    source_ts = _source_server_ts()
+    result: dict = {
+        "installed": True,
+        "version": version_dir.name,
+        "deploy_path": str(deployed_file),
+        "source_path": str(source_ts) if source_ts else None,
+        "source_configured": source_ts is not None,
+        "server_ts_exists": deployed_file.exists(),
+    }
+    if deployed_file.exists():
+        result["is_symlink"] = deployed_file.is_symlink()
+        if deployed_file.is_symlink():
+            result["symlink_target"] = str(deployed_file.resolve())
+            result["WARNING"] = "Symlinks break bun module resolution! Use cp instead."
+        # Check feature markers
+        try:
+            content = deployed_file.read_text()
+            result["has_resilience"] = "logInbound" in content
+            result["has_heartbeat"] = "heartbeat" in content
+        except OSError:
+            pass
+        # Compare source vs deployed — only if a source dir is configured.
+        if source_ts is not None:
+            source_hash = _file_hash(source_ts)
+            deploy_hash = _file_hash(deployed_file)
+            result["source_hash"] = source_hash
+            result["deploy_hash"] = deploy_hash
+            if source_hash and deploy_hash:
+                result["in_sync"] = source_hash == deploy_hash
+                if not result["in_sync"]:
+                    result["WARNING_DRIFT"] = (
+                        "Source and deployed server.ts differ! "
+                        f"Run: cp {source_ts} {deployed_file}"
+                    )
+            result["source_exists"] = source_ts.exists()
+    return result
+
+
+def check_watchdog() -> dict:
+    """Check watchdog state."""
+    pid_file = STATE_DIR / "watchdog.pid"
+    test_file = STATE_DIR / "watchdog_test.json"
+    result = {"pid": check_pid_file("watchdog", pid_file)}
+    if test_file.exists():
+        try:
+            result["last_test"] = json.loads(test_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return result
+
+
+def full_diagnostic(tail: int = 20) -> dict:
+    """Run all diagnostic checks and return structured results."""
+    return {
+        "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "bun_processes": check_bun_processes(),
+        "claude_sessions": check_claude_sessions(),
+        "bot_pid": check_pid_file("bot", STATE_DIR / "bot.pid"),
+        "server_log": check_server_log(n=tail),
+        "inbound_log": check_inbound_log(n=tail),
+        "telegram_db": check_telegram_db(n=tail),
+        "access_config": check_access_config(),
+        "plugin_deploy": check_plugin_deploy(),
+        "watchdog": check_watchdog(),
+    }
+
+
+def print_report(diag: dict) -> None:
+    """Print a human-readable diagnostic report."""
+    print(f"=== Telegram MCP Diagnostic — {diag['timestamp']} ===\n")
+
+    # Bun processes
+    buns = diag["bun_processes"]
+    tg_buns = [b for b in buns if b.get("is_telegram")]
+    other_buns = [b for b in buns if not b.get("is_telegram")]
+    print(
+        f"BUN server.ts PROCESSES: {len(buns)} total ({len(tg_buns)} telegram, {len(other_buns)} other)"
+    )
+    if buns:
+        for b in buns:
+            tag = " [TELEGRAM]" if b.get("is_telegram") else ""
+            print(f"  PID {b['pid']} (ppid {b['ppid']}, {b['tty']}){tag}")
+            print(f"    cmd: {b['cmd']}")
+            print(f"    cwd: {b.get('cwd', '?')}")
+    else:
+        print("  NONE RUNNING")
+
+    # Claude sessions
+    sessions = diag["claude_sessions"]
+    print(f"\nCLAUDE SESSIONS: {len(sessions)}")
+    for s in sessions:
+        channels = " [+channels]" if s["has_channels"] else ""
+        print(f"  PID {s['pid']} ({s['tty']}){channels}")
+
+    # Bot PID
+    bp = diag["bot_pid"]
+    status = "ALIVE" if bp.get("alive") else "DEAD" if bp.get("exists") else "NO FILE"
+    print(f"\nBOT PID: {bp.get('pid', 'n/a')} — {status}")
+
+    # Plugin deploy
+    pd = diag["plugin_deploy"]
+    print("\nPLUGIN DEPLOY:")
+    if pd.get("installed"):
+        print(f"  Version: {pd.get('version')}")
+        symlink = " ⚠️  SYMLINK (BROKEN!)" if pd.get("is_symlink") else " (real file)"
+        print(f"  server.ts: {pd.get('server_ts_exists')}{symlink}")
+        print(
+            f"  Resilience: {pd.get('has_resilience', False)}  Heartbeat: {pd.get('has_heartbeat', False)}"
+        )
+        if pd.get("in_sync") is True:
+            print(f"  Source ↔ Deploy: ✅ IN SYNC ({pd.get('deploy_hash')})")
+        elif pd.get("in_sync") is False:
+            print("  Source ↔ Deploy: ❌ DRIFTED")
+            print(f"    source: {pd.get('source_hash')} ({pd.get('source_path')})")
+            print(f"    deploy: {pd.get('deploy_hash')} ({pd.get('deploy_path')})")
+            print(f"    Fix: cp {pd.get('source_path')} {pd.get('deploy_path')}")
+        elif not pd.get("source_exists", True):
+            print(f"  Source: ⚠️  {pd.get('source_path')} not found — can't verify sync")
+    else:
+        print("  NOT INSTALLED")
+
+    # Server log
+    print("\nSERVER LOG (last 10):")
+    for line in diag["server_log"][-10:]:
+        print(f"  {line}")
+
+    # Inbound log
+    inbound = diag["inbound_log"]
+    print(f"\nINBOUND LOG: {len(inbound)} recent entries")
+    for entry in inbound[-3:]:
+        if "ts" in entry:
+            print(
+                f"  [{entry['ts']}] {entry.get('user', '?')}: {entry.get('text_preview', '')[:60]}"
+            )
+
+    # Telegram DB
+    db = diag["telegram_db"]
+    print("\nTELEGRAM DB:")
+    if db.get("exists"):
+        print(f"  Total messages: {db.get('total', '?')}")
+        print(f"  Last 24h: {db.get('recent_24h', '?')}")
+        for m in db.get("last_messages", []):
+            text = (m.get("text") or "")[:70]
+            print(f"  [{m['ts'][:19]}] {m['dir']:8s} {text}")
+    else:
+        print("  NOT FOUND")
+
+    # Access config
+    ac = diag["access_config"]
+    print("\nACCESS CONFIG:")
+    if ac.get("exists"):
+        print(
+            f"  dmPolicy: {ac.get('dmPolicy')}  allowFrom: {ac.get('allowFrom_count')}  groups: {ac.get('groups_count')}"
+        )
+    else:
+        print("  NOT FOUND")
+
+    # Watchdog
+    wd = diag["watchdog"]
+    wp = wd["pid"]
+    ws = "ALIVE" if wp.get("alive") else "DEAD" if wp.get("exists") else "NO FILE"
+    print(f"\nWATCHDOG: {wp.get('pid', 'n/a')} — {ws}")
+    if "last_test" in wd:
+        lt = wd["last_test"]
+        print(f"  Last test: {lt.get('ts', '?')} — pane {lt.get('tmux_pane', '?')}")
+
+    # Verdict
+    print(f"\n{'=' * 60}")
+    issues = []
+    if len(tg_buns) == 0:
+        issues.append("❌ No Telegram bun process running — bot is dead")
+    if len(tg_buns) > 1:
+        issues.append(
+            f"⚠️  {len(tg_buns)} Telegram bun processes — zombie stealing updates"
+        )
+    if other_buns:
+        pids = ", ".join(b["pid"] for b in other_buns)
+        issues.append(
+            f"ℹ️  {len(other_buns)} non-Telegram bun server.ts ({pids}) — ignored"
+        )
+    if pd.get("is_symlink"):
+        issues.append("❌ server.ts is a symlink — bun can't resolve modules. Use cp!")
+    if not pd.get("has_resilience"):
+        issues.append("⚠️  Resilience features not deployed")
+    if pd.get("in_sync") is False:
+        issues.append("❌ Source/deploy server.ts DRIFTED — hot-patch is stale")
+    sessions_with_channels = [s for s in sessions if s["has_channels"]]
+    if len(sessions_with_channels) == 0:
+        issues.append("⚠️  No Claude session launched with --channels flag")
+    if len(sessions_with_channels) > 1:
+        issues.append(
+            f"⚠️  {len(sessions_with_channels)} sessions with --channels — will fight over bot token"
+        )
+
+    if issues:
+        print("ISSUES FOUND:")
+        for i in issues:
+            print(f"  {i}")
+    else:
+        print("✅ All checks passed")
+
+
+# ---------------------------------------------------------------------------
+# Doctor mode — validate the full two-process chain end-to-end.
+#
+# Two-process layout (spec §telegram_debug.py doctor mode):
+#   telegram_bot.py  (persistent)  → writes inbound.db + binds bot.sock
+#   server.ts        (ephemeral)   → reads inbound.db, subscribes to bot.sock,
+#                                    delivers to Claude over MCP
+# Doctor prints a ✅/❌/⚠️ line per check and exits 1 on any failure.
+# ---------------------------------------------------------------------------
+
+
+OK = "✅"
+BAD = "❌"
+WARN = "⚠️ "
+
+
+def _base_dir() -> Path:
+    return Path(
+        os.environ.get("LARRY_TELEGRAM_DIR", str(Path.home() / "larry-telegram"))
+    ).expanduser()
+
+
+def _fmt_age(seconds: float) -> str:
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m {seconds % 60}s"
+    if seconds < 86400:
+        hours, rem = divmod(seconds, 3600)
+        return f"{hours}h {rem // 60}m"
+    days, rem = divmod(seconds, 86400)
+    return f"{days}d {rem // 3600}h"
+
+
+class DoctorReport:
+    """Accumulator for doctor checks. Tracks pass/fail across sections."""
+
+    def __init__(self) -> None:
+        self.failures = 0
+        self.lines: list[str] = []
+
+    def section(self, name: str) -> None:
+        self.lines.append(f"\n{name}:")
+
+    def ok(self, msg: str) -> None:
+        self.lines.append(f"  {OK} {msg}")
+
+    def warn(self, msg: str) -> None:
+        self.lines.append(f"  {WARN} {msg}")
+
+    def fail(self, msg: str) -> None:
+        self.lines.append(f"  {BAD} {msg}")
+        self.failures += 1
+
+    def note(self, msg: str) -> None:
+        """Informational line with no pass/fail semantics — for log tails,
+        secondary file paths, anything that adds context but isn't a check."""
+        self.lines.append(f"  · {msg}")
+
+    def render(self) -> str:
+        out = ["=== Telegram Doctor ==="]
+        out.extend(self.lines)
+        out.append("")
+        out.append("=" * 60)
+        if self.failures == 0:
+            out.append(f"{OK} All checks passed")
+        else:
+            out.append(f"{BAD} {self.failures} checks failed")
+        return "\n".join(out)
+
+
+def _doctor_check_bot_pid(report: DoctorReport, base: Path) -> None:
+    report.section("TELEGRAM_BOT.PY")
+    pid_file = base / "bot.pid"
+    if not pid_file.exists():
+        report.fail(f"bot.pid missing at {pid_file}")
+        return
+    try:
+        pid = int(pid_file.read_text().strip())
+    except (ValueError, OSError) as e:
+        report.fail(f"bot.pid unreadable: {e}")
+        return
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        report.fail(f"bot.pid says {pid} but process is dead")
+        return
+    except PermissionError:
+        pass  # alive, owned by another user (shouldn't happen but OK)
+    try:
+        uptime = _fmt_age(time.time() - pid_file.stat().st_mtime)
+    except OSError:
+        uptime = "unknown"
+    report.ok(f"PID alive: {pid} (uptime {uptime})")
+
+
+def _doctor_check_socket(report: DoctorReport, base: Path) -> None:
+    report.section("UNIX SOCKET")
+    sock_path = base / "bot.sock"
+    if not sock_path.exists():
+        report.fail(f"bot.sock missing at {sock_path}")
+        return
+    s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    s.settimeout(2.0)
+    try:
+        s.connect(str(sock_path))
+    except (OSError, socket.timeout) as e:
+        report.fail(f"bot.sock at {sock_path} not accepting connections: {e}")
+        return
+    finally:
+        try:
+            s.close()
+        except OSError:
+            pass
+    report.ok(f"bot.sock: {sock_path} accepting connections")
+
+
+def _doctor_check_inbound_db(report: DoctorReport, base: Path) -> None:
+    report.section("INBOUND.DB")
+    db_path = base / "inbound.db"
+    if not db_path.exists():
+        report.fail(f"inbound.db missing at {db_path}")
+        return
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA busy_timeout=2000")
+        cur = conn.cursor()
+        cur.execute("SELECT COUNT(*) FROM inbound")
+        total = int(cur.fetchone()[0])
+        cur.execute(
+            "SELECT COUNT(*) FROM inbound WHERE delivered = 0 AND gate_action = 'allow'"
+        )
+        undelivered = int(cur.fetchone()[0])
+        cur.execute("SELECT MAX(ts) FROM inbound")
+        row = cur.fetchone()
+        last_ts = row[0] if row else None
+        conn.close()
+    except sqlite3.Error as e:
+        report.fail(f"inbound.db query failed: {e}")
+        return
+
+    last_write_age = "never"
+    last_write_secs: float | None = None
+    if last_ts:
+        # ts is ISO-8601 UTC (see telegram_bot.py). Be tolerant of fractional seconds.
+        parsed: float | None = None
+        for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
+            try:
+                import datetime as _dt
+
+                parsed = (
+                    _dt.datetime.strptime(last_ts, fmt)
+                    .replace(tzinfo=_dt.timezone.utc)
+                    .timestamp()
+                )
+                break
+            except ValueError:
+                continue
+        if parsed is None:
+            try:
+                import datetime as _dt
+
+                parsed = _dt.datetime.fromisoformat(
+                    last_ts.replace("Z", "+00:00")
+                ).timestamp()
+            except ValueError:
+                parsed = None
+        if parsed is not None:
+            last_write_secs = time.time() - parsed
+            last_write_age = f"{_fmt_age(last_write_secs)} ago"
+
+    summary = (
+        f"total messages: {total:,} / undelivered: {undelivered} / "
+        f"last write: {last_write_age}"
+    )
+
+    if undelivered > 100:
+        report.fail(
+            f"{summary} — backlog >100 means server.ts isn't draining the queue"
+        )
+    elif undelivered > 10:
+        report.warn(f"{summary} — backlog >10 rows, server.ts may be slow")
+    elif last_write_secs is not None and last_write_secs > 3600:
+        report.warn(f"{summary} — no writes in >1h (bot may be idle or stuck)")
+    else:
+        report.ok(summary)
+
+
+def _doctor_check_server_ts(report: DoctorReport) -> None:
+    report.section("SERVER.TS")
+    try:
+        r = subprocess.run(
+            ["pgrep", "-f", "bun.*server.ts"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        report.fail(f"pgrep failed: {e}")
+        return
+    pids = [p for p in r.stdout.strip().split() if p]
+    if len(pids) == 0:
+        # 0 is OK — Claude may not be running. Informational only.
+        report.warn("no server.ts process (OK if Claude isn't running)")
+    elif len(pids) == 1:
+        report.ok(f"1 process: pid={pids[0]}")
+    else:
+        report.fail(f"{len(pids)} processes running: {', '.join(pids)} — zombie bridge")
+
+
+def _find_plugin_server_ts() -> tuple[Path, str | None] | None:
+    """Locate the newest plugin-cache server.ts and return (path, hash).
+
+    Returns None if no cached server.ts is found. The hash may itself be
+    None if the file exists but can't be read (permissions, race with
+    plugin update, etc.) — callers should handle the (path, None) case.
+
+    Shared between the deploy check and the --paths inventory so both
+    agree on which file is the canonical deploy target.
+    """
+    try:
+        r = subprocess.run(
+            [
+                "find",
+                str(Path.home() / ".claude" / "plugins" / "cache"),
+                "-name",
+                "server.ts",
+                "-path",
+                "*telegram*",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    plugin_hits = [Path(line) for line in r.stdout.strip().splitlines() if line]
+    if not plugin_hits:
+        return None
+    # Prefer newest version dir — sort by mtime.
+    plugin_hits.sort(key=lambda p: p.stat().st_mtime if p.exists() else 0, reverse=True)
+    plugin = plugin_hits[0]
+    return plugin, _file_hash(plugin)
+
+
+def _doctor_check_deploy(report: DoctorReport) -> None:
+    report.section("DEPLOY")
+    plugin_info = _find_plugin_server_ts()
+    src = _source_server_ts()
+    if src is None:
+        # No canonical source configured — we can still validate the plugin
+        # cache exists, just not whether it's in sync with an upstream copy.
+        if plugin_info is None:
+            report.warn("no plugin-cache server.ts found (TELEGRAM_SOURCE_DIR unset)")
+            return
+        plugin_path, plugin_hash = plugin_info
+        report.note(
+            f"plugin cache: {plugin_hash} ({plugin_path}) — "
+            "set TELEGRAM_SOURCE_DIR to enable drift check"
+        )
+        return
+    if not src.exists():
+        report.fail(f"source server.ts missing at {src}")
+        return
+    src_hash = _file_hash(src)
+    if plugin_info is None:
+        report.warn(f"no plugin-cache server.ts found (src={src_hash})")
+        return
+    plugin_path, plugin_hash = plugin_info
+    if src_hash and plugin_hash and src_hash == plugin_hash:
+        report.ok(f"source == plugin: {src_hash} ({plugin_path})")
+    else:
+        report.warn(
+            f"source/plugin drift: src={src_hash} plugin={plugin_hash} — "
+            f"redeploy needed ({plugin_path})"
+        )
+
+
+def _doctor_check_token(report: DoctorReport) -> None:
+    token_file = Path.home() / ".claude" / "channels" / "telegram" / ".env"
+    if not token_file.exists():
+        report.fail(f"token file missing: {token_file}")
+        return
+    if not os.access(token_file, os.R_OK):
+        report.fail(f"token file {token_file} not readable")
+        return
+    try:
+        content = token_file.read_text()
+    except OSError as e:
+        report.fail(f"token file read failed: {e}")
+        return
+    has_token = any(
+        line.strip().startswith("TELEGRAM_BOT_TOKEN=")
+        and len(line.split("=", 1)[1].strip()) > 0
+        for line in content.splitlines()
+    )
+    if has_token:
+        report.ok("token: present")
+    else:
+        report.fail("token: missing TELEGRAM_BOT_TOKEN= line")
+
+
+def _doctor_check_access(report: DoctorReport) -> None:
+    access_file = Path.home() / ".claude" / "channels" / "telegram" / "access.json"
+    if not access_file.exists():
+        report.fail(f"access.json missing at {access_file}")
+        return
+    try:
+        data = json.loads(access_file.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        report.fail(f"access.json parse failed: {e}")
+        return
+    if "dmPolicy" not in data or "allowFrom" not in data:
+        report.fail("access.json missing dmPolicy/allowFrom keys")
+        return
+    allow = len(data.get("allowFrom", []) or [])
+    groups = len(data.get("groups", {}) or {})
+    pending = len(data.get("pending", {}) or {})
+    report.ok(f"access.json: {allow} allowed, {groups} groups, {pending} pending")
+
+
+def _doctor_check_hooks(report: DoctorReport, base: Path) -> None:
+    report.section("HOOKS")
+    settings_file = Path.home() / ".claude" / "settings.json"
+    if not settings_file.exists():
+        report.fail(f"settings.json missing at {settings_file}")
+        return
+    try:
+        settings = json.loads(settings_file.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        report.fail(f"settings.json parse failed: {e}")
+        return
+
+    # Walk all hook command strings looking for log-telegram*.py references.
+    hook_paths: list[tuple[str, str]] = []  # (basename, resolved_path)
+
+    def _walk(obj) -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                if k == "command" and isinstance(v, str) and "log-telegram" in v:
+                    # Heuristic: last .py token in the command is the script path.
+                    tokens = v.split()
+                    for tok in tokens:
+                        if tok.endswith(".py") and "log-telegram" in tok:
+                            hook_paths.append((Path(tok).name, tok))
+                            break
+                else:
+                    _walk(v)
+        elif isinstance(obj, list):
+            for item in obj:
+                _walk(item)
+
+    _walk(settings.get("hooks", {}))
+
+    if not hook_paths:
+        report.warn("no log-telegram*.py hook entries found in settings.json")
+    else:
+        seen: set[str] = set()
+        for name, path in hook_paths:
+            if path in seen:
+                continue
+            seen.add(path)
+            if Path(path).exists():
+                report.ok(f"{name}: {path}")
+            else:
+                report.fail(f"{name}: {path} does not exist on disk")
+
+    # telegram_log.db writable check.
+    log_db = base / "telegram_log.db"
+    if not log_db.exists():
+        try:
+            log_db.parent.mkdir(parents=True, exist_ok=True)
+            log_db.touch()
+        except OSError as e:
+            report.fail(f"telegram_log.db: cannot create at {log_db}: {e}")
+            return
+    if os.access(log_db, os.W_OK):
+        report.ok(f"telegram_log.db: writable ({log_db})")
+    else:
+        report.fail(f"telegram_log.db: {log_db} not writable")
+
+
+def _doctor_check_logs(report: DoctorReport, base: Path) -> None:
+    """Check log file state and surface the last few lines for context.
+
+    Igor's debugging rule: when something breaks, you almost always want to
+    see the actual log content, not just 'last write N ago'. The doctor
+    shows the tail inline so you don't have to cat a second file.
+    """
+    report.section("LOGS")
+
+    # server.log is the shared log stream — both telegram_bot.py (via
+    # its Python log() helper) and server.ts (via its bun log() helper)
+    # append to this file, tagged with [bot] or [mcp] respectively.
+    log_file = base / "server.log"
+    if not log_file.exists():
+        report.warn(f"server.log missing at {log_file}")
+    else:
+        try:
+            age = time.time() - log_file.stat().st_mtime
+        except OSError as e:
+            report.warn(f"server.log stat failed: {e}")
+        else:
+            if age < 600:
+                report.ok(f"server.log: last write {_fmt_age(age)} ago ({log_file})")
+            else:
+                report.warn(
+                    f"server.log: last write {_fmt_age(age)} ago (>10m — may be stale) ({log_file})"
+                )
+            # Tail the last 8 lines so the operator sees recent activity
+            # without leaving the doctor.
+            try:
+                lines = log_file.read_text(errors="replace").splitlines()[-8:]
+            except OSError as e:
+                report.warn(f"server.log unreadable: {e}")
+            else:
+                report.note(f"server.log tail ({len(lines)} lines):")
+                for line in lines:
+                    report.note(f"    {line}")
+
+    # Known auxiliary log locations. Show them even when present-but-stale
+    # so the operator knows where to look by hand.
+    aux_logs = [
+        ("startup.log", base / "startup.log"),
+        (
+            "legacy server.log",
+            Path.home() / ".claude" / "channels" / "telegram" / "server.log",
+        ),
+        ("watchdog reload log", Path("/tmp/watchdog_reload.log")),
+    ]
+    for label, p in aux_logs:
+        if p.exists():
+            try:
+                age = time.time() - p.stat().st_mtime
+            except OSError:
+                report.note(f"{label}: exists at {p}")
+            else:
+                report.note(f"{label}: {_fmt_age(age)} ago — {p}")
+
+
+def run_doctor() -> int:
+    """Run all doctor checks and print a report. Returns exit code."""
+    base = _base_dir()
+    report = DoctorReport()
+    _doctor_check_bot_pid(report, base)
+    _doctor_check_socket(report, base)
+    _doctor_check_inbound_db(report, base)
+    _doctor_check_server_ts(report)
+    _doctor_check_deploy(report)
+    report.section("CONFIG")
+    _doctor_check_token(report)
+    _doctor_check_access(report)
+    _doctor_check_hooks(report, base)
+    _doctor_check_logs(report, base)
+    print(report.render())
+    return 1 if report.failures > 0 else 0
+
+
+def run_paths() -> int:
+    """Print every file the two-process Telegram chain cares about.
+
+    This used to live as a table in the /telegram-debug skill — it kept
+    rotting as paths moved (e.g. the STATE_DIR→BASE_DIR migration in
+    2026-04 made the old table actively wrong). Putting it in code means
+    the single source of truth is the constants at the top of this file
+    and the --paths output is always correct.
+
+    Skill author's rule: if a diagnostic is "here's a list of files and
+    whether they exist," it goes here, not in prose.
+    """
+    base = _base_dir()
+    plugin_info = _find_plugin_server_ts()
+    plugin_path = plugin_info[0] if plugin_info else None
+
+    groups: list[tuple[str, list[tuple[str, Path]]]] = [
+        (
+            "Runtime state (base = LARRY_TELEGRAM_DIR)",
+            [
+                ("bot.pid", base / "bot.pid"),
+                ("bot.sock", base / "bot.sock"),
+                ("inbound.db", base / "inbound.db"),
+                ("telegram_log.db", base / "telegram_log.db"),
+                ("server.log", base / "server.log"),
+                ("startup.log", base / "startup.log"),
+                ("attachments/", base / "attachments"),
+            ],
+        ),
+        (
+            "Credential store (plugin-managed)",
+            [
+                (
+                    ".env (BOT_TOKEN)",
+                    Path.home() / ".claude" / "channels" / "telegram" / ".env",
+                ),
+                (
+                    "access.json",
+                    Path.home() / ".claude" / "channels" / "telegram" / "access.json",
+                ),
+                (
+                    "approved/",
+                    Path.home() / ".claude" / "channels" / "telegram" / "approved",
+                ),
+            ],
+        ),
+        *(
+            [
+                (
+                    "Source tree (TELEGRAM_SOURCE_DIR)",
+                    [
+                        ("telegram_bot.py", _source_dir() / "telegram_bot.py"),  # type: ignore[operator]
+                        ("server.ts", _source_dir() / "server.ts"),  # type: ignore[operator]
+                        ("hooks/", _source_dir() / "hooks"),  # type: ignore[operator]
+                    ],
+                )
+            ]
+            if _source_dir()
+            else []
+        ),
+        (
+            "Plugin cache (deploy target)",
+            [
+                (
+                    "server.ts (deployed)",
+                    plugin_path if plugin_path else Path("/nonexistent"),
+                ),
+            ],
+        ),
+        (
+            "Legacy / transition (should be empty post-migration)",
+            [
+                (
+                    "~/.claude/channels/telegram/server.log",
+                    Path.home() / ".claude" / "channels" / "telegram" / "server.log",
+                ),
+                (
+                    "~/.claude/channels/telegram/bot.pid",
+                    Path.home() / ".claude" / "channels" / "telegram" / "bot.pid",
+                ),
+                (
+                    "~/.claude/channels/telegram/inbound.jsonl",
+                    Path.home() / ".claude" / "channels" / "telegram" / "inbound.jsonl",
+                ),
+                (
+                    "~/.claude/telegram_log.db",
+                    Path.home() / ".claude" / "telegram_log.db",
+                ),
+            ],
+        ),
+    ]
+
+    print("=== Telegram chain file map ===\n")
+    for heading, items in groups:
+        print(f"{heading}:")
+        for label, path in items:
+            if path == Path("/nonexistent"):
+                print(f"  ? {label:<40s} (plugin cache not found)")
+                continue
+            if path.exists():
+                mark = OK
+                try:
+                    size = path.stat().st_size
+                    extra = f" ({size}B)" if path.is_file() and size < 1024 else ""
+                except OSError:
+                    extra = ""
+                print(f"  {mark} {label:<40s} {path}{extra}")
+            else:
+                print(f"  {BAD} {label:<40s} {path}  (missing)")
+        print()
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Telegram MCP diagnostic tool")
+    parser.add_argument("--json", action="store_true", help="JSON output (pipe to jq)")
+    parser.add_argument(
+        "--tail",
+        type=int,
+        default=20,
+        help="Number of log lines/messages to show (default: 20)",
+    )
+    parser.add_argument(
+        "--doctor",
+        action="store_true",
+        help="Validate the two-process chain end-to-end (exit 1 on failure)",
+    )
+    parser.add_argument(
+        "--paths",
+        action="store_true",
+        help="Print every file the two-process chain cares about, with existence check",
+    )
+    args = parser.parse_args()
+
+    if args.doctor:
+        sys.exit(run_doctor())
+
+    if args.paths:
+        sys.exit(run_paths())
+
+    diag = full_diagnostic(tail=args.tail)
+
+    if args.json:
+        print(json.dumps(diag, indent=2, default=str))
+    else:
+        print_report(diag)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/harden-telegram/tools/watchdog.py
+++ b/skills/harden-telegram/tools/watchdog.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""
+Telegram MCP watchdog — auto-recover Claude Code's Telegram plugin.
+
+When the bun process running server.ts dies, this watchdog detects the death
+and sends /reload-plugins into Claude Code's tmux pane via tmux send-keys.
+The reloaded plugin spawns a new bun process, which spawns a new watchdog,
+so the old one exits (self-replacing chain).
+
+Spawned by server.ts as a detached process. Accepts context via env vars:
+  WATCHDOG_BUN_PID     - PID of the bun process to monitor
+  WATCHDOG_CLAUDE_PID  - PID of the Claude Code process
+  WATCHDOG_TMUX_PANE   - tmux pane identifier (e.g. %3)
+
+Singleton: only one watchdog runs at a time (PID file at /tmp/telegram-watchdog.pid).
+"""
+
+import fcntl
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+PID_FILE = os.path.join(
+    os.environ.get("HOME", "/tmp"), ".claude", "channels", "telegram", "watchdog.pid"
+)
+POLL_INTERVAL = 5  # seconds between liveness checks
+SETTLE_DELAY = 2  # seconds to wait after bun death before recovery
+NEW_BUN_TIMEOUT = 60  # seconds to wait for new bun to appear
+
+
+def log(msg: str) -> None:
+    """Log to stderr with timestamp and PID."""
+    ts = time.strftime("%Y-%m-%dT%H:%M:%S%z")
+    print(f"[{ts}] watchdog[{os.getpid()}]: {msg}", file=sys.stderr, flush=True)
+
+
+def is_pid_alive(pid: int) -> bool:
+    """Check if a process with the given PID is alive."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Process exists but we can't signal it — still alive
+        return True
+    except OSError:
+        return False
+
+
+def write_pid_file() -> None:
+    """Write our PID to the PID file."""
+    with open(PID_FILE, "w") as f:
+        f.write(str(os.getpid()))
+
+
+def read_pid_file() -> int | None:
+    """Read PID from the PID file, or None if missing/invalid."""
+    try:
+        with open(PID_FILE, "r") as f:
+            return int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def cleanup_pid_file() -> None:
+    """Remove PID file if it belongs to us."""
+    try:
+        existing = read_pid_file()
+        if existing == os.getpid():
+            os.unlink(PID_FILE)
+            log("cleaned up PID file")
+    except OSError:
+        pass
+
+
+_lock_fd: int | None = None
+
+
+def acquire_singleton() -> bool:
+    """Acquire singleton lock via PID file with flock to prevent races."""
+    global _lock_fd
+    try:
+        _lock_fd = os.open(PID_FILE, os.O_CREAT | os.O_WRONLY, 0o644)
+        fcntl.flock(_lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        os.ftruncate(_lock_fd, 0)
+        os.write(_lock_fd, str(os.getpid()).encode())
+        os.fsync(_lock_fd)
+        # Keep fd open — lock held for process lifetime
+        return True
+    except OSError:
+        existing_pid = read_pid_file()
+        log(f"another watchdog is running (PID {existing_pid}), exiting")
+        if _lock_fd is not None:
+            os.close(_lock_fd)
+            _lock_fd = None
+        return False
+
+
+def tmux_send_keys(pane: str, *keys: str) -> bool:
+    """Send keys to a tmux pane. Each arg is a separate send-keys argument.
+    Use "Enter", "Escape" etc as separate args for special keys."""
+    try:
+        result = subprocess.run(
+            ["tmux", "send-keys", "-t", pane, *keys],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            log(f"tmux send-keys failed: {result.stderr.strip()}")
+            return False
+        return True
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        log(f"tmux send-keys error: {e}")
+        return False
+
+
+def wait_for_new_bun(timeout: int = NEW_BUN_TIMEOUT) -> bool:
+    """Wait for a new bun server.ts process to appear."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ["pgrep", "-f", "bun.*server.ts"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                log(
+                    f"new bun process detected: PID {result.stdout.strip().splitlines()[0]}"
+                )
+                return True
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+        time.sleep(2)
+    return False
+
+
+def wait_for_idle_prompt(tmux_pane: str, timeout: int = 30) -> bool:
+    """Wait until Claude's TUI shows an idle prompt (empty ❯ line)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        capture = tmux_capture_pane(tmux_pane)
+        lines = capture.rstrip().splitlines()
+        # Look for an empty prompt: line with just "❯" or "❯ " (no user input)
+        for line in lines[-5:]:
+            stripped = line.strip()
+            if stripped == "❯" or stripped == "❯ ":
+                log("detected idle prompt")
+                return True
+        time.sleep(1)
+    log(f"idle prompt not detected within {timeout}s")
+    return False
+
+
+def do_recovery(tmux_pane: str) -> bool:
+    """Execute the recovery sequence via tmux send-keys."""
+    log("starting recovery sequence")
+
+    # Step 1: Let Claude notice the disconnect
+    log("waiting 2s for Claude to notice disconnect")
+    time.sleep(SETTLE_DELAY)
+
+    # Step 2: Escape x2 to cancel generation + dismiss any prompts
+    log("sending Escape x2 + Enter x3 to clear state")
+    tmux_send_keys(tmux_pane, "Escape")
+    time.sleep(0.3)
+    tmux_send_keys(tmux_pane, "Escape")
+    time.sleep(0.3)
+    # Enter x3 to dismiss any queued input or confirmation prompts
+    tmux_send_keys(tmux_pane, "Enter")
+    time.sleep(0.3)
+    tmux_send_keys(tmux_pane, "Enter")
+    time.sleep(0.3)
+    tmux_send_keys(tmux_pane, "Enter")
+    time.sleep(0.5)
+
+    # Step 3: Wait for Claude to return to idle prompt
+    log("waiting for idle prompt...")
+    if not wait_for_idle_prompt(tmux_pane, timeout=30):
+        log("Claude not idle after 30s — trying /reload-plugins anyway")
+
+    # Step 4: Clear any text in the input box, then send /reload-plugins
+    tmux_send_keys(tmux_pane, "C-u")  # Ctrl-U clears the input line
+    time.sleep(0.3)
+    log("sending /reload-plugins")
+    if not tmux_send_keys(tmux_pane, "/reload-plugins", "Enter"):
+        log("failed to send /reload-plugins")
+        return False
+
+    # Step 5: Wait for reload and verify it ran
+    log("waiting for reload to complete...")
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        capture = tmux_capture_pane(tmux_pane)
+        if "Reloaded:" in capture:
+            log("confirmed: /reload-plugins executed successfully")
+            return True
+        time.sleep(1)
+
+    log("could not confirm /reload-plugins ran — 'Reloaded:' not found in pane")
+    return False
+
+
+def detect_tmux_pane() -> str:
+    """Detect the current tmux pane ID."""
+    try:
+        result = subprocess.run(
+            ["tmux", "display-message", "-p", "#{pane_id}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return ""
+
+
+def find_claude_pid() -> int | None:
+    """Find the Claude Code process PID by searching for the process."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "claude.*--dangerously-skip-permissions"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            # Return the first match
+            return int(result.stdout.strip().splitlines()[0])
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+        pass
+    return None
+
+
+def find_bun_pid() -> int | None:
+    """Find the bun server.ts process PID."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "bun.*server.ts"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return int(result.stdout.strip().splitlines()[0])
+    except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
+        pass
+    return None
+
+
+def tmux_capture_pane(pane: str) -> str:
+    """Capture the last 100 lines of a tmux pane (including scrollback)."""
+    try:
+        result = subprocess.run(
+            ["tmux", "capture-pane", "-t", pane, "-p", "-S", "-100"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return ""
+
+
+def cmd_reload(tmux_pane: str | None = None, message: str | None = None) -> None:
+    """Send /reload-plugins to Claude's tmux pane. Full live test."""
+    pane = tmux_pane or detect_tmux_pane()
+    if not pane:
+        log("ERROR: not in a tmux session (no pane detected)")
+        sys.exit(1)
+
+    claude_pid = find_claude_pid()
+    bun_pid = find_bun_pid()
+
+    log("=== Watchdog Reload Test ===")
+    log(f"tmux pane:  {pane}")
+    log(f"claude PID: {claude_pid or 'NOT FOUND'}")
+    log(f"bun PID:    {bun_pid or 'NOT FOUND'}")
+    log(f"our PID:    {os.getpid()}")
+
+    # Capture pane BEFORE
+    log("--- BEFORE capture ---")
+    before = tmux_capture_pane(pane)
+    for line in before.rstrip().splitlines()[-10:]:
+        log(f"  {line}")
+
+    # Send the actual recovery sequence
+    # Run the actual recovery sequence
+    success = do_recovery(pane)
+
+    # Capture pane AFTER
+    log("--- AFTER capture ---")
+    after = tmux_capture_pane(pane)
+    for line in after.rstrip().splitlines()[-10:]:
+        log(f"  {line}")
+
+    if success:
+        log("SUCCESS: recovery sequence completed")
+        if message:
+            log(f"sending follow-up message: {message}")
+            time.sleep(2)  # let reload settle
+            tmux_send_keys(pane, "C-u")
+            time.sleep(0.2)
+            tmux_send_keys(pane, message, "Enter")
+    else:
+        log("FAILED: recovery sequence did not confirm reload")
+
+    # Write state file
+    state_file = os.path.join(
+        os.environ.get("HOME", "/tmp"),
+        ".claude",
+        "channels",
+        "telegram",
+        "watchdog_test.json",
+    )
+    state = {
+        "ts": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "tmux_pane": pane,
+        "claude_pid": claude_pid,
+        "bun_pid": bun_pid,
+        "watchdog_pid": os.getpid(),
+        "command": "reload",
+        "success": success,
+        "before_last_line": before.rstrip().splitlines()[-1] if before.strip() else "",
+        "after_last_line": after.rstrip().splitlines()[-1] if after.strip() else "",
+    }
+    try:
+        with open(state_file, "w") as f:
+            json.dump(state, f, indent=2)
+        log(f"wrote state to {state_file}")
+    except OSError as e:
+        log(f"could not write state file: {e}")
+
+    log("=== Reload Test Complete ===")
+
+
+def _parse_cli():
+    """Parse CLI args. Returns (command, pane, pid) or falls through to daemon mode."""
+    # Usage:
+    #   watchdog.py reload [--pane %17] [--pid 12345]
+    #   watchdog.py                          (daemon mode, uses env vars)
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Telegram MCP watchdog")
+    sub = parser.add_subparsers(dest="command")
+
+    reload_p = sub.add_parser(
+        "reload", help="Send /reload-plugins to Claude's tmux pane"
+    )
+    reload_p.add_argument(
+        "--pane", help="tmux pane ID (e.g. %%17). Auto-detects if omitted."
+    )
+    reload_p.add_argument(
+        "--pid", type=int, help="PID of process in target pane. Used to find the pane."
+    )
+    reload_p.add_argument(
+        "--message",
+        "-m",
+        help="Message to send to Claude after reload (e.g. 'Larry reloaded, I\\'m back')",
+    )
+
+    return parser.parse_args()
+
+
+def pane_from_pid(pid: int) -> str | None:
+    """Find the tmux pane containing a given PID by walking pane PIDs."""
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode != 0:
+            return None
+        for line in result.stdout.strip().splitlines():
+            parts = line.split()
+            if len(parts) == 2:
+                pane_id, pane_pid = parts
+                # Check if target PID is a descendant of this pane's shell
+                try:
+                    children = subprocess.run(
+                        ["pgrep", "-P", pane_pid, "--ns", pane_pid],
+                        capture_output=True,
+                        text=True,
+                        timeout=5,
+                    )
+                    # Check pane_pid itself and all descendants
+                    if str(pid) == pane_pid:
+                        return pane_id
+                    if children.returncode == 0 and str(pid) in children.stdout:
+                        return pane_id
+                except (subprocess.TimeoutExpired, FileNotFoundError):
+                    pass
+                # Simpler fallback: check /proc/<pid>/stat for ppid chain
+                try:
+                    check_pid = pid
+                    for _ in range(10):  # walk up max 10 levels
+                        with open(f"/proc/{check_pid}/stat") as f:
+                            ppid = int(f.read().split()[3])
+                        if str(ppid) == pane_pid:
+                            return pane_id
+                        if ppid <= 1:
+                            break
+                        check_pid = ppid
+                except (FileNotFoundError, ValueError, IndexError):
+                    pass
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def main() -> None:
+    args = _parse_cli()
+
+    if args.command == "reload":
+        # Resolve pane
+        pane = args.pane
+        if not pane and args.pid:
+            log(f"looking up tmux pane for PID {args.pid}...")
+            pane = pane_from_pid(args.pid)
+            if pane:
+                log(f"found pane {pane} for PID {args.pid}")
+            else:
+                log(f"could not find tmux pane for PID {args.pid}")
+                sys.exit(1)
+        if not pane:
+            pane = detect_tmux_pane()
+        if not pane:
+            log("ERROR: no pane specified and auto-detect failed. Use --pane or --pid.")
+            sys.exit(1)
+        cmd_reload(pane, message=args.message)
+        return
+
+    # --- Daemon mode: parse environment ---
+    bun_pid_str = os.environ.get("WATCHDOG_BUN_PID", "")
+    claude_pid_str = os.environ.get("WATCHDOG_CLAUDE_PID", "")
+    tmux_pane = os.environ.get("WATCHDOG_TMUX_PANE", "")
+
+    if not bun_pid_str or not claude_pid_str:
+        log("WATCHDOG_BUN_PID and WATCHDOG_CLAUDE_PID must be set")
+        sys.exit(1)
+
+    if not tmux_pane:
+        log("WATCHDOG_TMUX_PANE is empty/unset — not in a tmux session, exiting")
+        sys.exit(0)
+
+    try:
+        bun_pid = int(bun_pid_str)
+        claude_pid = int(claude_pid_str)
+    except ValueError:
+        log(f"invalid PID values: bun={bun_pid_str!r} claude={claude_pid_str!r}")
+        sys.exit(1)
+
+    log(f"starting: bun_pid={bun_pid} claude_pid={claude_pid} tmux_pane={tmux_pane}")
+
+    # --- Singleton ---
+    if not acquire_singleton():
+        sys.exit(0)
+
+    # --- Signal handling ---
+    def handle_signal(signum: int, _frame: object) -> None:
+        sig_name = signal.Signals(signum).name
+        log(f"received {sig_name}, exiting")
+        cleanup_pid_file()
+        sys.exit(0)
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    # --- Main loop ---
+    try:
+        while True:
+            time.sleep(POLL_INTERVAL)
+
+            # Check Claude first — if Claude is gone, nothing to recover
+            if not is_pid_alive(claude_pid):
+                log("Claude process is dead, nothing to recover — exiting")
+                break
+
+            # Check bun
+            if not is_pid_alive(bun_pid):
+                log(f"bun process (PID {bun_pid}) is dead!")
+
+                if do_recovery(tmux_pane):
+                    log("recovery sequence sent, waiting for new bun process")
+                    if wait_for_new_bun():
+                        log(
+                            "new bun process started — new watchdog will take over, exiting"
+                        )
+                    else:
+                        log("no new bun process appeared within timeout")
+                else:
+                    log("recovery sequence failed")
+                # Either way, exit — if recovery worked, new watchdog replaces us;
+                # if it failed, we can't do more.
+                break
+    finally:
+        cleanup_pid_file()
+
+    log("watchdog exiting")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `/harden-telegram` skill for diagnosing and recovering the two-process Telegram MCP chain
- Vendors `telegram_debug.py` (doctor + paths + log tail) and `watchdog.py` into `skills/harden-telegram/tools/` — no source-repo coupling
- Folds `durable-telegram` design reference into `harden-telegram/design.md`
- Updates `CLAUDE.md` with two new conventions: vendor doctors into skills, and wait for N=2 before abstracting

## Test plan

- [ ] Verify `skills/harden-telegram/SKILL.md` loads in Claude Code via `/harden-telegram`
- [ ] Run `skills/harden-telegram/tools/telegram_debug.py --doctor` on a machine with the Telegram bridge running
- [ ] Confirm `--paths` prints the file inventory without hardcoded paths (respects env vars)
- [ ] Check watchdog runs without crashing on a clean machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)