### PR TITLE
up-to-date: report patch-equivalent main divergence

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ default:
     @just --list
 
 fast-test:
-    @rg --files skills -g 'test_*.py' | xargs -r -n1 dirname | sort -u | xargs -r -I{} python3 -m unittest discover -s '{}' -p 'test_*.py'
+    @python3 -c "from pathlib import Path; import subprocess, sys; test_dirs = sorted({str(path.parent) for path in Path('skills').rglob('test_*.py')}); sys.exit(0 if all(subprocess.run(['python3', '-m', 'unittest', 'discover', '-s', test_dir, '-p', 'test_*.py']).returncode == 0 for test_dir in test_dirs) else 1)"
 
 test:
     @echo "All tests - Add comprehensive tests" 

--- a/justfile
+++ b/justfile
@@ -2,7 +2,7 @@ default:
     @just --list
 
 fast-test:
-    @echo "0/0 tests passed - Add tests"
+    @rg --files skills -g 'test_*.py' | xargs -r -n1 dirname | sort -u | xargs -r -I{} python3 -m unittest discover -s '{}' -p 'test_*.py'
 
 test:
     @echo "All tests - Add comprehensive tests" 

--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -67,7 +67,7 @@ Conventions:
 - `branch.ahead_patch_unique_commits` and `branch.ahead_patch_equivalent_commits` come from `git cherry -v source/main HEAD`, so the script tells you whether ahead commits are unique work or already present upstream under different SHAs.
 - `branch.can_force_align` is `true` only on `main` when every ahead commit is patch-equivalent to `source/main`; in that case, re-aligning the fork's `main` loses no unique work.
 - `branch.leftover_commits` lists patch-unique commits on a feature branch that are still missing from `source/main`. Commits already applied upstream under a different SHA are filtered out.
-- `errors` contains any subprocess failures the script wants surfaced (empty on the happy path).
+- `errors` contains subprocess failures from fetch and the post-fetch git diagnostics (`rev-list`, `log`, `status`, `stash`, `cherry`) so callers can tell the difference between "no divergence" and "diagnostic failed".
 
 ## Step 2: Report Hygiene
 

--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -10,13 +10,17 @@ Diagnose and sync the current git repo with upstream.
 
 ## Step 1: Diagnose
 
-Run the helper — it fetches, queries `gh pr view`, and checks remote hygiene in parallel, then prints JSON:
+Run the versioned helper that lives with this skill — it fetches, queries
+`gh pr view`, and checks remote hygiene in parallel, then prints JSON. In this
+source repo that path is:
 
 ```bash
-~/.claude/skills/up-to-date/diagnose.py
+skills/up-to-date/diagnose.py
 ```
 
-(Project-level installs: the script lives alongside this SKILL.md at `<project>/.claude/skills/up-to-date/diagnose.py`. If `~/.claude/skills/up-to-date/diagnose.py` is missing, use the project-local path instead.)
+When the skill is installed into `~/.claude/skills/` or `<project>/.claude/skills/`,
+that installed path is typically a symlink to this same file. Prefer the
+versioned repo copy when you are editing this repository.
 
 The JSON output has this shape:
 
@@ -34,6 +38,9 @@ The JSON output has this shape:
     "behind": 0,
     "ahead": 0,
     "behind_commits": ["abc123 subject", ...],
