### PR TITLE
up-to-date: handle upstream-equivalent leftovers and PR recovery flow

### DIFF
--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -84,6 +84,12 @@ git pull $SRC main
 [ "$SRC" = "upstream" ] && git push origin main
 ```
 
+If a PR is needed after syncing `main`, derive it from the remotes:
+
+- Fork workflow (`origin` = fork, `upstream` = canonical): if commits are already on fork `main` but not canonical `main`, open a recovery PR from `origin:main` to `upstream:main` with `gh pr create --repo <upstream-owner>/<repo> --head <origin-owner>:main --base main`.
+- No fork (`origin` is canonical): do **not** use the recovery flow. Create a feature branch from the current commit and open a branch PR instead.
+- Remote hygiene issues present: fix remotes first; do not guess the PR command from a miswired setup.
+
 ### Feature branch + PR merged (`pr.state == "MERGED"`)
 
 Check `branch.leftover_commits` first:

--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -54,9 +54,10 @@ The JSON output has this shape:
 ```
 
 Conventions:
+
 - `remotes.source` is either `"upstream"` (fork workflow) or `"origin"` (single-remote). Use this as `SRC` for all subsequent git commands.
 - `pr` is `null` on main or when no PR exists for the current branch.
-- `branch.leftover_commits` lists commits on a feature branch not yet in `source/main` — relevant when the PR is merged but work continued.
+- `branch.leftover_commits` lists patch-unique commits on a feature branch that are still missing from `source/main`. Commits already applied upstream under a different SHA are filtered out.
 - `errors` contains any subprocess failures the script wants surfaced (empty on the happy path).
 
 ## Step 2: Report Hygiene
@@ -86,6 +87,7 @@ git pull $SRC main
 ### Feature branch + PR merged (`pr.state == "MERGED"`)
 
 Check `branch.leftover_commits` first:
+
 - Non-empty → **ASK USER**: new PR for leftovers, or discard?
 - Empty → safe to switch to main and delete branch
 
@@ -119,15 +121,15 @@ If `worktree.stashes` is non-empty, list them and inform the user.
 
 ## Output Format
 
-| Check | Status | Action |
-|---|---|---|
-| Remote naming | pass/fail | Offer rename commands from issue `fix` field |
-| Workflow | PR / direct push | Warn if fork org pushing direct |
-| Branch | `branch.name` | — |
-| PR | `#N STATE` | Context-dependent |
-| Uncommitted | N files | Listed below |
-| Behind source/main | N commits | Will pull |
-| Stashes | N stashes | Listed below |
+| Check              | Status           | Action                                       |
+| ------------------ | ---------------- | -------------------------------------------- |
+| Remote naming      | pass/fail        | Offer rename commands from issue `fix` field |
+| Workflow           | PR / direct push | Warn if fork org pushing direct              |
+| Branch             | `branch.name`    | —                                            |
+| PR                 | `#N STATE`       | Context-dependent                            |
+| Uncommitted        | N files          | Listed below                                 |
+| Behind source/main | N commits        | Will pull                                    |
+| Stashes            | N stashes        | Listed below                                 |
 
 ## Post-Sync
 

--- a/skills/up-to-date/diagnose.py
+++ b/skills/up-to-date/diagnose.py
@@ -123,7 +123,9 @@ def classify_remotes(remotes: list[Remote], fork_orgs: list[str]) -> RemoteAnaly
     if fork_remotes and canonical_remotes:
         origin = by_name.get("origin")
         upstream = by_name.get("upstream")
-        origin_is_canonical = origin is not None and not is_fork_url(origin.url, fork_orgs)
+        origin_is_canonical = origin is not None and not is_fork_url(
+            origin.url, fork_orgs
+        )
         upstream_is_fork = upstream is not None and is_fork_url(upstream.url, fork_orgs)
         if origin_is_canonical or upstream_is_fork:
             issues.append(
@@ -155,6 +157,16 @@ def classify_remotes(remotes: list[Remote], fork_orgs: list[str]) -> RemoteAnaly
         is_fork_workflow=is_fork_workflow,
         issues=issues,
     )
+
+
+def parse_cherry_leftovers(raw: str) -> list[str]:
+    """Return only patch-unique commits from `git cherry -v` output."""
+    leftovers: list[str] = []
+    for line in raw.splitlines():
+        if not line.startswith("+ "):
+            continue
+        leftovers.append(line[2:])
+    return leftovers
 
 
 # ---------- Subprocess helpers ----------
@@ -198,9 +210,7 @@ def run_diagnose() -> dict[str, Any]:
     # Run fetch and PR lookup in parallel — they don't depend on each other.
     # gh pr view reads local branch state, not the remote fetch result.
     with ThreadPoolExecutor(max_workers=2) as pool:
