### PR TITLE
skills: rename build-bd to build-bd-static

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,22 +79,22 @@ Machine-level skills go in `~/.claude/skills/` and are available everywhere. Pro
 
 ### Available Skills
 
-| Skill                    | Scope   | Description                                                                     |
-| ------------------------ | ------- | ------------------------------------------------------------------------------- |
-| `ammon`                  | machine | Look up the current time in Denmark for Ammon                                   |
-| `architect-review`       | machine | Iterative architect review passes on design specs, tracking convergence         |
-| `background-usage`       | machine | Check Claude Code plan usage without blocking the session                       |
-| `build-bd`               | machine | Build and install the `bd` (Beads) CLI with a static build                      |
-| `clock`                  | machine | Schedule recurring session tasks (time checks, reminders)                       |
-| `delegate-to-other-repo` | machine | Delegate cross-repo work to a subagent with an isolated context; ends with a PR |
-| `docs`                   | machine | Fetch fresh library/framework docs via Context7 (`ctx7`)                        |
-| `gen-image`              | machine | Generate illustrations via Gemini image API                                     |
-| `gist-image`             | machine | Host images on GitHub gists for PRs/issues                                      |
-| `image-explore`          | machine | Brainstorm and compare visual directions                                        |
-| `learn-from-session`     | machine | Extract durable lessons from a session into the right CLAUDE.md files           |
-| `machine-doctor`         | machine | Diagnose system health, kill rogue processes                                    |
-| `showboat`               | machine | Create executable demo documents with screenshots                               |
-| `up-to-date`             | machine | Sync git repo with upstream                                                     |
+| Skill                    | Scope   | Description                                                                      |
+| ------------------------ | ------- | -------------------------------------------------------------------------------- |
+| `ammon`                  | machine | Look up the current time in Denmark for Ammon                                    |
+| `architect-review`       | machine | Iterative architect review passes on design specs, tracking convergence          |
+| `background-usage`       | machine | Check Claude Code plan usage without blocking the session                        |
+| `build-bd-static`        | machine | Build a static `bd` fallback when Homebrew is unavailable or not portable enough |
+| `clock`                  | machine | Schedule recurring session tasks (time checks, reminders)                        |
+| `delegate-to-other-repo` | machine | Delegate cross-repo work to a subagent with an isolated context; ends with a PR  |
+| `docs`                   | machine | Fetch fresh library/framework docs via Context7 (`ctx7`)                         |
+| `gen-image`              | machine | Generate illustrations via Gemini image API                                      |
+| `gist-image`             | machine | Host images on GitHub gists for PRs/issues                                       |
+| `image-explore`          | machine | Brainstorm and compare visual directions                                         |
+| `learn-from-session`     | machine | Extract durable lessons from a session into the right CLAUDE.md files            |
+| `machine-doctor`         | machine | Diagnose system health, kill rogue processes                                     |
+| `showboat`               | machine | Create executable demo documents with screenshots                                |
+| `up-to-date`             | machine | Sync git repo with upstream                                                      |
 
 ## Usage
 

--- a/skills/build-bd-static/SKILL.md
+++ b/skills/build-bd-static/SKILL.md
@@ -1,11 +1,26 @@
-# Build bd (Beads CLI)
+---
+name: build-bd-static
+description: Build a static `bd` binary when Homebrew is unavailable or its dynamically-linked package is not portable enough for the machine.
+allowed-tools: Bash, Read
+---
 
-Install or upgrade the `bd` CLI tool with a fully static build to avoid shared library issues (e.g., ICU version mismatches across machines).
+# Build bd Static
+
+Use Homebrew as the default install path:
+
+```bash
+brew install beads
+brew upgrade beads
+```
+
+Use this skill only when Homebrew is unavailable, or when the packaged `bd` is not enough because you need a self-contained binary that avoids shared-library issues (for example ICU version mismatches across machines).
+
+`bd upgrade` is not the installer path here; it reviews version changes but does not replace the binary.
 
 ## Usage
 
 ```text
-/build-bd
+/build-bd-static
 ```
 
 ## Steps
@@ -22,7 +37,7 @@ Install or upgrade the `bd` CLI tool with a fully static build to avoid shared l
    go list -m -json github.com/steveyegge/beads@latest 2>&1 | grep '"Version"'
    ```
 
-3. If already on the latest version, report that and stop. Otherwise, proceed to build.
+3. If already on the latest version, report that and stop. Otherwise, proceed to build the static fallback binary.
 
 4. Build the latest version statically with CGO disabled (use the version from step 2):
 


### PR DESCRIPTION
## Summary
- rename the skill to `build-bd-static`
- make Homebrew the default `bd` install path and position the skill as the static fallback
- clarify that `bd upgrade` reviews version changes but does not replace the binary

## Testing
- Run Fast Tests pre-commit hook passed
- Prettier markdown hook passed