+    "ahead_patch_unique_commits": ["def456 subject", ...],
+    "ahead_patch_equivalent_commits": ["ghi789 subject", ...],
+    "can_force_align": false,
     "leftover_commits": [...]
   },
   "worktree": {
@@ -57,6 +64,8 @@ Conventions:
 
 - `remotes.source` is either `"upstream"` (fork workflow) or `"origin"` (single-remote). Use this as `SRC` for all subsequent git commands.
 - `pr` is `null` on main or when no PR exists for the current branch.
+- `branch.ahead_patch_unique_commits` and `branch.ahead_patch_equivalent_commits` come from `git cherry -v source/main HEAD`, so the script tells you whether ahead commits are unique work or already present upstream under different SHAs.
+- `branch.can_force_align` is `true` only on `main` when every ahead commit is patch-equivalent to `source/main`; in that case, re-aligning the fork's `main` loses no unique work.
 - `branch.leftover_commits` lists patch-unique commits on a feature branch that are still missing from `source/main`. Commits already applied upstream under a different SHA are filtered out.
 - `errors` contains any subprocess failures the script wants surfaced (empty on the happy path).
 
@@ -77,6 +86,15 @@ git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
 ```
 
 ### On main (`branch.is_main` true)
+
+If `branch.can_force_align` is true, prefer:
+
+```bash
+git pull --rebase $SRC main
+[ "$SRC" = "upstream" ] && git push --force-with-lease origin main
+```
+
+Otherwise:
 
 ```bash
 git pull $SRC main
@@ -158,11 +176,11 @@ git fetch --all --prune
 git branch --show-current
 git status --porcelain
 git stash list
-git rev-list --count HEAD..$SRC/main   # behind
-git rev-list --count $SRC/main..HEAD   # ahead
+git rev-list --left-right --count $SRC/main...HEAD
+git cherry -v $SRC/main HEAD
 gh pr view --json state,number,title,mergeable,reviewDecision 2>/dev/null
 ```
 
 ## Implementation
 
-The `diagnose.py` script is ~150 lines of stdlib Python with a `#!/usr/bin/env -S uv run --script` shebang, so it runs without manual env setup wherever `uv` is installed. Pure classification logic (`parse_remotes`, `is_fork_url`, `classify_remotes`) is unit-tested in `test_diagnose.py` — run `python3 -m unittest test_diagnose.py` from this directory.
+The `diagnose.py` script is stdlib-only Python with a `#!/usr/bin/env -S uv run --script` shebang, so it runs without manual env setup wherever `uv` is installed. Pure classification logic (`parse_remotes`, `is_fork_url`, `classify_remotes`, cherry parsing) is unit-tested in `test_diagnose.py` — run `python3 -m unittest test_diagnose.py` from this directory.

--- a/skills/up-to-date/diagnose.py
+++ b/skills/up-to-date/diagnose.py
@@ -247,12 +247,9 @@ def run_diagnose() -> dict[str, Any]:
     with ThreadPoolExecutor(max_workers=5) as pool:
         branch_name_fut = pool.submit(git, "branch", "--show-current", check=False)
         divergence_fut = pool.submit(
-            git,
-            "rev-list",
-            "--left-right",
-            "--count",
-            f"{src}/main...HEAD",
-            check=False,
+            _run,
+            ["git", "rev-list", "--left-right", "--count", f"{src}/main...HEAD"],
+            False,
         )
         behind_commits_fut = pool.submit(
             git, "log", "--oneline", f"HEAD..{src}/main", check=False
@@ -261,7 +258,22 @@ def run_diagnose() -> dict[str, Any]:
         stashes_fut = pool.submit(git, "stash", "list", check=False)
 
         branch_name = branch_name_fut.result()
-        behind, ahead = parse_left_right_count(divergence_fut.result())
+        divergence_proc = divergence_fut.result()
+        if divergence_proc.returncode != 0:
+            errors.append(
+                f"git rev-list --left-right --count failed: {divergence_proc.stderr.strip()}"
+            )
+            behind, ahead = 0, 0
+        else:
+            divergence_raw = divergence_proc.stdout.strip()
+            if re.fullmatch(r"\d+\s+\d+", divergence_raw):
+                behind, ahead = parse_left_right_count(divergence_raw)
+            else:
+                errors.append(
+                    "git rev-list --left-right --count returned unexpected output: "
+                    f"{divergence_raw!r}"
+                )
+                behind, ahead = 0, 0
         behind_commits_raw = behind_commits_fut.result()
         uncommitted_raw = uncommitted_fut.result()
         stash_raw = stashes_fut.result()

--- a/skills/up-to-date/diagnose.py
+++ b/skills/up-to-date/diagnose.py
@@ -56,6 +56,12 @@ class RemoteAnalysis:
     issues: list[RemoteIssue] = field(default_factory=list)
 
 
+@dataclass(frozen=True)
+class CherryAnalysis:
+    unique_commits: list[str]
+    equivalent_commits: list[str]
+
+
 # ---------- Pure functions (tested) ----------
 
 
@@ -159,14 +165,30 @@ def classify_remotes(remotes: list[Remote], fork_orgs: list[str]) -> RemoteAnaly
     )
 
 
-def parse_cherry_leftovers(raw: str) -> list[str]:
-    """Return only patch-unique commits from `git cherry -v` output."""
-    leftovers: list[str] = []
+def parse_cherry_status(raw: str) -> CherryAnalysis:
+    """Split `git cherry -v` output into unique and patch-equivalent commits."""
+    unique_commits: list[str] = []
+    equivalent_commits: list[str] = []
     for line in raw.splitlines():
-        if not line.startswith("+ "):
-            continue
-        leftovers.append(line[2:])
-    return leftovers
+        if line.startswith("+ "):
+            unique_commits.append(line[2:])
+        elif line.startswith("- "):
+            equivalent_commits.append(line[2:])
+    return CherryAnalysis(
+        unique_commits=unique_commits,
+        equivalent_commits=equivalent_commits,
+    )
+
+
+def parse_left_right_count(raw: str) -> tuple[int, int]:
+    """Parse `git rev-list --left-right --count A...B` output."""
+    parts = raw.split()
+    if len(parts) != 2:
+        return (0, 0)
+    try:
+        return (int(parts[0]), int(parts[1]))
+    except ValueError:
+        return (0, 0)
 
 
 # ---------- Subprocess helpers ----------
@@ -221,27 +243,47 @@ def run_diagnose() -> dict[str, Any]:
     if fetch_proc.returncode != 0:
         errors.append(f"git fetch failed: {fetch_proc.stderr.strip()}")
 
-    # Branch state
-    branch_name = git("branch", "--show-current", check=False)
+    # Post-fetch git queries are independent; run them in parallel.
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        branch_name_fut = pool.submit(git, "branch", "--show-current", check=False)
+        divergence_fut = pool.submit(
+            git,
+            "rev-list",
+            "--left-right",
+            "--count",
+            f"{src}/main...HEAD",
+            check=False,
+        )
+        behind_commits_fut = pool.submit(
+            git, "log", "--oneline", f"HEAD..{src}/main", check=False
+        )
+        uncommitted_fut = pool.submit(git, "status", "--porcelain", check=False)
+        stashes_fut = pool.submit(git, "stash", "list", check=False)
+
+        branch_name = branch_name_fut.result()
+        behind, ahead = parse_left_right_count(divergence_fut.result())
+        behind_commits_raw = behind_commits_fut.result()
+        uncommitted_raw = uncommitted_fut.result()
+        stash_raw = stashes_fut.result()
+
     is_main = branch_name == "main"
-
-    behind = int(git("rev-list", "--count", f"HEAD..{src}/main", check=False) or "0")
-    ahead = int(git("rev-list", "--count", f"{src}/main..HEAD", check=False) or "0")
-
-    behind_commits_raw = git("log", "--oneline", f"HEAD..{src}/main", check=False)
     behind_commits = [ln for ln in behind_commits_raw.splitlines() if ln][:10]
 
-    leftover_commits: list[str] = []
-    if not is_main and branch_name:
+    cherry = CherryAnalysis(unique_commits=[], equivalent_commits=[])
+    if ahead > 0 and branch_name:
         # Use patch equivalence, not commit reachability, so rebased/cherry-picked
-        # commits already present upstream do not show up as leftover work.
-        leftover_raw = git("cherry", "-v", f"{src}/main", branch_name, check=False)
-        leftover_commits = parse_cherry_leftovers(leftover_raw)[:10]
+        # commits already present upstream do not show up as unique work.
+        cherry_raw = git("cherry", "-v", f"{src}/main", branch_name, check=False)
+        cherry = parse_cherry_status(cherry_raw)
+
+    ahead_patch_unique_commits = cherry.unique_commits[:10]
+    ahead_patch_equivalent_commits = cherry.equivalent_commits[:10]
+    can_force_align = is_main and ahead > 0 and not cherry.unique_commits
+
+    leftover_commits = [] if is_main else ahead_patch_unique_commits
 
     # Worktree state
-    uncommitted_raw = git("status", "--porcelain", check=False)
     uncommitted = [ln for ln in uncommitted_raw.splitlines() if ln]
-    stash_raw = git("stash", "list", check=False)
     stashes = [ln for ln in stash_raw.splitlines() if ln]
 
     # PR state — only on feature branches, and only if we got data
@@ -272,6 +314,9 @@ def run_diagnose() -> dict[str, Any]:
             "behind": behind,
             "ahead": ahead,
             "behind_commits": behind_commits,
+            "ahead_patch_unique_commits": ahead_patch_unique_commits,
+            "ahead_patch_equivalent_commits": ahead_patch_equivalent_commits,
+            "can_force_align": can_force_align,
             "leftover_commits": leftover_commits,
         },
         "worktree": {

--- a/skills/up-to-date/diagnose.py
+++ b/skills/up-to-date/diagnose.py
@@ -180,15 +180,15 @@ def parse_cherry_status(raw: str) -> CherryAnalysis:
     )
 
 
