### PR TITLE
harden-telegram: --direct-send emergency escape hatch

### DIFF
--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -13,6 +13,7 @@ Diagnose and repair the two-process Telegram MCP channel. Three tiers:
 | `/harden-telegram doctor` | Quick health check via `telegram_debug.py --doctor` |
 | `/harden-telegram reload` | Hot redeploy + reload plugins without dropping MCP |
 | `/harden-telegram deep` | Walk known failure modes if the doctor is clean but the channel is still broken |
+| **`--direct-send "..."`** | **Emergency escape hatch** — POST straight to Telegram Bot API, bypass MCP entirely. Use when `server.ts` is dead and you still need to reach Igor. Message is auto-prefixed with `[direct-send]` so it's visually distinct. See §Emergency Direct-Send below. |
 
 ## 🧭 Principle: diagnostics live in code, not here
 
@@ -57,6 +58,31 @@ Read the output top-to-bottom. If everything is green, say so and stop. If anyth
 Two processes share the Telegram MCP responsibility. `telegram_bot.py` is the persistent Python poller — owns `getUpdates`, writes every event to `~/larry-telegram/inbound.db` (SQLite WAL), survives Claude restarts, singleton via `flock`. `server.ts` is the ephemeral bun MCP bridge — reads undelivered rows, emits MCP notifications, dies with the Claude session. Flow: `Telegram → telegram_bot.py → inbound.db → bot.sock wakeup → server.ts catchup → MCP → Claude`. Dual-reaction liveness: 👀 (inner, bot.py) + 🫡 (outer, server.ts). Both glyphs on a message means both halves of the pipeline ran.
 
 **For the full design rationale** — durability contract, why SQLite WAL + Unix socket, flock semantics, 409 retry logic, invariants across crashes — read [`design.md`](./design.md) in this skill directory. That's the architectural reference, loaded on demand; this file is the operator runbook.
+
+### Emergency Direct-Send (bypass MCP)
+
+When the doctor is red, the MCP `reply` tool may be unavailable — you can't use the thing you're trying to fix. Use the escape hatch:
+
+```bash
+python3 ~/.claude/skills/harden-telegram/tools/telegram_debug.py --direct-send "your message here"
+# --send is accepted as a shorter alias
+python3 ~/.claude/skills/harden-telegram/tools/telegram_debug.py --send "short form"
+# Override the default chat_id:
+python3 ~/.claude/skills/harden-telegram/tools/telegram_debug.py --direct-send "..." --chat-id 12345
+```
+
+How it works:
+- Reads `TELEGRAM_BOT_TOKEN` from `~/.claude/channels/telegram/.env` (the same file the doctor checks).
+- POSTs straight to `https://api.telegram.org/bot<TOKEN>/sendMessage` via stdlib `urllib` — no MCP, no `server.ts`, no `bot.sock`, no inbound.db. The only moving parts are the token file and Telegram's HTTPS endpoint.
+- Chat id defaults to the most recent `inbound.chat_id` in `inbound.db`. Override with `--chat-id` if you need a specific target.
+- Every outgoing message is auto-prefixed with `[direct-send] ` so Igor can tell on his phone that MCP was down when it landed. **Do not remove the tag** — the visual signal is the whole point.
+
+Use it when:
+- The hourly watchdog cron detects a red doctor and needs to notify Igor.
+- You're walking Tier 2 recovery and need to send status updates that don't depend on `server.ts` being alive.
+- You restart `telegram_bot.py` or redeploy `server.ts` and want to confirm the fix landed — the next message Igor sees without a `[direct-send]` tag proves MCP is back.
+
+The watchdog cron scheduled by `/startup-larry` step 3 item 4 uses this exclusively — that's the design principle: **the thing watching Telegram must not depend on Telegram's MCP bridge.**
 
 ---
 

--- a/skills/harden-telegram/tools/telegram_debug.py
+++ b/skills/harden-telegram/tools/telegram_debug.py
@@ -1283,6 +1283,145 @@ def run_paths() -> int:
     return 0
 
 
