### PR TITLE
dev-setup: tap statusline JSON for session introspection

### DIFF
--- a/dev-setup/statusline-command.sh
+++ b/dev-setup/statusline-command.sh
@@ -4,6 +4,13 @@
 
 input=$(cat)
 
+# Debug tap: overwrite the most-recent statusline input each turn so it can be
+# inspected with `jq . ~/.claude/statusline_last_input.json` to see the real
+# JSON shape Claude Code sends. Cheap (one short write per turn). Future
+# sessions can read context_window.used_percentage / context_window_size /
+# cost.total_cost_usd from here when the user asks "how many tokens am I using".
+printf '%s' "$input" > ~/.claude/statusline_last_input.json 2>/dev/null
+
 cwd=$(echo "$input" | jq -r '.cwd // .workspace.current_dir // ""')
 model=$(echo "$input" | jq -r '.model.display_name // ""')
 used=$(echo "$input" | jq -r '.context_window.used_percentage // empty')


### PR DESCRIPTION
## Summary

- Persist the statusline stdin JSON to `~/.claude/statusline_last_input.json` on every turn.
- Lets future Claude Code sessions answer "how many tokens am I using / how much context is left" by reading `context_window.used_percentage`, `context_window.context_window_size`, and `cost.total_cost_usd` directly from the harness JSON instead of guessing from transcript length.
- One short write per turn, errors swallowed — nothing the user sees changes.

## Why

The statusline script already receives a rich JSON blob from Claude Code on each turn containing context window size, used percentage, cost, model display name, workspace dir, etc. That data is currently consumed for display and then discarded. Tapping it once to a sibling file is effectively free and unlocks programmatic introspection from inside any session.

Companion note going into the user-level global `CLAUDE.md`:

> **Session token / context usage** — when the user asks "how many tokens am I using," read `~/.claude/statusline_last_input.json` with `jq`, don't guess from transcript length.

## Test plan

- [ ] Deploy the updated script to `~/.claude/statusline-command.sh`
- [ ] Trigger a turn in a fresh session, confirm `~/.claude/statusline_last_input.json` appears and contains `context_window`, `cost`, `model` keys
- [ ] Verify the statusline itself still renders (no visible regression)
- [ ] `jq .context_window.used_percentage ~/.claude/statusline_last_input.json` returns a number

Generated with [Claude Code](https://claude.com/claude-code)