### PR TITLE
harden-telegram: doctor learns multi-session bridge ownership

### DIFF
--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -84,12 +84,15 @@ Doctor catches source/plugin drift automatically via sha256 compare when `TELEGR
 
 **Cause:** `/reload-plugins` re-reads skills/hooks/agents/plugin config but leaves running MCP server processes alone. The existing bun process keeps serving the old code.
 
-**Fix:** kill the old bun first, then reload — the next MCP request respawns from the plugin cache:
+**Fix:** kill ONLY this session's bridge, then reload — the next MCP request respawns from the plugin cache. Run the doctor first to find the bridge owned by this session (look for the `SERVER.TS` line that prints `pid=<n> (claude=<your-claude-pid>)`):
 
 ```bash
-pkill -TERM -f 'bun.*server.ts'
+python3 ~/.claude/skills/harden-telegram/tools/telegram_debug.py --doctor
+kill -TERM <pid-from-doctor>
 # Then run /reload-plugins from another context (or via the watchdog below).
 ```
+
+**DO NOT** use `pkill -f 'bun.*server.ts'` — that's a broadcast kill that also nukes bridges owned by *other* Claude sessions on the same machine. Each Claude session spawns its own bun `server.ts` child. The doctor classifies them as `ours` / `other-session` / `orphaned` by walking the `ppid` chain up to the nearest `claude` ancestor; trust that, never age or count. The historical "older bun = zombie" heuristic is wrong — multi-session machines routinely have several legitimate bridges running concurrently.
 
 ### 2c. Watchdog reload (from a background shell — NEVER foreground)
 

--- a/skills/harden-telegram/tools/telegram_debug.py
+++ b/skills/harden-telegram/tools/telegram_debug.py
@@ -84,6 +84,173 @@ def _proc_cwd(pid: str) -> str | None:
         return None
 
 
+def parse_proc_stat(data: str) -> tuple[str, int] | None:
+    """Parse /proc/<pid>/stat contents into (comm, ppid).
+
+    The comm field is wrapped in parens and can contain spaces or parens
+    itself, so we anchor on the *last* ')' rather than splitting whitespace
+    naively. Returns None on any malformed input.
+    """
+    rparen = data.rfind(")")
+    lparen = data.find("(")
+    if rparen == -1 or lparen == -1 or rparen < lparen:
+        return None
+    comm = data[lparen + 1 : rparen]
+    tail = data[rparen + 1 :].split()
+    # tail[0] is state, tail[1] is ppid
+    if len(tail) < 2:
+        return None
+    try:
+        ppid = int(tail[1])
+    except ValueError:
+        return None
+    return (comm, ppid)
+
+
+def _read_proc_stat(pid: int) -> tuple[str, int] | None:
+    """Return (comm, ppid) for a PID, or None if the process is gone."""
+    try:
+        data = Path(f"/proc/{pid}/stat").read_text()
+    except (OSError, ValueError):
+        return None
+    return parse_proc_stat(data)
+
+
+def _pid_alive(pid: int) -> bool:
+    """Best-effort liveness probe that works across UIDs."""
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        # Signal denied → the process exists but isn't ours. Still alive.
+        return True
+    except OSError:
+        return False
+
+
+def _find_owning_claude(
+    pid: int,
+    *,
+    stat_reader=_read_proc_stat,
+) -> int | None:
+    """Walk the ppid chain from `pid` until we hit a process whose comm starts with `claude`.
+
+    Returns the PID of the nearest claude ancestor, or None if the chain
+    reaches init without finding one (or breaks because a process went
+    away mid-walk). `stat_reader` is injected for tests.
+
+    Matches `claude`, `claude-code`, `claude-1m`, etc. Linux truncates comm
+    to TASK_COMM_LEN-1 = 15 chars, so any launcher/shim that starts with
+    "claude" fits and still matches here.
+    """
+    seen: set[int] = set()
+    current = pid
+    while current and current > 1:
+        # Guard against self-loops and pid-reuse cycles.
+        if current in seen:
+            return None
+        seen.add(current)
+        info = stat_reader(current)
+        if info is None:
+            return None
+        comm, ppid = info
+        if comm.startswith("claude"):
+            return current
+        current = ppid
+    return None
+
+
+def _read_proc_cmdline(pid: int) -> list[str] | None:
+    """Return argv of a PID from /proc/<pid>/cmdline, or None if unreadable.
+
+    The file is null-separated; a trailing null terminates the final arg.
+    """
+    try:
+        data = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except (OSError, ValueError):
+        return None
+    if not data:
+        return None
+    parts = data.rstrip(b"\x00").split(b"\x00")
+    return [p.decode("utf-8", errors="replace") for p in parts]
+
+
+def session_subscribed_to_telegram(argv: list[str]) -> bool:
+    """Return True iff argv has a `--channels` value mentioning telegram.
+
+    Accepts both `--channels X` and `--channels=X`. A single `--channels`
+    flag may carry a comma-separated list (`a,b,c`) — we split and check
+    each entry. Values are matched case-insensitively against the literal
+    substring 'telegram' to stay tolerant of plugin name variations like
+    `plugin:telegram@claude-plugins-official`.
+    """
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        value: str | None = None
+        if arg == "--channels":
+            if i + 1 < len(argv):
+                value = argv[i + 1]
+                i += 2
+            else:
+                i += 1
+                continue
+        elif arg.startswith("--channels="):
+            value = arg[len("--channels=") :]
+            i += 1
+        else:
+            i += 1
+            continue
+        if value is None:
+            continue
+        for entry in value.split(","):
+            if "telegram" in entry.lower():
+                return True
+    return False
+
+
+def classify_bridges(
+    pids: list[int],
+    our_claude_pid: int | None,
+    *,
+    stat_reader=_read_proc_stat,
+    is_alive=_pid_alive,
+) -> list[dict]:
+    """Classify each bun server.ts PID by which Claude session owns it.
+
+    Classifications:
+      - "ours":          owning claude == our_claude_pid
+      - "other-session": owning claude is alive but not ours
+      - "orphaned":      no owning claude found, or it's dead
+
+    Pure function — all I/O is injected via `stat_reader` / `is_alive`
+    so tests can drive it without touching /proc.
+    """
+    bridges: list[dict] = []
+    for pid in pids:
+        owning = _find_owning_claude(pid, stat_reader=stat_reader)
+        if owning is None:
+            classification = "orphaned"
+        elif owning == our_claude_pid:
+            classification = "ours"
+        elif is_alive(owning):
+            classification = "other-session"
+        else:
+            classification = "orphaned"
+        bridges.append(
+            {
+                "pid": pid,
+                "owning_claude": owning,
+                "classification": classification,
+            }
+        )
+    return bridges
+
+
 def check_claude_sessions() -> list[dict]:
     """Find all Claude Code sessions."""
     output = run(["bash", "-c", r"\ps -ef | grep -v grep | grep claude.*dangerously"])
@@ -644,14 +811,114 @@ def _doctor_check_server_ts(report: DoctorReport) -> None:
     except (FileNotFoundError, subprocess.TimeoutExpired) as e:
         report.fail(f"pgrep failed: {e}")
         return
-    pids = [p for p in r.stdout.strip().split() if p]
-    if len(pids) == 0:
-        # 0 is OK — Claude may not be running. Informational only.
-        report.warn("no server.ts process (OK if Claude isn't running)")
-    elif len(pids) == 1:
-        report.ok(f"1 process: pid={pids[0]}")
+
+    # Filter to the Telegram plugin's bridges by /proc/<pid>/cwd.
+    # Other bun server.ts processes (unrelated projects) don't count here.
+    candidate_pids = [int(p) for p in r.stdout.strip().split() if p.isdigit()]
+    tg_pids = [
+        pid
+        for pid in candidate_pids
+        if TELEGRAM_PLUGIN_MARKER in (_proc_cwd(str(pid)) or "")
+    ]
+
+    our_claude = _find_owning_claude(os.getpid())
+    bridges = classify_bridges(tg_pids, our_claude)
+
+    ours = [b for b in bridges if b["classification"] == "ours"]
+    others = [b for b in bridges if b["classification"] == "other-session"]
+    orphans = [b for b in bridges if b["classification"] == "orphaned"]
+
+    if our_claude is None:
+        # Running outside a Claude session (cron, shell, CI). We can't do
+        # session-scoped ownership — fall back to a looser status line.
+        if not tg_pids:
+            report.warn("no telegram server.ts process (OK if no Claude is running)")
+        else:
+            pids_str = ", ".join(str(p) for p in tg_pids)
+            report.note(
+                f"{len(tg_pids)} telegram bridge(s) running ({pids_str}) — "
+                "doctor not inside a Claude session, skipping ownership check"
+            )
+        if orphans:
+            pids_str = ", ".join(str(b["pid"]) for b in orphans)
+            report.warn(
+                f"{len(orphans)} orphaned bridge(s): {pids_str} — "
+                "owning Claude is gone"
+            )
+        return
+
+    if len(ours) == 0:
+        report.warn(
+            f"no bridge owned by this Claude session (pid={our_claude}) — "
+            "MCP tools may be disconnected; /reload-plugins to respawn"
+        )
+    elif len(ours) == 1:
+        report.ok(
+            f"1 bridge for this session: pid={ours[0]['pid']} (claude={our_claude})"
+        )
     else:
-        report.fail(f"{len(pids)} processes running: {', '.join(pids)} — zombie bridge")
+        pids_str = ", ".join(str(b["pid"]) for b in ours)
+        report.fail(
+            f"{len(ours)} bridges owned by this Claude session ({pids_str}) — "
+            "true zombie, kill the extras"
+        )
+
+    if others:
+        summary = ", ".join(
+            f"{b['pid']}→claude:{b['owning_claude']}" for b in others
+        )
+        report.note(
+            f"{len(others)} bridge(s) in other Claude sessions: {summary} — ignored"
+        )
+
+    if orphans:
+        pids_str = ", ".join(str(b["pid"]) for b in orphans)
+        report.warn(
+            f"{len(orphans)} orphaned bridge(s): {pids_str} — "
+            "owning Claude is dead, safe to kill"
+        )
+
+
+def _doctor_check_session_subscription(report: DoctorReport) -> None:
+    """Warn if this Claude session wasn't launched with --channels telegram.
+
+    Without `--channels plugin:telegram@claude-plugins-official`, the MCP
+    bridge can still send messages (plain tool call) but inbound Telegram
+    messages never surface as `<channel source="telegram">` blocks — the
+    harness drops the notifications. This check catches the silent-
+    receive-path failure that is otherwise only detectable by sending a
+    test message and watching it vanish.
+    """
+    report.section("SESSION")
+    our_claude = _find_owning_claude(os.getpid())
+    if our_claude is None:
+        report.note(
+            "doctor not running inside a Claude session — "
+            "subscription check skipped"
+        )
+        return
+    argv = _read_proc_cmdline(our_claude)
+    if argv is None:
+        report.warn(
+            f"could not read /proc/{our_claude}/cmdline — "
+            "subscription check skipped"
+        )
+        return
+    if session_subscribed_to_telegram(argv):
+        report.ok(
+            f"claude pid={our_claude} launched with --channels telegram; "
+            "inbound messages will surface as channel blocks"
+        )
+    else:
+        # warn, not fail: send-only sessions (outbound MCP tool calls without
+        # needing inbound notifications) are a legitimate use case, so don't
+        # poison the doctor's exit code.
+        report.warn(
+            f"claude pid={our_claude} launched WITHOUT --channels telegram — "
+            "bridge can send but incoming messages won't surface. "
+            "Relaunch with: claude ... "
+            "--channels plugin:telegram@claude-plugins-official"
+        )
 
 
 def _find_plugin_server_ts() -> tuple[Path, str | None] | None:
@@ -892,6 +1159,7 @@ def run_doctor() -> int:
     _doctor_check_socket(report, base)
     _doctor_check_inbound_db(report, base)
     _doctor_check_server_ts(report)
+    _doctor_check_session_subscription(report)
     _doctor_check_deploy(report)
     report.section("CONFIG")
     _doctor_check_token(report)

--- a/skills/harden-telegram/tools/test_telegram_debug.py
+++ b/skills/harden-telegram/tools/test_telegram_debug.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Unit tests for telegram_debug.py pure functions.
+
+Run with: python3 -m unittest test_telegram_debug.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from telegram_debug import (  # noqa: E402
+    _find_owning_claude,
+    classify_bridges,
+    parse_proc_stat,
+    session_subscribed_to_telegram,
+)
+
+
+def make_stat_reader(table: dict[int, tuple[str, int]]):
+    """Build a fake stat reader from a {pid: (comm, ppid)} table."""
+    def reader(pid: int):
+        return table.get(pid)
+    return reader
+
+
+def make_alive(alive_pids: set[int]):
+    def is_alive(pid: int) -> bool:
+        return pid in alive_pids
+    return is_alive
+
+
+class TestParseProcStat(unittest.TestCase):
+    def test_simple_comm(self):
+        self.assertEqual(
+            parse_proc_stat("123 (claude) S 99 123 99 ...\n"),
+            ("claude", 99),
+        )
+
+    def test_comm_with_space(self):
+        self.assertEqual(
+            parse_proc_stat("123 (my proc) S 99 123 99 ...\n"),
+            ("my proc", 99),
+        )
+
+    def test_comm_with_inner_parens(self):
+        # The whole point of anchoring on rfind(')') — a naive split on
+        # space or on first ')' would truncate the comm mid-string.
+        self.assertEqual(
+            parse_proc_stat("123 (weird )name) S 99 123 99 ...\n"),
+            ("weird )name", 99),
+        )
+
+    def test_comm_with_only_parens(self):
+        self.assertEqual(
+            parse_proc_stat("7 (()) S 1 0 0 ...\n"),
+            ("()", 1),
+        )
+
+    def test_missing_parens_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 bad line\n"))
+
+    def test_truncated_after_comm_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 (claude)"))
+
+    def test_non_numeric_ppid_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 (claude) S ??? 123 99 ...\n"))
+
+    def test_empty_string_returns_none(self):
+        self.assertIsNone(parse_proc_stat(""))
+
+
+class TestFindOwningClaude(unittest.TestCase):
+    def test_direct_child_of_claude(self):
+        table = {
+            100: ("bun", 99),
+            99: ("claude", 1),
+        }
+        self.assertEqual(_find_owning_claude(100, stat_reader=make_stat_reader(table)), 99)
+
+    def test_grandchild_through_shell(self):
+        table = {
+            200: ("python3", 150),
+            150: ("bash", 99),
+            99: ("claude", 1),
+        }
+        self.assertEqual(_find_owning_claude(200, stat_reader=make_stat_reader(table)), 99)
+
+    def test_no_claude_ancestor(self):
+        table = {
+            200: ("bun", 150),
+            150: ("systemd", 1),
+        }
+        self.assertIsNone(_find_owning_claude(200, stat_reader=make_stat_reader(table)))
+
+    def test_process_vanished_mid_walk(self):
+        # pid 150 is missing from the table — simulates a race where a parent
+        # exited between the pgrep result and the stat read.
+        table = {
+            200: ("bun", 150),
+        }
+        self.assertIsNone(_find_owning_claude(200, stat_reader=make_stat_reader(table)))
+
+    def test_nearest_claude_wins_when_nested(self):
+        # Two claude in the ancestry — return the nearest one, not the outermost.
+        table = {
+            300: ("bun", 250),
+            250: ("claude", 200),
+            200: ("bash", 100),
+            100: ("claude", 1),
+        }
+        self.assertEqual(_find_owning_claude(300, stat_reader=make_stat_reader(table)), 250)
+
+    def test_matches_claude_code_shim(self):
+        # Linux truncates comm to 15 chars; launchers like `claude-code` or
+        # `claude-1m` show up as-is and must still be recognized.
+        table = {
+            100: ("bun", 99),
+            99: ("claude-code", 1),
+        }
+        self.assertEqual(_find_owning_claude(100, stat_reader=make_stat_reader(table)), 99)
+
+    def test_loop_guard(self):
+        # Impossible in practice, but a pid-reuse race could in theory produce
+        # a cycle. The guard returns None instead of spinning forever.
+        table = {
+            10: ("a", 20),
+            20: ("b", 10),
+        }
+        self.assertIsNone(_find_owning_claude(10, stat_reader=make_stat_reader(table)))
+
+
+class TestClassifyBridges(unittest.TestCase):
+    def test_single_bridge_owned_by_us(self):
+        table = {
+            500: ("bun", 400),
+            400: ("bun", 300),
+            300: ("claude", 1),
+        }
+        bridges = classify_bridges(
+            [500],
+            our_claude_pid=300,
+            stat_reader=make_stat_reader(table),
+            is_alive=make_alive({300}),
+        )
+        self.assertEqual(len(bridges), 1)
+        self.assertEqual(bridges[0]["classification"], "ours")
+        self.assertEqual(bridges[0]["owning_claude"], 300)
+
+    def test_multi_session_ours_plus_other(self):
+        # The scenario that tripped up the old doctor: two legitimate bridges,
+        # one per Claude session, neither a zombie.
+        table = {
+            500: ("bun", 400),
+            400: ("bun", 300),
+            300: ("claude", 1),
+            600: ("bun", 550),
+            550: ("bun", 290),
+            290: ("claude", 1),
+        }
+        bridges = classify_bridges(
+            [500, 600],
+            our_claude_pid=300,
+            stat_reader=make_stat_reader(table),
+            is_alive=make_alive({300, 290}),
+        )
+        by_pid = {b["pid"]: b for b in bridges}
+        self.assertEqual(by_pid[500]["classification"], "ours")
+        self.assertEqual(by_pid[600]["classification"], "other-session")
+
+    def test_bridge_whose_claude_died_is_orphaned(self):
+        table = {
+            500: ("bun", 400),
+            400: ("bun", 290),
+            290: ("claude", 1),
+        }
+        bridges = classify_bridges(
+            [500],
+            our_claude_pid=300,
+            stat_reader=make_stat_reader(table),
+            is_alive=make_alive(set()),  # no one alive
+        )
+        self.assertEqual(bridges[0]["classification"], "orphaned")
+
+    def test_bridge_with_no_claude_ancestor_is_orphaned(self):
+        table = {
+            500: ("bun", 1),
+        }
+        bridges = classify_bridges(
+            [500],
+            our_claude_pid=300,
+            stat_reader=make_stat_reader(table),
+            is_alive=make_alive({300}),
+        )
+        self.assertEqual(bridges[0]["classification"], "orphaned")
+        self.assertIsNone(bridges[0]["owning_claude"])
+
+    def test_two_bridges_both_owned_by_us_is_true_zombie(self):
+        # Actual duplicate within a single session — this IS a failure.
+        table = {
+            500: ("bun", 400),
+            400: ("bun", 300),
+            600: ("bun", 550),
+            550: ("bun", 300),
+            300: ("claude", 1),
+        }
+        bridges = classify_bridges(
+            [500, 600],
+            our_claude_pid=300,
+            stat_reader=make_stat_reader(table),
+            is_alive=make_alive({300}),
+        )
+        self.assertEqual(
+            [b["classification"] for b in bridges],
+            ["ours", "ours"],
+        )
+
+    def test_empty_pid_list(self):
+        self.assertEqual(
+            classify_bridges(
+                [],
+                our_claude_pid=300,
+                stat_reader=make_stat_reader({}),
+                is_alive=make_alive({300}),
+            ),
+            [],
+        )
+
+    def test_doctor_run_from_cron_has_no_our_claude(self):
+        # When our_claude_pid is None, every bridge with a live claude
+        # ancestor is "other-session"; bridges with no ancestry are orphaned.
+        table = {
+            500: ("bun", 300),
+            300: ("claude", 1),
+        }
+        bridges = classify_bridges(
+            [500],
+            our_claude_pid=None,
+            stat_reader=make_stat_reader(table),
+            is_alive=make_alive({300}),
+        )
+        self.assertEqual(bridges[0]["classification"], "other-session")
+
+
+class TestSessionSubscribedToTelegram(unittest.TestCase):
+    def test_plain_claude_is_not_subscribed(self):
+        self.assertFalse(
+            session_subscribed_to_telegram(
+                ["claude", "--dangerously-skip-permissions"]
+            )
+        )
+
+    def test_channels_flag_with_telegram_plugin(self):
+        self.assertTrue(
+            session_subscribed_to_telegram(
+                [
+                    "claude",
+                    "--dangerously-skip-permissions",
+                    "--channels",
+                    "plugin:telegram@claude-plugins-official",
+                ]
+            )
+        )
+
+    def test_channels_flag_equals_form(self):
+        self.assertTrue(
+            session_subscribed_to_telegram(
+                ["claude", "--channels=plugin:telegram@claude-plugins-official"]
+            )
+        )
+
+    def test_channels_with_comma_separated_list(self):
+        self.assertTrue(
+            session_subscribed_to_telegram(
+                [
+                    "claude",
+                    "--channels",
+                    "plugin:other-channel,plugin:telegram@claude-plugins-official",
+                ]
+            )
+        )
+
+    def test_channels_with_unrelated_plugin(self):
+        self.assertFalse(
+            session_subscribed_to_telegram(
+                ["claude", "--channels", "plugin:slack@somewhere"]
+            )
+        )
+
+    def test_channels_case_insensitive(self):
+        self.assertTrue(
+            session_subscribed_to_telegram(
+                ["claude", "--channels", "plugin:Telegram@official"]
+            )
+        )
+
+    def test_channels_flag_with_no_value_is_ignored(self):
+        # Trailing --channels with nothing after it shouldn't crash or match.
+        self.assertFalse(
+            session_subscribed_to_telegram(["claude", "--channels"])
+        )
+
+    def test_empty_argv(self):
+        self.assertFalse(session_subscribed_to_telegram([]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Doctor walks `/proc/<pid>/stat` up the ppid chain to classify each bun `server.ts` bridge as `ours` / `other-session` / `orphaned`, replacing the old count-based heuristic that misdiagnosed multi-session machines.
- New SESSION check warns (not fails — send-only sessions are valid) when the owning Claude was launched without `--channels plugin:telegram@...`, catching the silent inbound-drop failure.
- SKILL.md recipe replaces the dangerous broadcast `pkill -f 'bun.*server.ts'` (which nuked other sessions' bridges) with `kill -TERM <pid-from-doctor>` and an explicit DO-NOT callout.
- 30 stdlib unittest cases cover pure logic (`parse_proc_stat`, `_find_owning_claude`, `classify_bridges`, `session_subscribed_to_telegram`) via dependency injection — no `/proc` or `os.kill` touched in tests, per the repo's signalling-test rule.

## Why

Multi-session machines routinely run multiple legitimate bridges (one per Claude session). The old doctor failed on `>1 bun server.ts` and the fix-it recipe was `pkill -f 'bun.*server.ts'`, a broadcast kill. Before this change, running the fix in one session would terminate the MCP bridge of every *other* active session on the same box.

The `comm.startswith("claude")` match (not equality) covers launcher shims like `claude-code` / `claude-1m` within Linux's 15-char comm truncation window — a silent-failure hazard caught during review.

## Test plan

- [x] `python3 -m unittest test_telegram_debug.py` — 30/30 pass
- [x] `ruff check` — clean
- [x] `--doctor` on a multi-session box correctly shows 1 ours, 1 other-session, exit code 0
- [x] SESSION check correctly warns when session lacks `--channels telegram`
- [ ] Reviewer: verify on a single-session box the SERVER.TS output matches the old ok-path (1 bridge, no other-session line)
- [ ] Reviewer: confirm the `parse_proc_stat` parser handles a comm containing `)` characters (covered by `test_comm_with_inner_parens`)