-def parse_left_right_count(raw: str) -> tuple[int, int]:
+def parse_left_right_count(raw: str) -> tuple[int, int] | None:
     """Parse `git rev-list --left-right --count A...B` output."""
     parts = raw.split()
     if len(parts) != 2:
-        return (0, 0)
+        return None
     try:
         return (int(parts[0]), int(parts[1]))
     except ValueError:
-        return (0, 0)
+        return None
 
 
 # ---------- Subprocess helpers ----------
@@ -203,6 +203,11 @@ def git(*args: str, check: bool = True) -> str:
     """Run `git <args>` and return stdout (stripped)."""
     result = _run(["git", *args], check=check)
     return result.stdout.strip()
+
+
+def git_proc(*args: str, check: bool = True) -> subprocess.CompletedProcess:
+    """Run `git <args>` and return the full CompletedProcess."""
+    return _run(["git", *args], check=check)
 
 
 def gh_pr_view_json(fields: str) -> dict[str, Any] | None:
@@ -245,48 +250,79 @@ def run_diagnose() -> dict[str, Any]:
 
     # Post-fetch git queries are independent; run them in parallel.
     with ThreadPoolExecutor(max_workers=5) as pool:
-        branch_name_fut = pool.submit(git, "branch", "--show-current", check=False)
+        branch_name_fut = pool.submit(git_proc, "branch", "--show-current", check=False)
         divergence_fut = pool.submit(
-            _run,
-            ["git", "rev-list", "--left-right", "--count", f"{src}/main...HEAD"],
-            False,
+            git_proc,
+            "rev-list",
+            "--left-right",
+            "--count",
+            f"{src}/main...HEAD",
+            check=False,
         )
         behind_commits_fut = pool.submit(
-            git, "log", "--oneline", f"HEAD..{src}/main", check=False
+            git_proc, "log", "--oneline", f"HEAD..{src}/main", check=False
         )