-        fetch_fut = pool.submit(
-            _run, ["git", "fetch", "--all", "--prune"], False
-        )
+        fetch_fut = pool.submit(_run, ["git", "fetch", "--all", "--prune"], False)
         pr_fut = pool.submit(
             gh_pr_view_json,
             "state,number,title,mergeable,reviewDecision,reviews,comments",
@@ -223,10 +233,10 @@ def run_diagnose() -> dict[str, Any]:
 
     leftover_commits: list[str] = []
     if not is_main and branch_name:
-        leftover_raw = git(
-            "log", "--oneline", f"{src}/main..{branch_name}", check=False
-        )
-        leftover_commits = [ln for ln in leftover_raw.splitlines() if ln][:10]
+        # Use patch equivalence, not commit reachability, so rebased/cherry-picked
+        # commits already present upstream do not show up as leftover work.
+        leftover_raw = git("cherry", "-v", f"{src}/main", branch_name, check=False)
+        leftover_commits = parse_cherry_leftovers(leftover_raw)[:10]
 
     # Worktree state
     uncommitted_raw = git("status", "--porcelain", check=False)
@@ -274,7 +284,9 @@ def run_diagnose() -> dict[str, Any]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Diagnose git repo state for up-to-date skill")
+    parser = argparse.ArgumentParser(
+        description="Diagnose git repo state for up-to-date skill"
+    )
     parser.add_argument("--pretty", action="store_true", help="pretty-print JSON")
     args = parser.parse_args()
 

--- a/skills/up-to-date/test_diagnose.py
+++ b/skills/up-to-date/test_diagnose.py
@@ -15,6 +15,7 @@ from diagnose import (  # noqa: E402
     Remote,
     classify_remotes,
     is_fork_url,
+    parse_cherry_leftovers,
     parse_remotes,
 )
 
@@ -41,7 +42,9 @@ class TestParseRemotes(unittest.TestCase):
         )
         result = parse_remotes(raw)
         self.assertEqual(len(result), 2)
-        self.assertIn(Remote("origin", "git@github.com:idvorkin-ai-tools/chop.git"), result)
+        self.assertIn(
+            Remote("origin", "git@github.com:idvorkin-ai-tools/chop.git"), result
+        )
         self.assertIn(Remote("upstream", "git@github.com:idvorkin/chop.git"), result)
 
     def test_empty_output(self):
@@ -50,17 +53,25 @@ class TestParseRemotes(unittest.TestCase):
 
 class TestIsForkUrl(unittest.TestCase):
     def test_ssh_url_matches(self):
-        self.assertTrue(is_fork_url("git@github.com:idvorkin-ai-tools/foo.git", FORK_ORGS))
+        self.assertTrue(
+            is_fork_url("git@github.com:idvorkin-ai-tools/foo.git", FORK_ORGS)
+        )
 
     def test_https_url_matches(self):
-        self.assertTrue(is_fork_url("https://github.com/idvorkin-ai-tools/foo", FORK_ORGS))
+        self.assertTrue(
+            is_fork_url("https://github.com/idvorkin-ai-tools/foo", FORK_ORGS)
+        )
 
     def test_non_fork_does_not_match(self):
         self.assertFalse(is_fork_url("git@github.com:idvorkin/foo.git", FORK_ORGS))
 
     def test_substring_does_not_false_match(self):
         # A user org named "idvorkin" should NOT match fork org "idvorkin-ai-tools"
-        self.assertFalse(is_fork_url("git@github.com:idvorkin/idvorkin-ai-tools-plugin.git", FORK_ORGS))
+        self.assertFalse(
+            is_fork_url(
+                "git@github.com:idvorkin/idvorkin-ai-tools-plugin.git", FORK_ORGS
+            )
+        )
 
 
 class TestClassifyRemotes(unittest.TestCase):
@@ -115,6 +126,21 @@ class TestClassifyRemotes(unittest.TestCase):
         result = classify_remotes(remotes, FORK_ORGS)
         for issue in result.issues:
             self.assertTrue(issue.fix, f"issue {issue.kind} missing fix command")
+
+
+class TestParseCherryLeftovers(unittest.TestCase):
+    def test_keeps_only_patch_unique_commits(self):
+        raw = (
+            "- 1234567 already upstream under different sha\n"
+            "+ 89abcde follow-up work still missing upstream\n"
+        )
+        self.assertEqual(
+            parse_cherry_leftovers(raw),
+            ["89abcde follow-up work still missing upstream"],
+        )
+
+    def test_empty_output(self):
+        self.assertEqual(parse_cherry_leftovers(""), [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ignore merged-branch leftovers that are already upstream under a different SHA
- document when to use a recovery PR from fork main versus a normal branch PR
- keep the rule portable across fork and no-fork setups

## Testing
- python3 -m unittest skills/up-to-date/test_diagnose.py
- validated  reports upstream-equivalent leftovers with 
- Run Fast Tests pre-commit hook passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the definition of branch leftover commits to clarify patch-unique identification.
  * Added decision flow guidance for recovery PRs during main-branch syncs, covering fork and non-fork workflows.
  * Updated table formatting for improved readability.

* **Bug Fixes**
  * Improved detection of commits requiring upstream application by using patch equivalence instead of reachability checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->