+def parse_env_token(data: str) -> str | None:
+    """Extract TELEGRAM_BOT_TOKEN from .env-style text.
+
+    Handles `export ` prefix, surrounding quotes, inline `# comments` on
+    unquoted values, and leading whitespace. Returns None if no match.
+    Pure — no filesystem access, so it can be unit-tested directly.
+    """
+    for line in data.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("export "):
+            stripped = stripped[len("export ") :].lstrip()
+        if not stripped.startswith("TELEGRAM_BOT_TOKEN="):
+            continue
+        value = stripped.split("=", 1)[1].strip()
+        if (value.startswith('"') and value.endswith('"')) or (
+            value.startswith("'") and value.endswith("'")
+        ):
+            # Quoted: take the content as-is (no comment stripping).
+            return value[1:-1]
+        # Unquoted: a `#` starts an inline comment.
+        if "#" in value:
+            value = value.split("#", 1)[0].rstrip()
+        return value or None
+    return None
+
+
+def _read_bot_token(token_file: Path | None = None) -> str:
+    """Read TELEGRAM_BOT_TOKEN from ~/.claude/channels/telegram/.env.
+
+    `token_file` is injected for tests; defaults to the canonical path.
+    """
+    if token_file is None:
+        token_file = Path.home() / ".claude" / "channels" / "telegram" / ".env"
+    if not token_file.exists():
+        raise RuntimeError(f"token file missing: {token_file}")
+    token = parse_env_token(token_file.read_text())
+    if not token:
+        raise RuntimeError(f"TELEGRAM_BOT_TOKEN= not found in {token_file}")
+    return token
+
+
+def _default_chat_id() -> str | None:
+    """Pull the most recent inbound chat_id from inbound.db as a sensible default."""
+    db = (
+        Path(os.environ.get("LARRY_TELEGRAM_DIR", Path.home() / "larry-telegram"))
+        / "inbound.db"
+    )
+    if not db.exists():
+        return None
+    try:
+        con = sqlite3.connect(f"file:{db}?mode=ro", uri=True, timeout=1)
+        row = con.execute(
+            "SELECT chat_id FROM inbound ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        con.close()
+        return str(row[0]) if row else None
+    except Exception as e:
+        # Don't swallow silently — the caller's "no chat_id" error is
+        # confusing if the real failure was a corrupt DB or locked file.
+        print(f"default chat_id lookup failed: {e}", file=sys.stderr)
+        return None
+
+
+TELEGRAM_API_BASE = "https://api.telegram.org"
+DIRECT_SEND_TAG = "[direct-send]"
+
+
+def build_direct_request(
+    token: str,
+    chat_id: str,
+    text: str,
+) -> tuple[str, bytes]:
+    """Build the (url, body) for a Bot API sendMessage request.
+
+    Pure — no network, no token leak risk in tests. Auto-prefixes the
+    `[direct-send]` tag so the operator can see on their phone that MCP
+    was down when the message landed.
+    """
+    import urllib.parse
+
+    url = f"{TELEGRAM_API_BASE}/bot{token}/sendMessage"
+    tagged = f"{DIRECT_SEND_TAG} {text}"
+    body = urllib.parse.urlencode({"chat_id": str(chat_id), "text": tagged}).encode()
+    return url, body
+
+
+def _redact(s: str, token: str) -> str:
+    """Replace every occurrence of `token` in `s` with `<redacted>`.
+
+    Defense in depth — CPython's urllib error strings currently don't
+    embed the URL, but that's not a contract. Scrub before printing to
+    stderr so the token can never appear in operator bug reports.
+    """
+    if token and token in s:
+        return s.replace(token, "<redacted>")
+    return s
+
+
+def send_direct(text: str, chat_id: str | None = None) -> int:
+    """Emergency direct-send: POST to Telegram Bot API, bypassing MCP entirely.
+
+    Use when server.ts (the MCP bridge) might be down — depends only on the bot
+    token and Telegram's HTTPS endpoint, nothing on the local two-process chain.
+    """
+    import urllib.request
+
+    try:
+        token = _read_bot_token()
+    except RuntimeError as e:
+        print(f"direct send failed: {e}", file=sys.stderr)
+        return 1
+
+    if chat_id is None:
+        chat_id = _default_chat_id()
+    if not chat_id:
+        print(
+            "direct send failed: no chat_id (pass --chat-id or have an inbound message on record)",
+            file=sys.stderr,
+        )
+        return 1
+
+    url, data = build_direct_request(token, chat_id, text)
+    try:
+        with urllib.request.urlopen(url, data=data, timeout=10) as resp:
+            body = resp.read().decode()
+            if resp.status != 200:
+                print(
+                    f"direct send HTTP {resp.status}: {_redact(body, token)}",
+                    file=sys.stderr,
+                )
+                return 1
+    except Exception as e:
+        print(f"direct send failed: {_redact(str(e), token)}", file=sys.stderr)
+        return 1
+
+    print(f"sent to chat_id={chat_id}")
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(description="Telegram MCP diagnostic tool")
     parser.add_argument("--json", action="store_true", help="JSON output (pipe to jq)")
@@ -1302,7 +1441,21 @@ def main():
         action="store_true",
         help="Print every file the two-process chain cares about, with existence check",
     )