-        uncommitted_fut = pool.submit(git, "status", "--porcelain", check=False)
-        stashes_fut = pool.submit(git, "stash", "list", check=False)
-
-        branch_name = branch_name_fut.result()
+        uncommitted_fut = pool.submit(git_proc, "status", "--porcelain", check=False)
+        stashes_fut = pool.submit(git_proc, "stash", "list", check=False)
+        branch_name_proc = branch_name_fut.result()
         divergence_proc = divergence_fut.result()
-        if divergence_proc.returncode != 0:
+        behind_commits_proc = behind_commits_fut.result()
+        uncommitted_proc = uncommitted_fut.result()
+        stash_proc = stashes_fut.result()
+
+    if branch_name_proc.returncode != 0:
+        errors.append(
+            f"git branch --show-current failed: {branch_name_proc.stderr.strip()}"
+        )
+    branch_name = branch_name_proc.stdout.strip()
+
+    behind = 0
+    ahead = 0
+    if divergence_proc.returncode != 0:
+        errors.append(
+            "git rev-list --left-right --count failed: "
+            f"{divergence_proc.stderr.strip()}"
+        )
+    else:
+        divergence = parse_left_right_count(divergence_proc.stdout.strip())
+        if divergence is None:
             errors.append(
-                f"git rev-list --left-right --count failed: {divergence_proc.stderr.strip()}"
+                "git rev-list --left-right --count returned unexpected output: "
+                f"{divergence_proc.stdout.strip()!r}"
             )
-            behind, ahead = 0, 0
         else:
-            divergence_raw = divergence_proc.stdout.strip()
-            if re.fullmatch(r"\d+\s+\d+", divergence_raw):
-                behind, ahead = parse_left_right_count(divergence_raw)
-            else:
-                errors.append(
-                    "git rev-list --left-right --count returned unexpected output: "
-                    f"{divergence_raw!r}"
-                )
-                behind, ahead = 0, 0
-        behind_commits_raw = behind_commits_fut.result()
-        uncommitted_raw = uncommitted_fut.result()
-        stash_raw = stashes_fut.result()
+            behind, ahead = divergence
+
+    if behind_commits_proc.returncode != 0:
+        errors.append(
+            f"git log HEAD..{src}/main failed: {behind_commits_proc.stderr.strip()}"
+        )
+    behind_commits_raw = behind_commits_proc.stdout.strip()
+
+    if uncommitted_proc.returncode != 0:
+        errors.append(
+            f"git status --porcelain failed: {uncommitted_proc.stderr.strip()}"
+        )
+    uncommitted_raw = uncommitted_proc.stdout.strip()
+
+    if stash_proc.returncode != 0:
+        errors.append(f"git stash list failed: {stash_proc.stderr.strip()}")
+    stash_raw = stash_proc.stdout.strip()
 
     is_main = branch_name == "main"
     behind_commits = [ln for ln in behind_commits_raw.splitlines() if ln][:10]
 
     cherry = CherryAnalysis(unique_commits=[], equivalent_commits=[])
-    if ahead > 0 and branch_name:
+    if branch_name:
         # Use patch equivalence, not commit reachability, so rebased/cherry-picked
         # commits already present upstream do not show up as unique work.
-        cherry_raw = git("cherry", "-v", f"{src}/main", branch_name, check=False)
-        cherry = parse_cherry_status(cherry_raw)
+        cherry_proc = git_proc("cherry", "-v", f"{src}/main", branch_name, check=False)
+        if cherry_proc.returncode != 0:
+            errors.append(
+                f"git cherry -v {src}/main {branch_name} failed: {cherry_proc.stderr.strip()}"
+            )
+        else:
+            cherry = parse_cherry_status(cherry_proc.stdout.strip())
 
     ahead_patch_unique_commits = cherry.unique_commits[:10]
     ahead_patch_equivalent_commits = cherry.equivalent_commits[:10]

--- a/skills/up-to-date/test_diagnose.py
+++ b/skills/up-to-date/test_diagnose.py
@@ -12,10 +12,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from diagnose import (  # noqa: E402
+    CherryAnalysis,
     Remote,
     classify_remotes,
     is_fork_url,
-    parse_cherry_leftovers,
+    parse_cherry_status,
+    parse_left_right_count,
     parse_remotes,
 )
 
@@ -128,19 +130,33 @@ class TestClassifyRemotes(unittest.TestCase):
             self.assertTrue(issue.fix, f"issue {issue.kind} missing fix command")
 
 
-class TestParseCherryLeftovers(unittest.TestCase):
-    def test_keeps_only_patch_unique_commits(self):
+class TestParseCherryStatus(unittest.TestCase):
+    def test_splits_unique_and_equivalent_commits(self):
         raw = (
             "- 1234567 already upstream under different sha\n"
             "+ 89abcde follow-up work still missing upstream\n"
         )
         self.assertEqual(
-            parse_cherry_leftovers(raw),
-            ["89abcde follow-up work still missing upstream"],
+            parse_cherry_status(raw),
+            CherryAnalysis(
+                unique_commits=["89abcde follow-up work still missing upstream"],
+                equivalent_commits=["1234567 already upstream under different sha"],
+            ),
         )
 
     def test_empty_output(self):
-        self.assertEqual(parse_cherry_leftovers(""), [])
+        self.assertEqual(
+            parse_cherry_status(""),
+            CherryAnalysis(unique_commits=[], equivalent_commits=[]),
+        )
+
+
+class TestParseLeftRightCount(unittest.TestCase):
+    def test_parses_tab_separated_counts(self):
+        self.assertEqual(parse_left_right_count("3\t7"), (3, 7))
+
+    def test_invalid_output_defaults_to_zeroes(self):
+        self.assertEqual(parse_left_right_count("nonsense"), (0, 0))
 
 
 if __name__ == "__main__":

--- a/skills/up-to-date/test_diagnose.py
+++ b/skills/up-to-date/test_diagnose.py
@@ -155,8 +155,8 @@ class TestParseLeftRightCount(unittest.TestCase):
     def test_parses_tab_separated_counts(self):
         self.assertEqual(parse_left_right_count("3\t7"), (3, 7))
 
-    def test_invalid_output_defaults_to_zeroes(self):
-        self.assertEqual(parse_left_right_count("nonsense"), (0, 0))
+    def test_invalid_output_returns_none(self):
+        self.assertIsNone(parse_left_right_count("nonsense"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- teach `skills/up-to-date/diagnose.py` to report patch-unique vs patch-equivalent ahead commits and a `can_force_align` signal for main
- reduce git subprocess overhead by using `rev-list --left-right --count` and parallelizing post-fetch git queries
- update `skills/up-to-date/SKILL.md` to prefer the versioned repo helper path and document the main re-align flow

## Testing
- python3 -m unittest skills/up-to-date/test_diagnose.py
- git commit hooks (ruff, prettier, fast tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Branch diagnostics now classify ahead commits and detect when a force-align is safe.
  * Fast test task now discovers and runs unit tests instead of emitting a static message.

* **Documentation**
  * Updated sync and install guidance to prefer the repository copy and reflect new classification/force-align behavior.
  * Manual fallback and error reporting guidance expanded.

* **Tests**
  * Extended tests to validate commit classification parsing and left/right count parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->