+    parser.add_argument(
+        "--direct-send",
+        "--send",
+        dest="direct_send",
+        metavar="TEXT",
+        help="EMERGENCY DIRECT-SEND via Telegram Bot API — bypasses MCP entirely. Use when server.ts is down and you still need to reach Igor. Message is auto-tagged with [direct-send] so it's visually distinct in Telegram. Runs alone; ignores --doctor/--paths if combined.",
+    )
+    parser.add_argument(
+        "--chat-id",
+        help="Target chat_id for --direct-send (defaults to last inbound chat_id from inbound.db)",
+    )
     args = parser.parse_args()
+
+    if args.direct_send is not None:
+        sys.exit(send_direct(args.direct_send, chat_id=args.chat_id))
 
     if args.doctor:
         sys.exit(run_doctor())

--- a/skills/harden-telegram/tools/test_telegram_debug.py
+++ b/skills/harden-telegram/tools/test_telegram_debug.py
@@ -4,15 +4,23 @@
 Run with: python3 -m unittest test_telegram_debug.py
 """
 
+import os
+import sqlite3
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 from telegram_debug import (  # noqa: E402
+    _default_chat_id,
     _find_owning_claude,
+    _read_bot_token,
+    _redact,
+    build_direct_request,
     classify_bridges,
+    parse_env_token,
     parse_proc_stat,
     session_subscribed_to_telegram,
 )
@@ -303,6 +311,182 @@ class TestSessionSubscribedToTelegram(unittest.TestCase):
 
     def test_empty_argv(self):
         self.assertFalse(session_subscribed_to_telegram([]))
+
+
+class TestParseEnvToken(unittest.TestCase):
+    def test_plain_assignment(self):
+        self.assertEqual(parse_env_token("TELEGRAM_BOT_TOKEN=123:abc\n"), "123:abc")
+
+    def test_double_quoted(self):
+        self.assertEqual(
+            parse_env_token('TELEGRAM_BOT_TOKEN="123:abc"\n'), "123:abc"
+        )
+
+    def test_single_quoted(self):
+        self.assertEqual(
+            parse_env_token("TELEGRAM_BOT_TOKEN='123:abc'\n"), "123:abc"
+        )
+
+    def test_export_prefix(self):
+        # `.env` files copied from shell profiles often carry `export`.
+        self.assertEqual(
+            parse_env_token("export TELEGRAM_BOT_TOKEN=123:abc\n"), "123:abc"
+        )
+
+    def test_trailing_whitespace(self):
+        self.assertEqual(
+            parse_env_token("TELEGRAM_BOT_TOKEN=123:abc   \n"), "123:abc"
+        )
+
+    def test_inline_comment_unquoted(self):
+        # Unquoted values take a `#` as an inline comment boundary.
+        self.assertEqual(
+            parse_env_token("TELEGRAM_BOT_TOKEN=123:abc # prod token\n"),
+            "123:abc",
+        )
+
+    def test_hash_inside_quoted_value_kept(self):
+        # Quoted values are literal — no comment stripping.
+        self.assertEqual(
+            parse_env_token('TELEGRAM_BOT_TOKEN="abc#def"\n'), "abc#def"
+        )
+
+    def test_ignores_comment_lines_before_match(self):
+        text = "# leading comment\nOTHER_VAR=foo\nTELEGRAM_BOT_TOKEN=123:abc\n"
+        self.assertEqual(parse_env_token(text), "123:abc")
+
+    def test_substring_collision_rejected(self):
+        # A different var whose name *contains* TELEGRAM_BOT_TOKEN must not match.
+        self.assertIsNone(
+            parse_env_token("OLD_TELEGRAM_BOT_TOKEN=stale\n")
+        )
+
+    def test_missing_returns_none(self):
+        self.assertIsNone(parse_env_token("OTHER=x\n"))
+
+    def test_empty_input(self):
+        self.assertIsNone(parse_env_token(""))
+
+
+class TestReadBotToken(unittest.TestCase):
+    def test_missing_file_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(RuntimeError) as ctx:
+                _read_bot_token(Path(d) / "nonexistent.env")
+            self.assertIn("token file missing", str(ctx.exception))
+
+    def test_present_but_no_token_key_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            env = Path(d) / ".env"
+            env.write_text("OTHER=foo\n")
+            with self.assertRaises(RuntimeError) as ctx:
+                _read_bot_token(env)
+            self.assertIn("TELEGRAM_BOT_TOKEN=", str(ctx.exception))
+
+    def test_reads_plain_value(self):
+        with tempfile.TemporaryDirectory() as d:
+            env = Path(d) / ".env"
+            env.write_text("TELEGRAM_BOT_TOKEN=999:xyz\n")
+            self.assertEqual(_read_bot_token(env), "999:xyz")
+
+
+class TestDefaultChatId(unittest.TestCase):
+    """Drive _default_chat_id via the LARRY_TELEGRAM_DIR env var it honors."""
+
+    def _with_db(self, rows):
+        tmp = tempfile.TemporaryDirectory()
+        db = Path(tmp.name) / "inbound.db"
+        con = sqlite3.connect(db)
+        con.execute(
+            "CREATE TABLE inbound (id INTEGER PRIMARY KEY, chat_id INTEGER)"
+        )
+        con.executemany("INSERT INTO inbound (chat_id) VALUES (?)", rows)
+        con.commit()
+        con.close()
+        return tmp  # caller keeps reference alive
+
+    def test_missing_db_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            old = os.environ.get("LARRY_TELEGRAM_DIR")
+            os.environ["LARRY_TELEGRAM_DIR"] = d
+            try:
+                self.assertIsNone(_default_chat_id())
+            finally:
+                if old is None:
+                    del os.environ["LARRY_TELEGRAM_DIR"]
+                else:
+                    os.environ["LARRY_TELEGRAM_DIR"] = old
+
+    def test_returns_latest_chat_id_as_string(self):
+        tmp = self._with_db([(111,), (222,), (333,)])
+        old = os.environ.get("LARRY_TELEGRAM_DIR")
+        os.environ["LARRY_TELEGRAM_DIR"] = tmp.name
+        try:
+            result = _default_chat_id()
+            self.assertEqual(result, "333")
+            self.assertIsInstance(result, str)  # int → str coercion
+        finally:
+            tmp.cleanup()
+            if old is None:
+                del os.environ["LARRY_TELEGRAM_DIR"]
+            else:
+                os.environ["LARRY_TELEGRAM_DIR"] = old
+
+    def test_empty_table_returns_none(self):
+        tmp = self._with_db([])
+        old = os.environ.get("LARRY_TELEGRAM_DIR")
+        os.environ["LARRY_TELEGRAM_DIR"] = tmp.name
+        try:
+            self.assertIsNone(_default_chat_id())
+        finally:
+            tmp.cleanup()
+            if old is None:
+                del os.environ["LARRY_TELEGRAM_DIR"]
+            else:
+                os.environ["LARRY_TELEGRAM_DIR"] = old
+
+
+class TestBuildDirectRequest(unittest.TestCase):
+    def test_url_shape(self):
+        url, _ = build_direct_request("T0KEN", "123", "hi")
+        self.assertEqual(url, "https://api.telegram.org/botT0KEN/sendMessage")
+
+    def test_tag_prefix(self):
+        _, body = build_direct_request("T", "123", "hello")
+        self.assertIn(b"text=%5Bdirect-send%5D+hello", body)
+
+    def test_chat_id_int_coerced_to_str(self):
+        # urlencode accepts ints, but pin the coercion contract.
+        _, body = build_direct_request("T", 456, "x")  # type: ignore[arg-type]
+        self.assertIn(b"chat_id=456", body)
+
+    def test_unicode_text_roundtrips(self):
+        _, body = build_direct_request("T", "1", "héllo 🚨")
+        # Body must decode back to the same string after urldecode.
+        import urllib.parse
+        decoded = dict(urllib.parse.parse_qsl(body.decode()))
+        self.assertEqual(decoded["text"], "[direct-send] héllo 🚨")
+
+    def test_double_tagging_allowed(self):
+        # Passing an already-tagged message produces a doubled tag. This is
+        # the documented behavior — don't silently strip.
+        _, body = build_direct_request("T", "1", "[direct-send] already")
+        decoded_body = body.decode()
+        self.assertIn("%5Bdirect-send%5D+%5Bdirect-send%5D+already", decoded_body)
+
+
+class TestRedact(unittest.TestCase):
+    def test_replaces_token(self):
+        self.assertEqual(
+            _redact("error: got 401 for bot12345:abc/sendMessage", "12345:abc"),
+            "error: got 401 for bot<redacted>/sendMessage",
+        )
+
+    def test_noop_when_token_absent(self):
+        self.assertEqual(_redact("network timeout", "12345:abc"), "network timeout")
+
+    def test_empty_token_is_noop(self):
+        self.assertEqual(_redact("anything", ""), "anything")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Adds `telegram_debug.py --direct-send "..."` (alias `--send`) — stdlib-only POST to `api.telegram.org/bot<TOKEN>/sendMessage`, bypassing the entire MCP bridge. Use when `server.ts` is down and you still need to notify Igor.
- Every outgoing message auto-prefixes `[direct-send]` so Igor can see on his phone that MCP was down when it landed. The absence of the tag on the next message is the positive signal that MCP is back.
- Chat id defaults to the most recent `inbound.chat_id` in `inbound.db`. `--chat-id` overrides.
- 25 new unit tests (total 55) covering token parsing, real-sqlite chat-id lookup, direct-request building, and token redaction.

## Why

When the two-process bridge is broken, the MCP `reply` tool is exactly what's broken — the operator can't use the thing they're trying to fix. The watchdog cron (`/startup-larry` step 3 item 4) and Tier 2 recovery walks both need a way to send status messages that depends on nothing but the token file and HTTPS. This is the escape hatch. Design principle: **the thing watching Telegram must not depend on Telegram's MCP bridge.**

## Code review hardenings applied before merge

From an internal review pass:

- **Token redaction on every stderr path.** `_redact()` scrubs the bot token from error messages before printing, so a future urllib exception string (or a third-party library change) can never leak the token into an operator bug report.
- **`parse_env_token` robustness.** Handles `export ` prefix, inline `# comments` on unquoted values, single/double quotes, leading whitespace, and rejects substring collisions like `OLD_TELEGRAM_BOT_TOKEN=`.
- **`_default_chat_id` surfaces errors.** The broad `except Exception: return None` now prints the exception to stderr before returning None, so a corrupt DB or locked file isn't confused with "no message received yet."
- **`build_direct_request` extracted as a pure helper.** Pairs with the existing `parse_proc_stat` / `classify_bridges` DI pattern — lets the tests cover URL shape, `[direct-send]` tag prefix, int→str chat_id coercion, and unicode round-trip without touching HTTPS.

## Test plan

- [x] `python3 -m unittest test_telegram_debug` — 55/55 pass
- [x] `ruff check` — clean
- [x] `--doctor` still green on this machine; exit 0
- [x] `--help` shows both `--direct-send` and `--send` aliases with "runs alone; ignores --doctor/--paths" note
- [ ] Reviewer: smoke-test `--direct-send "hello from review"` against a bot token of your choice (will actually hit Telegram)
- [ ] Reviewer: confirm the `[direct-send]` prefix appears in the received message on Telegram