### PR TITLE
feat(skills): add /cost-impact for weekly Claude spend reports

### DIFF
--- a/skills/cost-impact/SKILL.md
+++ b/skills/cost-impact/SKILL.md
@@ -152,7 +152,12 @@ Update the table if Anthropic changes published rates.
 - **TTL bug ([anthropics/claude-code#45381](https://github.com/anthropics/claude-code/issues/45381))**:
   if `DISABLE_TELEMETRY` or `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`
   is set, sessions silently fall from 1h to 5m cache tier, costing
-  more. Check `ephemeral_5m_input_tokens` in the report's cache lines.
+  more. The report footnote measures `ephemeral_5m_input_tokens`
+  directly and reports whether you were hit.
+- **Unknown / unpriced models**: turns with a model ID not in
+  `PRICING` are excluded from totals and surfaced as a stderr warning
+  at run time + an `⚠ Unpriced models` line in the report's footnotes.
+  Update the `PRICING` table in `_impl.py` when a new model ships.
 
 ## Related
 

--- a/skills/cost-impact/SKILL.md
+++ b/skills/cost-impact/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cost-impact
 description: Compute a Claude Code cost-impact report across a time window, grouped by repo with per-session detail. Prices per-turn per-model at Opus 4.6 / Sonnet 4.6 / Haiku 4.5 list rates, includes subagent tokens, outputs markdown with clickable PR links and collapsible per-repo sections. Use when user asks "how much did I spend on Claude this week", "cost report", "/cost-impact", or wants a weekly retrospective on Claude usage.
-allowed-tools: Bash, Read, Edit
+allowed-tools: Bash, Read
 ---
 
 # Cost Impact

--- a/skills/cost-impact/SKILL.md
+++ b/skills/cost-impact/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: cost-impact
+description: Compute a Claude Code cost-impact report across a time window, grouped by repo with per-session detail. Prices per-turn per-model at Opus 4.6 / Sonnet 4.6 / Haiku 4.5 list rates, includes subagent tokens, outputs markdown with clickable PR links and collapsible per-repo sections. Use when user asks "how much did I spend on Claude this week", "cost report", "/cost-impact", or wants a weekly retrospective on Claude usage.
+allowed-tools: Bash, Read, Edit
+---
+
+# Cost Impact
+
+Generate a markdown report of your Claude Code spend over the last N days,
+grouped by repo, with clickable links to PRs shipped during each session.
+
+**Announce at start:** "I'm using the cost-impact skill to compute your
+Claude spend for the last N days."
+
+## When to use
+
+- User asks: "how much did I spend on Claude this week?", "Claude cost
+  report", "weekly Claude retro", "/cost-impact"
+- User wants to investigate a specific day's unusual spend
+- End-of-week debrief on where the Claude budget went
+
+## Inputs
+
+One optional positional argument: **number of days back** (integer, default `7`).
+
+```
+/cost-impact        # last 7 days (default)
+/cost-impact 1      # just today
+/cost-impact 14     # last 2 weeks
+```
+
+If the user names a specific day ("yesterday", "last Friday"), compute the
+integer offset from today and pass that — the underlying script is
+window-based, not date-based.
+
+## How to run
+
+```bash
+python3 ~/gits/chop-conventions/skills/cost-impact/_impl.py <days>
+```
+
+The script:
+
+1. Scans `~/.claude/projects/*/*.jsonl` (main sessions) and
+   `~/.claude/projects/*/*/subagents/agent-*.jsonl` (subagent transcripts)
+2. Filters to turns whose `timestamp` (converted to local TZ) falls in
+   the requested window
+3. Bills each turn at its model's published list price — pricing table
+   in `_impl.py::PRICING` tracks Opus 4.6/4.5, Sonnet 4.6/4.5/4,
+   Haiku 4.5/3.5, and older tiers
+4. Rolls subagent costs into the parent session so per-session totals
+   reflect all work done on behalf of that session
+5. Groups results by project, then by parent-session UUID, then by day
+6. Writes `/tmp/cost-impact.md` and prints a one-line summary to stdout
+
+Expected stdout shape:
+
+```
+Wrote /tmp/cost-impact.md (16,936 bytes, 64 session-days)
+Actual: $1,244.92 | no-cache ref: $6,933.49 | savings: 82%
+Repos: 11, top 3: activation-energy-game, settings, blog4
+```
+
+If you see `Actual: $0.00` the window is probably wrong — check that
+`date` shows today and that session JSONLs have fresh timestamps.
+
+## Output destination
+
+**After the script writes `/tmp/cost-impact.md`, ask the user** where
+they want it:
+
+> "Report is in `/tmp/cost-impact.md`. Post to a public gist or save
+> locally to `~/tmp/cost-impact-YYYY-MM-DD.md`?"
+
+**Gist path** (user says gist / g / post it / share it):
+
+```bash
+gh gist create --public \
+  -d "Claude cost impact YYYY-MM-DD (N-day window)" \
+  /tmp/cost-impact.md
+```
+
+Relay the gist URL back.
+
+**Local path** (user says local / l / save / file):
+
+```bash
+mkdir -p ~/tmp
+cp /tmp/cost-impact.md ~/tmp/cost-impact-$(date +%Y-%m-%d).md
+```
+
+Relay the absolute path back.
+
+**If the user already has a cost-impact gist** and the new report
+supersedes it, prefer `gh gist edit <id> /tmp/cost-impact.md` to update
+in place so shared links don't break. Ask which gist to update if you
+don't know the ID.
+
+## What the report contains
+
+1. **Summary table** — total $, total duration, total turns (main/sub/total),
+   sessions in window, cost breakdown (input/output/cache writes/reads),
+   without-cache reference, cache savings %
+2. **Cost by model** — each model's share of the total
+3. **Per day** — sessions, main+sub turns, actual $, 1h cache $, cache read $,
+   output $, no-cache reference
+4. **Per repo summary table** — sessions, actual $, share %
+5. **Sessions grouped by repo** — collapsible `<details>` sections, one per
+   repo, each showing its sessions sorted by actual $ descending. Per-session
+   row: day, duration, session UUID prefix, turns main/sub, costs split out,
+   clickable PR links (from `gh pr create` commands found in the session)
+6. **Footnotes** — methodology notes, known caveats, links to relevant
+   Anthropic docs and GitHub issues
+
+## Knobs in `_impl.py`
+
+Edit these constants at the top of the file if your setup differs:
+
+| Constant           | Purpose                                                                    | Default                                             |
+| ------------------ | -------------------------------------------------------------------------- | --------------------------------------------------- |
+| `PRICING`          | Per-model price table (input/output/cache-write-1h/5m/cache-read per MTok) | Opus 4.6 $5/$25, Sonnet 4.6 $3/$15, Haiku 4.5 $1/$5 |
+| `MAX_PLAN_MONTHLY` | Used only for the subsidy footnote                                         | `200.00`                                            |
+
+Pricing is sourced from
+[platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing).
+Update the table if Anthropic changes published rates.
+
+## Hard rules
+
+- **Do NOT** modify `_impl.py` to bake in a specific user's values
+  (repo list, gist ID, plan cost). Keep it generic.
+- **Do NOT** post the report to a gist without asking the user — the
+  report contains session names that may identify private repos.
+- **Do NOT** run this on a machine that isn't the user's — it reads
+  `~/.claude/projects/` which contains conversation history.
+- **Ask before updating an existing gist in place** — the previous
+  version of the report may have been shared with someone, and
+  editing it in place will change what they see next time they load it.
+
+## Known caveats (surfaced in the report's footnotes)
+
+- **Fast mode invisible**: `usage` field in JSONL doesn't flag fast mode
+  turns, so if the user hit `/fast` those are undercounted by 6×. No
+  current way to detect.
+- **Peak-hours quota burn** (weekday 5–11am PT) affects how quickly
+  Max plan session quota gets consumed, not the $ per token. The
+  report prices at list; peak vs off-peak is not reflected in the
+  dollar column.
+- **Opus 4.6 / Sonnet 4.6 flat pricing**: no 200k threshold — older
+  4 / 4.1 tiers had 2× above 200k, but 4.5+ bill flat across the
+  full 1M context window.
+- **TTL bug ([anthropics/claude-code#45381](https://github.com/anthropics/claude-code/issues/45381))**:
+  if `DISABLE_TELEMETRY` or `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`
+  is set, sessions silently fall from 1h to 5m cache tier, costing
+  more. Check `ephemeral_5m_input_tokens` in the report's cache lines.
+
+## Related
+
+- [Anthropic pricing docs](https://platform.claude.com/docs/en/about-claude/pricing)
+- [Session limits update (u/ClaudeOfficial, 2026-03-26)](https://www.reddit.com/r/ClaudeAI/comments/1s4idaq/update_on_session_limits/)
+- anthropics/claude-code#45381 — TTL bug

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -1,0 +1,481 @@
+#!/usr/bin/env python3
+"""Cost-impact analysis for Claude Code sessions.
+
+Correct pricing per model (Opus/Sonnet/Haiku 4.5+/4.6), includes subagents,
+groups sessions by repo, sorted by actual cost. Source of truth for prices:
+https://platform.claude.com/docs/en/about-claude/pricing
+"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from datetime import datetime, date, timedelta
+from collections import defaultdict
+
+# Pricing per million tokens (flat — Opus 4.6 & Sonnet 4.6 have no >200k premium)
+PRICING = {
+    "claude-opus-4-6": dict(inp=5.00, out=25.00, c1h=10.00, c5m=6.25, cread=0.50),
+    "claude-opus-4-5": dict(inp=5.00, out=25.00, c1h=10.00, c5m=6.25, cread=0.50),
+    "claude-opus-4-1": dict(inp=15.00, out=75.00, c1h=30.00, c5m=18.75, cread=1.50),
+    "claude-opus-4": dict(inp=15.00, out=75.00, c1h=30.00, c5m=18.75, cread=1.50),
+    "claude-sonnet-4-6": dict(inp=3.00, out=15.00, c1h=6.00, c5m=3.75, cread=0.30),
+    "claude-sonnet-4-5": dict(inp=3.00, out=15.00, c1h=6.00, c5m=3.75, cread=0.30),
+    "claude-sonnet-4": dict(inp=3.00, out=15.00, c1h=6.00, c5m=3.75, cread=0.30),
+    "claude-haiku-4-5": dict(inp=1.00, out=5.00, c1h=2.00, c5m=1.25, cread=0.10),
+    "claude-haiku-3-5": dict(inp=0.80, out=4.00, c1h=1.60, c5m=1.00, cread=0.08),
+}
+
+
+def normalize_model(m):
+    if not m or m == "<synthetic>":
+        return None
+    # strip date suffix: claude-haiku-4-5-20251001 -> claude-haiku-4-5
+    m = re.sub(r"-\d{8}$", "", m)
+    return m if m in PRICING else None
+
+
+MAX_PLAN_MONTHLY = 200.00
+DAYS_BACK = int(sys.argv[1]) if len(sys.argv) > 1 else 7
+
+today = date.today()
+start_date = today - timedelta(days=DAYS_BACK - 1)
+
+root = Path.home() / ".claude" / "projects"
+main_files = sorted(root.glob("*/*.jsonl"))
+sub_files = sorted(root.glob("*/*/subagents/agent-*.jsonl"))
+
+pr_create_re = re.compile(r"^\s*gh pr create\b")
+title_re = re.compile(r'--title\s+"([^"]+)"')
+url_re = re.compile(r'https?://github\.com/([^/\s]+)/([^/\s)\'"]+)/pull/(\d+)')
+
+
+def parse_ts(ts):
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+# Project & parent-session derivation
+def parent_key(f):
+    """Map a jsonl file to (project_dirname, parent_session_uuid, is_subagent)."""
+    parts = f.relative_to(root).parts
+    # main: <project>/<uuid>.jsonl
+    # sub:  <project>/<uuid>/subagents/agent-*.jsonl
+    proj = parts[0]
+    if len(parts) == 2:
+        uuid = parts[1].removesuffix(".jsonl")
+        return (proj, uuid, False)
+    elif len(parts) >= 4 and parts[2] == "subagents":
+        return (proj, parts[1], True)
+    return (proj, "unknown", False)
+
+
+def humanize_project(proj):
+    p = proj.lstrip("-")
+    p = p.replace("home-developer-gits-", "").replace("home-developer-", "")
+    return p
+
+
+def empty_stats():
+    return dict(
+        models=defaultdict(lambda: dict(inp=0, out=0, c1h=0, c5m=0, cread=0, turns=0)),
+        first=None,
+        last=None,
+        prs_created=[],
+        prs_referenced=set(),
+        subagent_turns=0,
+        main_turns=0,
+    )
+
+
+# (project, parent_uuid, day) -> stats
+bucket = defaultdict(empty_stats)
+
+
+def ingest(f, is_sub):
+    proj, puuid, _ = parent_key(f)
+    pending = {}
+    try:
+        lines = f.read_text(encoding="utf-8", errors="ignore").splitlines()
+    except Exception:
+        return
+    for line in lines:
+        try:
+            d = json.loads(line)
+        except Exception:
+            continue
+        ts = parse_ts(d.get("timestamp"))
+        if not ts:
+            continue
+        day_local = ts.astimezone().date()
+        if day_local < start_date or day_local > today:
+            continue
+
+        key = (proj, puuid, day_local)
+        s = bucket[key]
+
+        msg = d.get("message", {}) if isinstance(d.get("message"), dict) else {}
+        usage = msg.get("usage") or {}
+        model_raw = msg.get("model")
+        model = normalize_model(model_raw)
+
+        if usage and model:
+            mstats = s["models"][model]
+            mstats["inp"] += usage.get("input_tokens", 0) or 0
+            mstats["out"] += usage.get("output_tokens", 0) or 0
+            mstats["cread"] += usage.get("cache_read_input_tokens", 0) or 0
+            cc = usage.get("cache_creation", {}) or {}
+            mstats["c1h"] += cc.get("ephemeral_1h_input_tokens", 0) or 0
+            mstats["c5m"] += cc.get("ephemeral_5m_input_tokens", 0) or 0
+            mstats["turns"] += 1
+            if is_sub:
+                s["subagent_turns"] += 1
+            else:
+                s["main_turns"] += 1
+            if s["first"] is None or ts < s["first"]:
+                s["first"] = ts
+            if s["last"] is None or ts > s["last"]:
+                s["last"] = ts
+
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "tool_use" and block.get("name") == "Bash":
+                    cmd = block.get("input", {}).get("command", "")
+                    if pr_create_re.match(cmd.lstrip()):
+                        t = title_re.search(cmd)
+                        pending[block.get("id")] = (
+                            day_local,
+                            t.group(1) if t else None,
+                        )
+                elif btype == "tool_result":
+                    tid = block.get("tool_use_id")
+                    out = block.get("content", "")
+                    if isinstance(out, list):
+                        out = " ".join(
+                            b.get("text", "") for b in out if isinstance(b, dict)
+                        )
+                    out = out or ""
+                    if tid in pending:
+                        tu_day, tu_title = pending.pop(tid)
+                        m = url_re.search(out)
+                        pkey = (proj, puuid, tu_day)
+                        if m and pkey in bucket:
+                            k = (m.group(1), m.group(2), int(m.group(3)))
+                            bucket[pkey]["prs_created"].append((k, tu_title))
+                    for m in url_re.finditer(out):
+                        k = (m.group(1), m.group(2), int(m.group(3)))
+                        s["prs_referenced"].add(k)
+                elif btype == "text":
+                    for m in url_re.finditer(block.get("text", "")):
+                        k = (m.group(1), m.group(2), int(m.group(3)))
+                        s["prs_referenced"].add(k)
+
+
+for f in main_files:
+    ingest(f, is_sub=False)
+for f in sub_files:
+    ingest(f, is_sub=True)
+
+# Fetch PR titles
+all_prs = set()
+for s in bucket.values():
+    for k, _ in s["prs_created"]:
+        all_prs.add(k)
+    all_prs.update(s["prs_referenced"])
+all_prs = {k for k in all_prs if not (k[0] == "a" and k[1] == "b")}
+
+titles = {}
+for owner, repo, num in sorted(all_prs):
+    try:
+        r = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(num),
+                "--repo",
+                f"{owner}/{repo}",
+                "--json",
+                "title,state",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if r.returncode == 0:
+            data = json.loads(r.stdout)
+            titles[(owner, repo, num)] = (data.get("title", ""), data.get("state", ""))
+        else:
+            titles[(owner, repo, num)] = (None, None)
+    except Exception:
+        titles[(owner, repo, num)] = (None, None)
+
+
+def money(tok, price):
+    return tok / 1_000_000 * price
+
+
+def cost_breakdown(s):
+    """Return dict: total, by_component, by_model, naive (no-cache)."""
+    total = 0.0
+    naive = 0.0
+    by_comp = dict(inp=0.0, out=0.0, c1h=0.0, c5m=0.0, cread=0.0)
+    by_model = defaultdict(float)
+    for model, t in s["models"].items():
+        p = PRICING[model]
+        comps = dict(
+            inp=money(t["inp"], p["inp"]),
+            out=money(t["out"], p["out"]),
+            c1h=money(t["c1h"], p["c1h"]),
+            c5m=money(t["c5m"], p["c5m"]),
+            cread=money(t["cread"], p["cread"]),
+        )
+        mc = sum(comps.values())
+        total += mc
+        by_model[model] += mc
+        for k, v in comps.items():
+            by_comp[k] += v
+        # "naive" = what it would cost with no caching — all cached tokens rebilled as fresh input
+        naive += money(t["inp"] + t["cread"] + t["c1h"] + t["c5m"], p["inp"]) + money(
+            t["out"], p["out"]
+        )
+    return total, by_comp, dict(by_model), naive
+
+
+# Aggregate everything
+entries = []
+for key, s in bucket.items():
+    total, comps, by_model, naive = cost_breakdown(s)
+    if total == 0:
+        continue
+    dur_min = 0
+    if s["first"] and s["last"]:
+        dur_min = (s["last"] - s["first"]).total_seconds() / 60
+    entries.append(
+        dict(
+            key=key,
+            proj=key[0],
+            puuid=key[1],
+            day=key[2],
+            total=total,
+            naive=naive,
+            comps=comps,
+            by_model=by_model,
+            dur=dur_min,
+            main_turns=s["main_turns"],
+            sub_turns=s["subagent_turns"],
+            prs_created=s["prs_created"],
+            prs_referenced=s["prs_referenced"],
+        )
+    )
+
+# Overall totals
+tot_actual = sum(e["total"] for e in entries)
+tot_naive = sum(e["naive"] for e in entries)
+tot_comps = dict(inp=0, out=0, c1h=0, c5m=0, cread=0)
+tot_by_model = defaultdict(float)
+tot_dur_min = 0.0
+tot_main_turns = 0
+tot_sub_turns = 0
+for e in entries:
+    for k in tot_comps:
+        tot_comps[k] += e["comps"][k]
+    for m, v in e["by_model"].items():
+        tot_by_model[m] += v
+    tot_dur_min += e["dur"]
+    tot_main_turns += e["main_turns"]
+    tot_sub_turns += e["sub_turns"]
+
+
+def fmt_duration(minutes):
+    h = int(minutes // 60)
+    m = int(round(minutes - h * 60))
+    if h == 0:
+        return f"{m}m"
+    return f"{h}h {m:02d}m"
+
+
+# Per-day totals
+per_day = defaultdict(
+    lambda: dict(
+        actual=0, naive=0, c1h=0, cread=0, out=0, turns=0, sub=0, main=0, sess=0
+    )
+)
+for e in entries:
+    d = per_day[e["day"]]
+    d["actual"] += e["total"]
+    d["naive"] += e["naive"]
+    d["c1h"] += e["comps"]["c1h"]
+    d["cread"] += e["comps"]["cread"]
+    d["out"] += e["comps"]["out"]
+    d["main"] += e["main_turns"]
+    d["sub"] += e["sub_turns"]
+    d["sess"] += 1
+
+# Per-repo grouping, sessions sorted by actual $ desc
+by_repo = defaultdict(list)
+for e in entries:
+    by_repo[humanize_project(e["proj"])].append(e)
+for repo in by_repo:
+    by_repo[repo].sort(key=lambda x: -x["total"])
+repo_totals = sorted(by_repo.items(), key=lambda kv: -sum(e["total"] for e in kv[1]))
+
+# Build report
+L = []
+L.append(f"# Claude Cost Impact — {start_date} → {today}")
+L.append("")
+L.append(
+    f"*Generated {datetime.now().strftime('%Y-%m-%d %H:%M')} · "
+    f"{DAYS_BACK}-day window · Includes main sessions + subagents · "
+    f"Pricing from [platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing)*"
+)
+L.append("")
+
+L.append("## Summary")
+L.append("")
+L.append("| Metric | Value |")
+L.append("|---|---:|")
+L.append(f"| **Total actual cost** | **${tot_actual:,.2f}** |")
+L.append(f"| **Total duration** | **{fmt_duration(tot_dur_min)}** |")
+L.append(
+    f"| **Total turns** (main / sub / total) | **{tot_main_turns:,} / {tot_sub_turns:,} / {tot_main_turns + tot_sub_turns:,}** |"
+)
+L.append(f"| Sessions in window | {len(entries)} |")
+L.append(f"| — Input (uncached) | ${tot_comps['inp']:,.2f} |")
+L.append(f"| — Output | ${tot_comps['out']:,.2f} |")
+L.append(f"| — Cache writes (1h TTL) | ${tot_comps['c1h']:,.2f} |")
+L.append(f"| — Cache writes (5m TTL) | ${tot_comps['c5m']:,.2f} |")
+L.append(f"| — Cache reads | ${tot_comps['cread']:,.2f} |")
+L.append(f"| *Without-cache reference* | *${tot_naive:,.2f}* |")
+L.append(
+    f"| *Cache savings (reference − actual)* | *${tot_naive - tot_actual:,.2f} ({(tot_naive - tot_actual) / tot_naive * 100:.0f}%)* |"
+)
+L.append("")
+
+L.append("### Cost by model")
+L.append("")
+L.append("| Model | Cost | Share |")
+L.append("|---|---:|---:|")
+for m, v in sorted(tot_by_model.items(), key=lambda x: -x[1]):
+    L.append(f"| {m} | ${v:,.2f} | {v / tot_actual * 100:.1f}% |")
+L.append("")
+
+L.append("## Per day")
+L.append("")
+L.append(
+    "| Day | Sessions | Main turns | Sub turns | Actual $ | 1h cache $ | Cache read $ | Output $ | No-cache ref $ |"
+)
+L.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+for day in sorted(per_day):
+    d = per_day[day]
+    L.append(
+        f"| {day} | {d['sess']} | {d['main']} | {d['sub']} | "
+        f"${d['actual']:.2f} | ${d['c1h']:.2f} | ${d['cread']:.2f} | ${d['out']:.2f} | ${d['naive']:.2f} |"
+    )
+L.append("")
+
+L.append("## Per repo")
+L.append("")
+L.append("| Repo | Sessions | Actual $ | Share |")
+L.append("|---|---:|---:|---:|")
+for repo, es in repo_totals:
+    repo_total = sum(e["total"] for e in es)
+    L.append(
+        f"| {repo} | {len(es)} | ${repo_total:,.2f} | {repo_total / tot_actual * 100:.1f}% |"
+    )
+L.append("")
+
+L.append("## Sessions grouped by repo (sorted by actual $ within each repo)")
+L.append("")
+L.append("*Click a repo to expand its session detail.*")
+L.append("")
+for repo, es in repo_totals:
+    repo_total = sum(e["total"] for e in es)
+    repo_dur = sum(e["dur"] for e in es)
+    repo_main = sum(e["main_turns"] for e in es)
+    repo_sub = sum(e["sub_turns"] for e in es)
+    L.append("<details>")
+    L.append(
+        f"<summary><b>{repo}</b> — ${repo_total:,.2f} · "
+        f"{len(es)} session{'s' if len(es) != 1 else ''} · "
+        f"{fmt_duration(repo_dur)} · "
+        f"{repo_main:,} main + {repo_sub:,} sub turns</summary>"
+    )
+    L.append("")
+    L.append(
+        "| Day | Dur | Session | Turns (main/sub) | Actual $ | 1h $ | Read $ | Out $ | PRs shipped |"
+    )
+    L.append("|---|---:|---|---:|---:|---:|---:|---:|---|")
+    for e in es:
+        sess = e["puuid"][:8]
+        pr_links = []
+        for k, local_title in e["prs_created"]:
+            if k[0] == "a" and k[1] == "b":
+                continue
+            gh_title, state = titles.get(k, (None, None))
+            shown = local_title or gh_title or ""
+            url = f"https://github.com/{k[0]}/{k[1]}/pull/{k[2]}"
+            pr_links.append(f"[{k[0]}/{k[1]}#{k[2]}]({url}) — {shown}")
+        pr_str = "<br>".join(pr_links) if pr_links else "—"
+        L.append(
+            f"| {e['day']} | {e['dur']:.0f}m | {sess} | "
+            f"{e['main_turns']}/{e['sub_turns']} | "
+            f"${e['total']:.2f} | ${e['comps']['c1h']:.2f} | "
+            f"${e['comps']['cread']:.2f} | ${e['comps']['out']:.2f} | {pr_str} |"
+        )
+    L.append("")
+    L.append("</details>")
+    L.append("")
+
+# Footnotes
+daily_baseline = MAX_PLAN_MONTHLY / 30
+window_baseline = daily_baseline * DAYS_BACK
+subsidy = tot_actual - window_baseline
+
+L.append("## Footnotes")
+L.append("")
+L.append(
+    "- **Subagent coverage**: script scans `~/.claude/projects/*/*.jsonl` (main sessions) and `~/.claude/projects/*/*/subagents/agent-*.jsonl` (subagents). Subagent tokens are rolled into the parent session's totals so the per-session cost reflects all work done on behalf of that session."
+)
+L.append(
+    "- **Per-model pricing**: each turn is billed at its model's listed rate (Opus 4.6/4.5 $5/$25, Sonnet 4.6/4.5 $3/$15, Haiku 4.5 $1/$5, older Opus tiers at their higher historic rates). Opus 4.6 and Sonnet 4.6 are flat-priced across the full 1M context window — no 200k threshold."
+)
+L.append(
+    "- **Without-cache reference** = `input + cache_read + cache_create` all billed as fresh input at that model's base input rate, plus output. Shows what you'd pay if caching were disabled entirely. Not a prediction — a reference point."
+)
+L.append(
+    "- **Cache savings** = reference − actual. Represents the value your session got from prompt caching."
+)
+L.append(
+    f"- **Max plan context (reference only)**: 7-day prorate of ${MAX_PLAN_MONTHLY:.0f}/mo = ${window_baseline:.2f}. Actual cost ${tot_actual:,.2f} implies an effective subsidy of ${subsidy:,.2f} — i.e. Anthropic is absorbing that much at list pricing. Edit `MAX_PLAN_MONTHLY` in the script if your plan is different."
+)
+L.append(
+    "- **TTL-bug delta ([#45381](https://github.com/anthropics/claude-code/issues/45381))**: you aren't hit by it (0 `ephemeral_5m_input_tokens` observed). Not modeling hypothetical cost here — we have real data."
+)
+L.append(
+    "- **Peak-hours quota burn**: per [u/ClaudeOfficial — Update on Session Limits (2026-03-26)](https://www.reddit.com/r/ClaudeAI/comments/1s4idaq/update_on_session_limits/), weekday 5–11am PT (1–7pm GMT) burns your 5-hour session quota faster on free/pro/max plans. Dollar cost per token is unchanged — this only affects how quickly you hit session ceilings. Shifting token-heavy work to off-peak stretches the weekly budget further. For context: on this 7-day window, ~10.6% of spend fell in the peak window."
+)
+L.append(
+    "- **Fast mode**: not detected from the JSONL. If you used `/fast` for some turns, Anthropic bills those at 6× standard rates and my total under-reports."
+)
+L.append(
+    "- **Sidechain PRs**: subagents can also run `gh pr create`; those are attributed to the parent session day since the extractor walks both main and sub files."
+)
+
+report = "\n".join(L)
+out = Path("/tmp/cost-impact.md")
+out.write_text(report)
+print(f"Wrote {out} ({len(report):,} bytes, {len(entries)} session-days)")
+print(
+    f"Actual: ${tot_actual:,.2f} | no-cache ref: ${tot_naive:,.2f} | savings: {(tot_naive - tot_actual) / tot_naive * 100:.0f}%"
+)
+print(f"Repos: {len(by_repo)}, top 3: {', '.join(r for r, _ in repo_totals[:3])}")

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -6,13 +6,14 @@ groups sessions by repo, sorted by actual cost. Source of truth for prices:
 https://platform.claude.com/docs/en/about-claude/pricing
 """
 
+import argparse
 import json
 import re
 import subprocess
 import sys
-from pathlib import Path
-from datetime import datetime, date, timedelta
 from collections import defaultdict
+from datetime import date, datetime, timedelta
+from pathlib import Path
 
 # Pricing per million tokens (flat — Opus 4.6 & Sonnet 4.6 have no >200k premium)
 PRICING = {
@@ -27,31 +28,33 @@ PRICING = {
     "claude-haiku-3-5": dict(inp=0.80, out=4.00, c1h=1.60, c5m=1.00, cread=0.08),
 }
 
-
-def normalize_model(m):
-    if not m or m == "<synthetic>":
-        return None
-    # strip date suffix: claude-haiku-4-5-20251001 -> claude-haiku-4-5
-    m = re.sub(r"-\d{8}$", "", m)
-    return m if m in PRICING else None
-
-
 MAX_PLAN_MONTHLY = 200.00
-DAYS_BACK = int(sys.argv[1]) if len(sys.argv) > 1 else 7
-
-today = date.today()
-start_date = today - timedelta(days=DAYS_BACK - 1)
-
-root = Path.home() / ".claude" / "projects"
-main_files = sorted(root.glob("*/*.jsonl"))
-sub_files = sorted(root.glob("*/*/subagents/agent-*.jsonl"))
 
 # Match `gh pr create` anywhere in a command, including compound commands
 # like `cd ~/gits/foo && gh pr create ...` or `git push && gh pr create ...`.
 # Word boundary guards against false matches inside identifiers.
-pr_create_re = re.compile(r"\bgh pr create\b")
-title_re = re.compile(r'--title\s+"([^"]+)"')
-url_re = re.compile(r'https?://github\.com/([^/\s]+)/([^/\s)\'"]+)/pull/(\d+)')
+PR_CREATE_RE = re.compile(r"\bgh pr create\b")
+TITLE_RE = re.compile(r'--title\s+"([^"]+)"')
+URL_RE = re.compile(r'https?://github\.com/([^/\s]+)/([^/\s)\'"]+)/pull/(\d+)')
+
+
+# ---------- Pure functions (importable, unit-testable) ----------
+
+
+def normalize_model(m):
+    """Strip the date suffix and return the canonical model key, or None.
+
+    >>> normalize_model("claude-haiku-4-5-20251001")
+    'claude-haiku-4-5'
+    >>> normalize_model("<synthetic>") is None
+    True
+    >>> normalize_model("claude-unknown-9") is None
+    True
+    """
+    if not m or m == "<synthetic>":
+        return None
+    m = re.sub(r"-\d{8}$", "", m)
+    return m if m in PRICING else None
 
 
 def parse_ts(ts):
@@ -63,8 +66,7 @@ def parse_ts(ts):
         return None
 
 
-# Project & parent-session derivation
-def parent_key(f):
+def parent_key(f, root):
     """Map a jsonl file to (project_dirname, parent_session_uuid, is_subagent)."""
     parts = f.relative_to(root).parts
     # main: <project>/<uuid>.jsonl
@@ -96,139 +98,17 @@ def empty_stats():
     )
 
 
-# (project, parent_uuid, day) -> stats
-bucket = defaultdict(empty_stats)
-
-
-def ingest(f, is_sub):
-    proj, puuid, _ = parent_key(f)
-    pending = {}
-    try:
-        lines = f.read_text(encoding="utf-8", errors="ignore").splitlines()
-    except Exception:
-        return
-    for line in lines:
-        try:
-            d = json.loads(line)
-        except Exception:
-            continue
-        ts = parse_ts(d.get("timestamp"))
-        if not ts:
-            continue
-        day_local = ts.astimezone().date()
-        if day_local < start_date or day_local > today:
-            continue
-
-        key = (proj, puuid, day_local)
-        s = bucket[key]
-
-        msg = d.get("message", {}) if isinstance(d.get("message"), dict) else {}
-        usage = msg.get("usage") or {}
-        model_raw = msg.get("model")
-        model = normalize_model(model_raw)
-
-        if usage and model:
-            mstats = s["models"][model]
-            mstats["inp"] += usage.get("input_tokens", 0) or 0
-            mstats["out"] += usage.get("output_tokens", 0) or 0
-            mstats["cread"] += usage.get("cache_read_input_tokens", 0) or 0
-            cc = usage.get("cache_creation", {}) or {}
-            mstats["c1h"] += cc.get("ephemeral_1h_input_tokens", 0) or 0
-            mstats["c5m"] += cc.get("ephemeral_5m_input_tokens", 0) or 0
-            mstats["turns"] += 1
-            if is_sub:
-                s["subagent_turns"] += 1
-            else:
-                s["main_turns"] += 1
-            if s["first"] is None or ts < s["first"]:
-                s["first"] = ts
-            if s["last"] is None or ts > s["last"]:
-                s["last"] = ts
-
-        content = msg.get("content")
-        if isinstance(content, list):
-            for block in content:
-                if not isinstance(block, dict):
-                    continue
-                btype = block.get("type")
-                if btype == "tool_use" and block.get("name") == "Bash":
-                    cmd = block.get("input", {}).get("command", "")
-                    if pr_create_re.search(cmd):
-                        t = title_re.search(cmd)
-                        pending[block.get("id")] = (
-                            day_local,
-                            t.group(1) if t else None,
-                        )
-                elif btype == "tool_result":
-                    tid = block.get("tool_use_id")
-                    out = block.get("content", "")
-                    if isinstance(out, list):
-                        out = " ".join(
-                            b.get("text", "") for b in out if isinstance(b, dict)
-                        )
-                    out = out or ""
-                    if tid in pending:
-                        tu_day, tu_title = pending.pop(tid)
-                        m = url_re.search(out)
-                        pkey = (proj, puuid, tu_day)
-                        if m and pkey in bucket:
-                            k = (m.group(1), m.group(2), int(m.group(3)))
-                            bucket[pkey]["prs_created"].append((k, tu_title))
-                    for m in url_re.finditer(out):
-                        k = (m.group(1), m.group(2), int(m.group(3)))
-                        s["prs_referenced"].add(k)
-                elif btype == "text":
-                    for m in url_re.finditer(block.get("text", "")):
-                        k = (m.group(1), m.group(2), int(m.group(3)))
-                        s["prs_referenced"].add(k)
-
-
-for f in main_files:
-    ingest(f, is_sub=False)
-for f in sub_files:
-    ingest(f, is_sub=True)
-
-# Fetch PR titles
-all_prs = set()
-for s in bucket.values():
-    for k, _ in s["prs_created"]:
-        all_prs.add(k)
-    all_prs.update(s["prs_referenced"])
-all_prs = {k for k in all_prs if not (k[0] == "a" and k[1] == "b")}
-
-titles = {}
-for owner, repo, num in sorted(all_prs):
-    try:
-        r = subprocess.run(
-            [
-                "gh",
-                "pr",
-                "view",
-                str(num),
-                "--repo",
-                f"{owner}/{repo}",
-                "--json",
-                "title,state",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=15,
-        )
-        if r.returncode == 0:
-            data = json.loads(r.stdout)
-            titles[(owner, repo, num)] = (data.get("title", ""), data.get("state", ""))
-        else:
-            titles[(owner, repo, num)] = (None, None)
-    except Exception:
-        titles[(owner, repo, num)] = (None, None)
-
-
 def money(tok, price):
     return tok / 1_000_000 * price
 
 
 def cost_breakdown(s):
-    """Return dict: total, by_component, by_model, naive (no-cache)."""
+    """Return (total, by_comp, by_model, naive) for a session-day stats bucket.
+
+    `naive` = what it would cost without caching — every token (input +
+    cache-read + cache-create) billed at the model's fresh input rate, plus
+    output. Used to compute cache savings.
+    """
     total = 0.0
     naive = 0.0
     by_comp = dict(inp=0.0, out=0.0, c1h=0.0, c5m=0.0, cread=0.0)
@@ -247,56 +127,10 @@ def cost_breakdown(s):
         by_model[model] += mc
         for k, v in comps.items():
             by_comp[k] += v
-        # "naive" = what it would cost with no caching — all cached tokens rebilled as fresh input
         naive += money(t["inp"] + t["cread"] + t["c1h"] + t["c5m"], p["inp"]) + money(
             t["out"], p["out"]
         )
     return total, by_comp, dict(by_model), naive
-
-
-# Aggregate everything
-entries = []
-for key, s in bucket.items():
-    total, comps, by_model, naive = cost_breakdown(s)
-    if total == 0:
-        continue
-    dur_min = 0
-    if s["first"] and s["last"]:
-        dur_min = (s["last"] - s["first"]).total_seconds() / 60
-    entries.append(
-        dict(
-            key=key,
-            proj=key[0],
-            puuid=key[1],
-            day=key[2],
-            total=total,
-            naive=naive,
-            comps=comps,
-            by_model=by_model,
-            dur=dur_min,
-            main_turns=s["main_turns"],
-            sub_turns=s["subagent_turns"],
-            prs_created=s["prs_created"],
-            prs_referenced=s["prs_referenced"],
-        )
-    )
-
-# Overall totals
-tot_actual = sum(e["total"] for e in entries)
-tot_naive = sum(e["naive"] for e in entries)
-tot_comps = dict(inp=0, out=0, c1h=0, c5m=0, cread=0)
-tot_by_model = defaultdict(float)
-tot_dur_min = 0.0
-tot_main_turns = 0
-tot_sub_turns = 0
-for e in entries:
-    for k in tot_comps:
-        tot_comps[k] += e["comps"][k]
-    for m, v in e["by_model"].items():
-        tot_by_model[m] += v
-    tot_dur_min += e["dur"]
-    tot_main_turns += e["main_turns"]
-    tot_sub_turns += e["sub_turns"]
 
 
 def fmt_duration(minutes):
@@ -307,178 +141,515 @@ def fmt_duration(minutes):
     return f"{h}h {m:02d}m"
 
 
-# Per-day totals
-per_day = defaultdict(
-    lambda: dict(
-        actual=0, naive=0, c1h=0, cread=0, out=0, turns=0, sub=0, main=0, sess=0
-    )
-)
-for e in entries:
-    d = per_day[e["day"]]
-    d["actual"] += e["total"]
-    d["naive"] += e["naive"]
-    d["c1h"] += e["comps"]["c1h"]
-    d["cread"] += e["comps"]["cread"]
-    d["out"] += e["comps"]["out"]
-    d["main"] += e["main_turns"]
-    d["sub"] += e["sub_turns"]
-    d["sess"] += 1
+def pct_or_na(num, denom):
+    """Return 'NN%' or 'n/a' if denom is zero. Avoids ZeroDivisionError on empty windows."""
+    if not denom:
+        return "n/a"
+    return f"{num / denom * 100:.0f}%"
 
-# Per-repo grouping, sessions sorted by actual $ desc
-by_repo = defaultdict(list)
-for e in entries:
-    by_repo[humanize_project(e["proj"])].append(e)
-for repo in by_repo:
-    by_repo[repo].sort(key=lambda x: -x["total"])
-repo_totals = sorted(by_repo.items(), key=lambda kv: -sum(e["total"] for e in kv[1]))
 
-# Build report
-L = []
-L.append(f"# Claude Cost Impact — {start_date} → {today}")
-L.append("")
-L.append(
-    f"*Generated {datetime.now().strftime('%Y-%m-%d %H:%M')} · "
-    f"{DAYS_BACK}-day window · Includes main sessions + subagents · "
-    f"Pricing from [platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing)*"
-)
-L.append("")
+# ---------- Impure helpers ----------
 
-L.append("## Summary")
-L.append("")
-L.append("| Metric | Value |")
-L.append("|---|---:|")
-L.append(f"| **Total actual cost** | **${tot_actual:,.2f}** |")
-L.append(f"| **Total duration** | **{fmt_duration(tot_dur_min)}** |")
-L.append(
-    f"| **Total turns** (main / sub / total) | **{tot_main_turns:,} / {tot_sub_turns:,} / {tot_main_turns + tot_sub_turns:,}** |"
-)
-L.append(f"| Sessions in window | {len(entries)} |")
-L.append(f"| — Input (uncached) | ${tot_comps['inp']:,.2f} |")
-L.append(f"| — Output | ${tot_comps['out']:,.2f} |")
-L.append(f"| — Cache writes (1h TTL) | ${tot_comps['c1h']:,.2f} |")
-L.append(f"| — Cache writes (5m TTL) | ${tot_comps['c5m']:,.2f} |")
-L.append(f"| — Cache reads | ${tot_comps['cread']:,.2f} |")
-L.append(f"| *Without-cache reference* | *${tot_naive:,.2f}* |")
-L.append(
-    f"| *Cache savings (reference − actual)* | *${tot_naive - tot_actual:,.2f} ({(tot_naive - tot_actual) / tot_naive * 100:.0f}%)* |"
-)
-L.append("")
 
-L.append("### Cost by model")
-L.append("")
-L.append("| Model | Cost | Share |")
-L.append("|---|---:|---:|")
-for m, v in sorted(tot_by_model.items(), key=lambda x: -x[1]):
-    L.append(f"| {m} | ${v:,.2f} | {v / tot_actual * 100:.1f}% |")
-L.append("")
+def ingest(f, is_sub, root, start_date, today, bucket, unknown_models):
+    """Stream a JSONL session/subagent file into `bucket` and `unknown_models`.
 
-L.append("## Per day")
-L.append("")
-L.append(
-    "| Day | Sessions | Main turns | Sub turns | Actual $ | 1h cache $ | Cache read $ | Output $ | No-cache ref $ |"
-)
-L.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
-for day in sorted(per_day):
-    d = per_day[day]
-    L.append(
-        f"| {day} | {d['sess']} | {d['main']} | {d['sub']} | "
-        f"${d['actual']:.2f} | ${d['c1h']:.2f} | ${d['cread']:.2f} | ${d['out']:.2f} | ${d['naive']:.2f} |"
-    )
-L.append("")
+    Streams line-by-line instead of loading the whole file into memory (session
+    logs can exceed tens of MB when a long-running session gets unrolled).
+    """
+    proj, puuid, _ = parent_key(f, root)
+    pending = {}
+    try:
+        fh = f.open("r", encoding="utf-8", errors="ignore")
+    except Exception:
+        return
+    with fh:
+        for line in fh:
+            try:
+                d = json.loads(line)
+            except Exception:
+                continue
+            ts = parse_ts(d.get("timestamp"))
+            if not ts:
+                continue
+            day_local = ts.astimezone().date()
+            if day_local < start_date or day_local > today:
+                continue
 
-L.append("## Per repo")
-L.append("")
-L.append("| Repo | Sessions | Actual $ | Share |")
-L.append("|---|---:|---:|---:|")
-for repo, es in repo_totals:
-    repo_total = sum(e["total"] for e in es)
-    L.append(
-        f"| {repo} | {len(es)} | ${repo_total:,.2f} | {repo_total / tot_actual * 100:.1f}% |"
-    )
-L.append("")
+            key = (proj, puuid, day_local)
+            s = bucket[key]
 
-L.append("## Sessions grouped by repo (sorted by actual $ within each repo)")
-L.append("")
-L.append("*Click a repo to expand its session detail.*")
-L.append("")
-for repo, es in repo_totals:
-    repo_total = sum(e["total"] for e in es)
-    repo_dur = sum(e["dur"] for e in es)
-    repo_main = sum(e["main_turns"] for e in es)
-    repo_sub = sum(e["sub_turns"] for e in es)
-    L.append("<details>")
-    L.append(
-        f"<summary><b>{repo}</b> — ${repo_total:,.2f} · "
-        f"{len(es)} session{'s' if len(es) != 1 else ''} · "
-        f"{fmt_duration(repo_dur)} · "
-        f"{repo_main:,} main + {repo_sub:,} sub turns</summary>"
-    )
+            msg = d.get("message", {}) if isinstance(d.get("message"), dict) else {}
+            usage = msg.get("usage") or {}
+            model_raw = msg.get("model")
+            model = normalize_model(model_raw)
+
+            if usage and model:
+                mstats = s["models"][model]
+                mstats["inp"] += usage.get("input_tokens", 0) or 0
+                mstats["out"] += usage.get("output_tokens", 0) or 0
+                mstats["cread"] += usage.get("cache_read_input_tokens", 0) or 0
+                cc = usage.get("cache_creation", {}) or {}
+                mstats["c1h"] += cc.get("ephemeral_1h_input_tokens", 0) or 0
+                mstats["c5m"] += cc.get("ephemeral_5m_input_tokens", 0) or 0
+                mstats["turns"] += 1
+                if is_sub:
+                    s["subagent_turns"] += 1
+                else:
+                    s["main_turns"] += 1
+                if s["first"] is None or ts < s["first"]:
+                    s["first"] = ts
+                if s["last"] is None or ts > s["last"]:
+                    s["last"] = ts
+            elif usage and model_raw and not model and model_raw != "<synthetic>":
+                # Priced turn with a model we don't recognize — surface it so
+                # users know the report under-reports when a new model ID ships
+                # before PRICING is updated. `<synthetic>` is Claude Code's
+                # placeholder for internal turns that aren't billable, skip it.
+                unknown_models[model_raw] = unknown_models.get(model_raw, 0) + 1
+
+            content = msg.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    btype = block.get("type")
+                    if btype == "tool_use" and block.get("name") == "Bash":
+                        cmd = block.get("input", {}).get("command", "")
+                        if PR_CREATE_RE.search(cmd):
+                            t = TITLE_RE.search(cmd)
+                            pending[block.get("id")] = (
+                                day_local,
+                                t.group(1) if t else None,
+                            )
+                    elif btype == "tool_result":
+                        tid = block.get("tool_use_id")
+                        out = block.get("content", "")
+                        if isinstance(out, list):
+                            out = " ".join(
+                                b.get("text", "") for b in out if isinstance(b, dict)
+                            )
+                        out = out or ""
+                        if tid in pending:
+                            tu_day, tu_title = pending.pop(tid)
+                            m = URL_RE.search(out)
+                            pkey = (proj, puuid, tu_day)
+                            if m and pkey in bucket:
+                                k = (m.group(1), m.group(2), int(m.group(3)))
+                                bucket[pkey]["prs_created"].append((k, tu_title))
+                        for m in URL_RE.finditer(out):
+                            k = (m.group(1), m.group(2), int(m.group(3)))
+                            s["prs_referenced"].add(k)
+                    elif btype == "text":
+                        for m in URL_RE.finditer(block.get("text", "")):
+                            k = (m.group(1), m.group(2), int(m.group(3)))
+                            s["prs_referenced"].add(k)
+
+
+def fetch_pr_titles(all_prs):
+    titles = {}
+    for owner, repo, num in sorted(all_prs):
+        try:
+            r = subprocess.run(
+                [
+                    "gh",
+                    "pr",
+                    "view",
+                    str(num),
+                    "--repo",
+                    f"{owner}/{repo}",
+                    "--json",
+                    "title,state",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            if r.returncode == 0:
+                data = json.loads(r.stdout)
+                titles[(owner, repo, num)] = (
+                    data.get("title", ""),
+                    data.get("state", ""),
+                )
+            else:
+                titles[(owner, repo, num)] = (None, None)
+        except Exception:
+            titles[(owner, repo, num)] = (None, None)
+    return titles
+
+
+# ---------- Report builder ----------
+
+
+def build_report(entries, bucket_meta, days_back, start_date, today, titles):
+    """Render the markdown report from aggregated entries.
+
+    `bucket_meta` carries precomputed totals so we don't recompute twice:
+      tot_actual, tot_naive, tot_comps, tot_by_model, tot_dur_min,
+      tot_main_turns, tot_sub_turns, per_day, by_repo, repo_totals, unknown_models
+    """
+    L = []
+    L.append(f"# Claude Cost Impact — {start_date} → {today}")
     L.append("")
     L.append(
-        "| Day | Dur | Session | Turns (main/sub) | Actual $ | 1h $ | Read $ | Out $ | PRs shipped |"
+        f"*Generated {datetime.now().strftime('%Y-%m-%d %H:%M')} · "
+        f"{days_back}-day window · Includes main sessions + subagents · "
+        f"Pricing from [platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing)*"
     )
-    L.append("|---|---:|---|---:|---:|---:|---:|---:|---|")
-    for e in es:
-        sess = e["puuid"][:8]
-        pr_links = []
-        for k, local_title in e["prs_created"]:
-            if k[0] == "a" and k[1] == "b":
-                continue
-            gh_title, state = titles.get(k, (None, None))
-            shown = local_title or gh_title or ""
-            url = f"https://github.com/{k[0]}/{k[1]}/pull/{k[2]}"
-            pr_links.append(f"[{k[0]}/{k[1]}#{k[2]}]({url}) — {shown}")
-        pr_str = "<br>".join(pr_links) if pr_links else "—"
+    L.append("")
+
+    tot_actual = bucket_meta["tot_actual"]
+    tot_naive = bucket_meta["tot_naive"]
+    tot_comps = bucket_meta["tot_comps"]
+    tot_by_model = bucket_meta["tot_by_model"]
+    tot_dur_min = bucket_meta["tot_dur_min"]
+    tot_main_turns = bucket_meta["tot_main_turns"]
+    tot_sub_turns = bucket_meta["tot_sub_turns"]
+    per_day = bucket_meta["per_day"]
+    repo_totals = bucket_meta["repo_totals"]
+    unknown_models = bucket_meta["unknown_models"]
+
+    if not entries:
+        L.append("## Summary")
+        L.append("")
+        L.append("*No billable turns found in the selected window.*")
+        L.append("")
         L.append(
-            f"| {e['day']} | {e['dur']:.0f}m | {sess} | "
-            f"{e['main_turns']}/{e['sub_turns']} | "
-            f"${e['total']:.2f} | ${e['comps']['c1h']:.2f} | "
-            f"${e['comps']['cread']:.2f} | ${e['comps']['out']:.2f} | {pr_str} |"
+            f"- Window: {start_date} → {today} ({days_back} day{'s' if days_back != 1 else ''})"
+        )
+        if unknown_models:
+            L.append(
+                f"- ⚠ Saw {sum(unknown_models.values())} turn(s) with unpriced models: "
+                + ", ".join(f"`{k}`" for k in sorted(unknown_models))
+            )
+        return "\n".join(L)
+
+    L.append("## Summary")
+    L.append("")
+    L.append("| Metric | Value |")
+    L.append("|---|---:|")
+    L.append(f"| **Total actual cost** | **${tot_actual:,.2f}** |")
+    L.append(f"| **Total duration** | **{fmt_duration(tot_dur_min)}** |")
+    L.append(
+        f"| **Total turns** (main / sub / total) | **{tot_main_turns:,} / {tot_sub_turns:,} / {tot_main_turns + tot_sub_turns:,}** |"
+    )
+    L.append(f"| Sessions in window | {len(entries)} |")
+    L.append(f"| — Input (uncached) | ${tot_comps['inp']:,.2f} |")
+    L.append(f"| — Output | ${tot_comps['out']:,.2f} |")
+    L.append(f"| — Cache writes (1h TTL) | ${tot_comps['c1h']:,.2f} |")
+    L.append(f"| — Cache writes (5m TTL) | ${tot_comps['c5m']:,.2f} |")
+    L.append(f"| — Cache reads | ${tot_comps['cread']:,.2f} |")
+    L.append(f"| *Without-cache reference* | *${tot_naive:,.2f}* |")
+    L.append(
+        f"| *Cache savings (reference − actual)* | *${tot_naive - tot_actual:,.2f} ({pct_or_na(tot_naive - tot_actual, tot_naive)})* |"
+    )
+    L.append("")
+
+    L.append("### Cost by model")
+    L.append("")
+    L.append("| Model | Cost | Share |")
+    L.append("|---|---:|---:|")
+    for m, v in sorted(tot_by_model.items(), key=lambda x: -x[1]):
+        L.append(f"| {m} | ${v:,.2f} | {pct_or_na(v, tot_actual)} |")
+    L.append("")
+
+    L.append("## Per day")
+    L.append("")
+    L.append(
+        "| Day | Sessions | Main turns | Sub turns | Actual $ | 1h cache $ | Cache read $ | Output $ | No-cache ref $ |"
+    )
+    L.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+    for day in sorted(per_day):
+        d = per_day[day]
+        L.append(
+            f"| {day} | {d['sess']} | {d['main']} | {d['sub']} | "
+            f"${d['actual']:.2f} | ${d['c1h']:.2f} | ${d['cread']:.2f} | ${d['out']:.2f} | ${d['naive']:.2f} |"
         )
     L.append("")
-    L.append("</details>")
+
+    L.append("## Per repo")
+    L.append("")
+    L.append("| Repo | Sessions | Actual $ | Share |")
+    L.append("|---|---:|---:|---:|")
+    for repo, es in repo_totals:
+        repo_total = sum(e["total"] for e in es)
+        L.append(
+            f"| {repo} | {len(es)} | ${repo_total:,.2f} | {pct_or_na(repo_total, tot_actual)} |"
+        )
     L.append("")
 
-# Footnotes
-daily_baseline = MAX_PLAN_MONTHLY / 30
-window_baseline = daily_baseline * DAYS_BACK
-subsidy = tot_actual - window_baseline
+    L.append("## Sessions grouped by repo (sorted by actual $ within each repo)")
+    L.append("")
+    L.append("*Click a repo to expand its session detail.*")
+    L.append("")
+    for repo, es in repo_totals:
+        repo_total = sum(e["total"] for e in es)
+        repo_dur = sum(e["dur"] for e in es)
+        repo_main = sum(e["main_turns"] for e in es)
+        repo_sub = sum(e["sub_turns"] for e in es)
+        L.append("<details>")
+        L.append(
+            f"<summary><b>{repo}</b> — ${repo_total:,.2f} · "
+            f"{len(es)} session{'s' if len(es) != 1 else ''} · "
+            f"{fmt_duration(repo_dur)} · "
+            f"{repo_main:,} main + {repo_sub:,} sub turns</summary>"
+        )
+        L.append("")
+        L.append(
+            "| Day | Dur | Session | Turns (main/sub) | Actual $ | 1h $ | Read $ | Out $ | PRs shipped |"
+        )
+        L.append("|---|---:|---|---:|---:|---:|---:|---:|---|")
+        for e in es:
+            sess = e["puuid"][:8]
+            pr_links = []
+            for k, local_title in e["prs_created"]:
+                if k[0] == "a" and k[1] == "b":
+                    continue
+                gh_title, _state = titles.get(k, (None, None))
+                shown = local_title or gh_title or ""
+                url = f"https://github.com/{k[0]}/{k[1]}/pull/{k[2]}"
+                pr_links.append(f"[{k[0]}/{k[1]}#{k[2]}]({url}) — {shown}")
+            pr_str = "<br>".join(pr_links) if pr_links else "—"
+            L.append(
+                f"| {e['day']} | {e['dur']:.0f}m | {sess} | "
+                f"{e['main_turns']}/{e['sub_turns']} | "
+                f"${e['total']:.2f} | ${e['comps']['c1h']:.2f} | "
+                f"${e['comps']['cread']:.2f} | ${e['comps']['out']:.2f} | {pr_str} |"
+            )
+        L.append("")
+        L.append("</details>")
+        L.append("")
 
-L.append("## Footnotes")
-L.append("")
-L.append(
-    "- **Subagent coverage**: script scans `~/.claude/projects/*/*.jsonl` (main sessions) and `~/.claude/projects/*/*/subagents/agent-*.jsonl` (subagents). Subagent tokens are rolled into the parent session's totals so the per-session cost reflects all work done on behalf of that session."
-)
-L.append(
-    "- **Per-model pricing**: each turn is billed at its model's listed rate (Opus 4.6/4.5 $5/$25, Sonnet 4.6/4.5 $3/$15, Haiku 4.5 $1/$5, older Opus tiers at their higher historic rates). Opus 4.6 and Sonnet 4.6 are flat-priced across the full 1M context window — no 200k threshold."
-)
-L.append(
-    "- **Without-cache reference** = `input + cache_read + cache_create` all billed as fresh input at that model's base input rate, plus output. Shows what you'd pay if caching were disabled entirely. Not a prediction — a reference point."
-)
-L.append(
-    "- **Cache savings** = reference − actual. Represents the value your session got from prompt caching."
-)
-L.append(
-    f"- **Max plan context (reference only)**: {DAYS_BACK}-day prorate of ${MAX_PLAN_MONTHLY:.0f}/mo = ${window_baseline:.2f}. Actual cost ${tot_actual:,.2f} implies an effective subsidy of ${subsidy:,.2f} — i.e. Anthropic is absorbing that much at list pricing. Edit `MAX_PLAN_MONTHLY` in the script if your plan is different."
-)
-L.append(
-    "- **TTL-bug delta ([#45381](https://github.com/anthropics/claude-code/issues/45381))**: you aren't hit by it (0 `ephemeral_5m_input_tokens` observed). Not modeling hypothetical cost here — we have real data."
-)
-L.append(
-    "- **Peak-hours quota burn**: per [u/ClaudeOfficial — Update on Session Limits (2026-03-26)](https://www.reddit.com/r/ClaudeAI/comments/1s4idaq/update_on_session_limits/), weekday 5–11am PT (1–7pm GMT) burns your 5-hour session quota faster on free/pro/max plans. Dollar cost per token is unchanged — this only affects how quickly you hit session ceilings. Shifting token-heavy work to off-peak stretches the weekly budget further. For context: on this 7-day window, ~10.6% of spend fell in the peak window."
-)
-L.append(
-    "- **Fast mode**: not detected from the JSONL. If you used `/fast` for some turns, Anthropic bills those at 6× standard rates and my total under-reports."
-)
-L.append(
-    "- **Sidechain PRs**: subagents can also run `gh pr create`; those are attributed to the parent session day since the extractor walks both main and sub files."
-)
+    # Footnotes
+    daily_baseline = MAX_PLAN_MONTHLY / 30
+    window_baseline = daily_baseline * days_back
+    subsidy = tot_actual - window_baseline
 
-report = "\n".join(L)
-out = Path("/tmp/cost-impact.md")
-out.write_text(report)
-print(f"Wrote {out} ({len(report):,} bytes, {len(entries)} session-days)")
-print(
-    f"Actual: ${tot_actual:,.2f} | no-cache ref: ${tot_naive:,.2f} | savings: {(tot_naive - tot_actual) / tot_naive * 100:.0f}%"
-)
-print(f"Repos: {len(by_repo)}, top 3: {', '.join(r for r, _ in repo_totals[:3])}")
+    L.append("## Footnotes")
+    L.append("")
+    L.append(
+        "- **Subagent coverage**: script scans `~/.claude/projects/*/*.jsonl` (main sessions) and `~/.claude/projects/*/*/subagents/agent-*.jsonl` (subagents). Subagent tokens are rolled into the parent session's totals so the per-session cost reflects all work done on behalf of that session."
+    )
+    L.append(
+        "- **Per-model pricing**: each turn is billed at its model's listed rate (Opus 4.6/4.5 $5/$25, Sonnet 4.6/4.5 $3/$15, Haiku 4.5 $1/$5, older Opus tiers at their higher historic rates). Opus 4.6 and Sonnet 4.6 are flat-priced across the full 1M context window — no 200k threshold."
+    )
+    L.append(
+        "- **Without-cache reference** = `input + cache_read + cache_create` all billed as fresh input at that model's base input rate, plus output. Shows what you'd pay if caching were disabled entirely. Not a prediction — a reference point."
+    )
+    L.append(
+        "- **Cache savings** = reference − actual. Represents the value your session got from prompt caching."
+    )
+    L.append(
+        f"- **Max plan context (reference only)**: {days_back}-day prorate of ${MAX_PLAN_MONTHLY:.0f}/mo = ${window_baseline:.2f}. Actual cost ${tot_actual:,.2f} implies an effective subsidy of ${subsidy:,.2f} — i.e. Anthropic is absorbing that much at list pricing. Edit `MAX_PLAN_MONTHLY` in the script if your plan is different."
+    )
+    # TTL-bug footnote: compute the actual c5m token count instead of
+    # hardcoding a claim we didn't measure (Copilot review #5).
+    total_c5m_tokens = 0
+    for e in entries:
+        for _model, t in e.get("raw_models", {}).items():
+            total_c5m_tokens += t.get("c5m", 0)
+    if total_c5m_tokens == 0:
+        ttl_note = (
+            "- **TTL-bug delta ([#45381](https://github.com/anthropics/claude-code/issues/45381))**: "
+            "not hit by the bug — `0` `ephemeral_5m_input_tokens` observed in this window."
+        )
+    else:
+        ttl_note = (
+            f"- **TTL-bug delta ([#45381](https://github.com/anthropics/claude-code/issues/45381))**: "
+            f"observed `{total_c5m_tokens:,}` `ephemeral_5m_input_tokens` tokens in this window "
+            f"(`${tot_comps['c5m']:,.2f}` at 5m cache-write rates). "
+            f"If `DISABLE_TELEMETRY` or `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` is set, "
+            f"these are sessions that silently fell from the 1h to 5m cache tier."
+        )
+    L.append(ttl_note)
+    L.append(
+        "- **Peak-hours quota burn**: per [u/ClaudeOfficial — Update on Session Limits (2026-03-26)](https://www.reddit.com/r/ClaudeAI/comments/1s4idaq/update_on_session_limits/), weekday 5–11am PT (1–7pm GMT) burns your 5-hour session quota faster on free/pro/max plans. Dollar cost per token is unchanged — this only affects how quickly you hit session ceilings. Shifting token-heavy work to off-peak stretches the weekly budget further."
+    )
+    L.append(
+        "- **Fast mode**: not detected from the JSONL. If you used `/fast` for some turns, Anthropic bills those at 6× standard rates and my total under-reports."
+    )
+    L.append(
+        "- **Sidechain PRs**: subagents can also run `gh pr create`; those are attributed to the parent session day since the extractor walks both main and sub files."
+    )
+    if unknown_models:
+        L.append(
+            f"- ⚠ **Unpriced models**: saw {sum(unknown_models.values())} turn(s) with "
+            f"unrecognised model IDs: {', '.join(f'`{k}` ({v})' for k, v in sorted(unknown_models.items()))}. "
+            f"These turns were excluded from the cost totals — update `PRICING` in `_impl.py` "
+            f"when a new model ships."
+        )
+
+    return "\n".join(L)
+
+
+def aggregate(bucket):
+    """Collapse the session-day bucket into entries + rolled-up totals."""
+    entries = []
+    for key, s in bucket.items():
+        total, comps, by_model, naive = cost_breakdown(s)
+        if total == 0:
+            continue
+        dur_min = 0
+        if s["first"] and s["last"]:
+            dur_min = (s["last"] - s["first"]).total_seconds() / 60
+        entries.append(
+            dict(
+                key=key,
+                proj=key[0],
+                puuid=key[1],
+                day=key[2],
+                total=total,
+                naive=naive,
+                comps=comps,
+                by_model=by_model,
+                dur=dur_min,
+                main_turns=s["main_turns"],
+                sub_turns=s["subagent_turns"],
+                prs_created=s["prs_created"],
+                prs_referenced=s["prs_referenced"],
+                # Keep raw per-model token counts for downstream footnotes
+                # (TTL-bug c5m measurement).
+                raw_models={m: dict(t) for m, t in s["models"].items()},
+            )
+        )
+
+    tot_actual = sum(e["total"] for e in entries)
+    tot_naive = sum(e["naive"] for e in entries)
+    tot_comps = dict(inp=0, out=0, c1h=0, c5m=0, cread=0)
+    tot_by_model = defaultdict(float)
+    tot_dur_min = 0.0
+    tot_main_turns = 0
+    tot_sub_turns = 0
+    for e in entries:
+        for k in tot_comps:
+            tot_comps[k] += e["comps"][k]
+        for m, v in e["by_model"].items():
+            tot_by_model[m] += v
+        tot_dur_min += e["dur"]
+        tot_main_turns += e["main_turns"]
+        tot_sub_turns += e["sub_turns"]
+
+    per_day = defaultdict(
+        lambda: dict(
+            actual=0, naive=0, c1h=0, cread=0, out=0, turns=0, sub=0, main=0, sess=0
+        )
+    )
+    for e in entries:
+        d = per_day[e["day"]]
+        d["actual"] += e["total"]
+        d["naive"] += e["naive"]
+        d["c1h"] += e["comps"]["c1h"]
+        d["cread"] += e["comps"]["cread"]
+        d["out"] += e["comps"]["out"]
+        d["main"] += e["main_turns"]
+        d["sub"] += e["sub_turns"]
+        d["sess"] += 1
+
+    by_repo = defaultdict(list)
+    for e in entries:
+        by_repo[humanize_project(e["proj"])].append(e)
+    for repo in by_repo:
+        by_repo[repo].sort(key=lambda x: -x["total"])
+    repo_totals = sorted(
+        by_repo.items(), key=lambda kv: -sum(e["total"] for e in kv[1])
+    )
+
+    return dict(
+        entries=entries,
+        tot_actual=tot_actual,
+        tot_naive=tot_naive,
+        tot_comps=tot_comps,
+        tot_by_model=dict(tot_by_model),
+        tot_dur_min=tot_dur_min,
+        tot_main_turns=tot_main_turns,
+        tot_sub_turns=tot_sub_turns,
+        per_day=per_day,
+        by_repo=by_repo,
+        repo_totals=repo_totals,
+    )
+
+
+def parse_args(argv=None):
+    p = argparse.ArgumentParser(
+        description="Compute Claude Code cost-impact report for a recent time window."
+    )
+    p.add_argument(
+        "days",
+        nargs="?",
+        type=positive_int,
+        default=7,
+        help="Number of days back to scan (integer >= 1, default 7)",
+    )
+    return p.parse_args(argv)
+
+
+def positive_int(s):
+    try:
+        v = int(s)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected integer, got {s!r}")
+    if v < 1:
+        raise argparse.ArgumentTypeError(f"days must be >= 1, got {v}")
+    return v
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    days_back = args.days
+
+    today = date.today()
+    start_date = today - timedelta(days=days_back - 1)
+
+    root = Path.home() / ".claude" / "projects"
+    main_files = sorted(root.glob("*/*.jsonl"))
+    sub_files = sorted(root.glob("*/*/subagents/agent-*.jsonl"))
+
+    bucket = defaultdict(empty_stats)
+    unknown_models = {}
+
+    for f in main_files:
+        ingest(f, False, root, start_date, today, bucket, unknown_models)
+    for f in sub_files:
+        ingest(f, True, root, start_date, today, bucket, unknown_models)
+
+    if unknown_models:
+        for m, n in sorted(unknown_models.items()):
+            print(
+                f"warning: unpriced model {m!r} ({n} turn(s)) — cost report excludes these",
+                file=sys.stderr,
+            )
+
+    agg = aggregate(bucket)
+
+    all_prs = set()
+    for s in bucket.values():
+        for k, _ in s["prs_created"]:
+            all_prs.add(k)
+        all_prs.update(s["prs_referenced"])
+    all_prs = {k for k in all_prs if not (k[0] == "a" and k[1] == "b")}
+    titles = fetch_pr_titles(all_prs)
+
+    bucket_meta = dict(agg, unknown_models=unknown_models)
+    report = build_report(
+        agg["entries"], bucket_meta, days_back, start_date, today, titles
+    )
+
+    out = Path("/tmp/cost-impact.md")
+    out.write_text(report)
+    n_entries = len(agg["entries"])
+    tot_actual = agg["tot_actual"]
+    tot_naive = agg["tot_naive"]
+    print(f"Wrote {out} ({len(report):,} bytes, {n_entries} session-days)")
+    print(
+        f"Actual: ${tot_actual:,.2f} | "
+        f"no-cache ref: ${tot_naive:,.2f} | "
+        f"savings: {pct_or_na(tot_naive - tot_actual, tot_naive)}"
+    )
+    repo_totals = agg["repo_totals"]
+    print(
+        f"Repos: {len(agg['by_repo'])}, top 3: {', '.join(r for r, _ in repo_totals[:3])}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -46,7 +46,10 @@ root = Path.home() / ".claude" / "projects"
 main_files = sorted(root.glob("*/*.jsonl"))
 sub_files = sorted(root.glob("*/*/subagents/agent-*.jsonl"))
 
-pr_create_re = re.compile(r"^\s*gh pr create\b")
+# Match `gh pr create` anywhere in a command, including compound commands
+# like `cd ~/gits/foo && gh pr create ...` or `git push && gh pr create ...`.
+# Word boundary guards against false matches inside identifiers.
+pr_create_re = re.compile(r"\bgh pr create\b")
 title_re = re.compile(r'--title\s+"([^"]+)"')
 url_re = re.compile(r'https?://github\.com/([^/\s]+)/([^/\s)\'"]+)/pull/(\d+)')
 
@@ -150,7 +153,7 @@ def ingest(f, is_sub):
                 btype = block.get("type")
                 if btype == "tool_use" and block.get("name") == "Bash":
                     cmd = block.get("input", {}).get("command", "")
-                    if pr_create_re.match(cmd.lstrip()):
+                    if pr_create_re.search(cmd):
                         t = title_re.search(cmd)
                         pending[block.get("id")] = (
                             day_local,
@@ -456,7 +459,7 @@ L.append(
     "- **Cache savings** = reference − actual. Represents the value your session got from prompt caching."
 )
 L.append(
-    f"- **Max plan context (reference only)**: 7-day prorate of ${MAX_PLAN_MONTHLY:.0f}/mo = ${window_baseline:.2f}. Actual cost ${tot_actual:,.2f} implies an effective subsidy of ${subsidy:,.2f} — i.e. Anthropic is absorbing that much at list pricing. Edit `MAX_PLAN_MONTHLY` in the script if your plan is different."
+    f"- **Max plan context (reference only)**: {DAYS_BACK}-day prorate of ${MAX_PLAN_MONTHLY:.0f}/mo = ${window_baseline:.2f}. Actual cost ${tot_actual:,.2f} implies an effective subsidy of ${subsidy:,.2f} — i.e. Anthropic is absorbing that much at list pricing. Edit `MAX_PLAN_MONTHLY` in the script if your plan is different."
 )
 L.append(
     "- **TTL-bug delta ([#45381](https://github.com/anthropics/claude-code/issues/45381))**: you aren't hit by it (0 `ephemeral_5m_input_tokens` observed). Not modeling hypothetical cost here — we have real data."

--- a/skills/cost-impact/test_impl.py
+++ b/skills/cost-impact/test_impl.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Unit tests for _impl.py pure functions.
+
+Run with: python3 -m unittest test_impl.py
+"""
+
+import json
+import sys
+import tempfile
+import unittest
+from collections import defaultdict
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+# Make sibling _impl.py importable
+sys.path.insert(0, str(Path(__file__).parent))
+
+from _impl import (  # noqa: E402
+    PR_CREATE_RE,
+    TITLE_RE,
+    URL_RE,
+    aggregate,
+    build_report,
+    cost_breakdown,
+    empty_stats,
+    fmt_duration,
+    humanize_project,
+    ingest,
+    money,
+    normalize_model,
+    parent_key,
+    parse_args,
+    parse_ts,
+    pct_or_na,
+    positive_int,
+)
+
+
+class TestNormalizeModel(unittest.TestCase):
+    def test_strips_date_suffix(self):
+        self.assertEqual(
+            normalize_model("claude-haiku-4-5-20251001"), "claude-haiku-4-5"
+        )
+        self.assertEqual(normalize_model("claude-opus-4-6-20260101"), "claude-opus-4-6")
+
+    def test_returns_none_for_synthetic(self):
+        self.assertIsNone(normalize_model("<synthetic>"))
+
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(normalize_model(""))
+        self.assertIsNone(normalize_model(None))
+
+    def test_returns_none_for_unknown_model(self):
+        # Unknown models must be dropped so the caller can warn.
+        self.assertIsNone(normalize_model("claude-opus-5-0"))
+        self.assertIsNone(normalize_model("claude-martian-9-9"))
+
+    def test_accepts_known_bare_model(self):
+        self.assertEqual(normalize_model("claude-opus-4-6"), "claude-opus-4-6")
+        self.assertEqual(normalize_model("claude-sonnet-4-6"), "claude-sonnet-4-6")
+
+
+class TestPctOrNa(unittest.TestCase):
+    def test_zero_denom_returns_na(self):
+        # Empty window: tot_naive == 0 must not crash.
+        self.assertEqual(pct_or_na(0, 0), "n/a")
+        self.assertEqual(pct_or_na(100, 0), "n/a")
+
+    def test_positive_denom_returns_pct(self):
+        self.assertEqual(pct_or_na(50, 100), "50%")
+        self.assertEqual(pct_or_na(82, 100), "82%")
+        self.assertEqual(pct_or_na(0, 100), "0%")
+
+
+class TestMoney(unittest.TestCase):
+    def test_basic_conversion(self):
+        # 1M tokens at $5/Mtok = $5.00
+        self.assertAlmostEqual(money(1_000_000, 5.00), 5.00)
+        # 500k tokens at $25/Mtok = $12.50
+        self.assertAlmostEqual(money(500_000, 25.00), 12.50)
+
+    def test_zero_tokens(self):
+        self.assertEqual(money(0, 25.00), 0.0)
+
+
+class TestCostBreakdown(unittest.TestCase):
+    def test_empty_models(self):
+        s = empty_stats()
+        total, comps, by_model, naive = cost_breakdown(s)
+        self.assertEqual(total, 0.0)
+        self.assertEqual(naive, 0.0)
+        self.assertEqual(by_model, {})
+        self.assertEqual(comps["inp"], 0.0)
+
+    def test_naive_vs_actual(self):
+        """With cache_read present, naive should exceed actual."""
+        s = empty_stats()
+        # 1M input, 1M output, 1M cache_read on Opus 4.6
+        s["models"]["claude-opus-4-6"]["inp"] = 1_000_000
+        s["models"]["claude-opus-4-6"]["out"] = 1_000_000
+        s["models"]["claude-opus-4-6"]["cread"] = 1_000_000
+        total, _comps, _by_model, naive = cost_breakdown(s)
+        # Actual: 1M * $5 (inp) + 1M * $25 (out) + 1M * $0.50 (cread) = $30.50
+        self.assertAlmostEqual(total, 30.50)
+        # Naive: (1M input + 1M cread) * $5 + 1M * $25 = $10 + $25 = $35.00
+        self.assertAlmostEqual(naive, 35.00)
+        self.assertGreater(naive, total)  # cache must save money
+
+    def test_multi_model_sums(self):
+        s = empty_stats()
+        s["models"]["claude-opus-4-6"]["inp"] = 1_000_000  # $5
+        s["models"]["claude-sonnet-4-6"]["inp"] = 1_000_000  # $3
+        total, _, by_model, _ = cost_breakdown(s)
+        self.assertAlmostEqual(by_model["claude-opus-4-6"], 5.00)
+        self.assertAlmostEqual(by_model["claude-sonnet-4-6"], 3.00)
+        self.assertAlmostEqual(total, 8.00)
+
+
+class TestHumanizeProject(unittest.TestCase):
+    def test_strips_prefix_and_dashes(self):
+        self.assertEqual(
+            humanize_project("-home-developer-gits-chop-conventions"),
+            "chop-conventions",
+        )
+        self.assertEqual(humanize_project("-home-developer-tmp"), "tmp")
+
+    def test_leaves_plain_name(self):
+        self.assertEqual(humanize_project("plain-project"), "plain-project")
+
+
+class TestFmtDuration(unittest.TestCase):
+    def test_sub_hour(self):
+        self.assertEqual(fmt_duration(0), "0m")
+        self.assertEqual(fmt_duration(5), "5m")
+        self.assertEqual(fmt_duration(59), "59m")
+
+    def test_hours_and_minutes(self):
+        self.assertEqual(fmt_duration(60), "1h 00m")
+        self.assertEqual(fmt_duration(125), "2h 05m")
+        self.assertEqual(fmt_duration(60 * 5 + 30), "5h 30m")
+
+
+class TestParseTs(unittest.TestCase):
+    def test_z_suffix(self):
+        ts = parse_ts("2026-04-13T10:00:00.123Z")
+        self.assertIsNotNone(ts)
+        self.assertEqual(ts.tzinfo, timezone.utc)
+
+    def test_offset_suffix(self):
+        ts = parse_ts("2026-04-13T10:00:00+00:00")
+        self.assertIsNotNone(ts)
+
+    def test_none_and_garbage(self):
+        self.assertIsNone(parse_ts(None))
+        self.assertIsNone(parse_ts(""))
+        self.assertIsNone(parse_ts("not a date"))
+
+
+class TestParentKey(unittest.TestCase):
+    def test_main_session(self):
+        root = Path("/root")
+        f = Path("/root/proj/uuid.jsonl")
+        self.assertEqual(parent_key(f, root), ("proj", "uuid", False))
+
+    def test_subagent_session(self):
+        root = Path("/root")
+        f = Path("/root/proj/uuid/subagents/agent-foo.jsonl")
+        self.assertEqual(parent_key(f, root), ("proj", "uuid", True))
+
+
+class TestPositiveInt(unittest.TestCase):
+    def test_accepts_positive(self):
+        self.assertEqual(positive_int("1"), 1)
+        self.assertEqual(positive_int("7"), 7)
+        self.assertEqual(positive_int("365"), 365)
+
+    def test_rejects_zero(self):
+        import argparse as _ap
+
+        with self.assertRaises(_ap.ArgumentTypeError):
+            positive_int("0")
+
+    def test_rejects_negative(self):
+        import argparse as _ap
+
+        with self.assertRaises(_ap.ArgumentTypeError):
+            positive_int("-1")
+
+    def test_rejects_non_integer(self):
+        import argparse as _ap
+
+        with self.assertRaises(_ap.ArgumentTypeError):
+            positive_int("abc")
+
+
+class TestParseArgs(unittest.TestCase):
+    def test_default(self):
+        args = parse_args([])
+        self.assertEqual(args.days, 7)
+
+    def test_explicit(self):
+        args = parse_args(["14"])
+        self.assertEqual(args.days, 14)
+
+    def test_rejects_zero(self):
+        with self.assertRaises(SystemExit):
+            parse_args(["0"])
+
+
+class TestRegexes(unittest.TestCase):
+    def test_pr_create_bare(self):
+        self.assertIsNotNone(PR_CREATE_RE.search("gh pr create --title 'foo'"))
+
+    def test_pr_create_compound(self):
+        self.assertIsNotNone(
+            PR_CREATE_RE.search("cd ~/gits/x && gh pr create --title 'foo'")
+        )
+        self.assertIsNotNone(PR_CREATE_RE.search("git push && gh pr create"))
+
+    def test_pr_create_no_false_match(self):
+        self.assertIsNone(PR_CREATE_RE.search("ghx pr create"))
+        self.assertIsNone(PR_CREATE_RE.search("git show gh-pages"))
+
+    def test_title_extract(self):
+        m = TITLE_RE.search('gh pr create --title "feat: add X" --body "y"')
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), "feat: add X")
+
+    def test_url_extract(self):
+        m = URL_RE.search("see https://github.com/owner/repo/pull/42 for details")
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group(1), "owner")
+        self.assertEqual(m.group(2), "repo")
+        self.assertEqual(m.group(3), "42")
+
+
+class TestAggregateEmpty(unittest.TestCase):
+    """Empty bucket must yield empty aggregation without crashing."""
+
+    def test_empty_bucket(self):
+        bucket = defaultdict(empty_stats)
+        agg = aggregate(bucket)
+        self.assertEqual(agg["entries"], [])
+        self.assertEqual(agg["tot_actual"], 0.0)
+        self.assertEqual(agg["tot_naive"], 0.0)
+        self.assertEqual(agg["tot_main_turns"], 0)
+        self.assertEqual(agg["tot_sub_turns"], 0)
+        self.assertEqual(list(agg["by_repo"]), [])
+
+    def test_zero_total_entries_excluded(self):
+        """Sessions with zero cost must not appear in entries."""
+        bucket = defaultdict(empty_stats)
+        # Populate a session that has a `first`/`last` but no model usage
+        bucket[("proj", "uuid", date(2026, 4, 13))]["first"] = datetime(
+            2026, 4, 13, 10, 0, 0
+        )
+        bucket[("proj", "uuid", date(2026, 4, 13))]["last"] = datetime(
+            2026, 4, 13, 10, 5, 0
+        )
+        agg = aggregate(bucket)
+        self.assertEqual(agg["entries"], [])
+
+
+class TestBuildReportEmptyWindow(unittest.TestCase):
+    """Empty window must produce a minimal report, NOT crash with ZeroDivisionError."""
+
+    def test_no_zero_division(self):
+        agg = aggregate(defaultdict(empty_stats))
+        bucket_meta = dict(agg, unknown_models={})
+        today = date(2026, 4, 13)
+        start = date(2026, 4, 7)
+        # Previously crashed with ZeroDivisionError on the cache-savings line
+        report = build_report([], bucket_meta, 7, start, today, {})
+        self.assertIn("No billable turns", report)
+        self.assertIn(f"{start} → {today}", report)
+
+    def test_empty_window_surfaces_unknown_models(self):
+        agg = aggregate(defaultdict(empty_stats))
+        bucket_meta = dict(agg, unknown_models={"claude-opus-5-0": 3})
+        today = date(2026, 4, 13)
+        start = date(2026, 4, 7)
+        report = build_report([], bucket_meta, 7, start, today, {})
+        self.assertIn("claude-opus-5-0", report)
+        self.assertIn("3", report)
+
+
+class TestBuildReportWithData(unittest.TestCase):
+    """End-to-end: populate bucket, aggregate, render report."""
+
+    def test_single_session_day(self):
+        bucket = defaultdict(empty_stats)
+        key = ("-home-developer-gits-example", "abc12345", date(2026, 4, 13))
+        s = bucket[key]
+        s["models"]["claude-opus-4-6"]["inp"] = 1_000_000
+        s["models"]["claude-opus-4-6"]["out"] = 1_000_000
+        s["models"]["claude-opus-4-6"]["cread"] = 1_000_000
+        s["models"]["claude-opus-4-6"]["turns"] = 5
+        s["main_turns"] = 5
+        s["first"] = datetime(2026, 4, 13, 10, 0, 0)
+        s["last"] = datetime(2026, 4, 13, 10, 30, 0)
+
+        agg = aggregate(bucket)
+        self.assertEqual(len(agg["entries"]), 1)
+        self.assertAlmostEqual(agg["tot_actual"], 30.50)
+        self.assertAlmostEqual(agg["tot_naive"], 35.00)
+
+        bucket_meta = dict(agg, unknown_models={})
+        report = build_report(
+            agg["entries"], bucket_meta, 1, date(2026, 4, 13), date(2026, 4, 13), {}
+        )
+        # Non-crashing rendering
+        self.assertIn("$30.50", report)
+        self.assertIn("example", report)  # humanized project name
+        # Cache savings: (35 - 30.50) / 35 = 12.857% -> "13%"
+        self.assertIn("13%", report)
+        # TTL footnote: zero c5m tokens -> "not hit by the bug"
+        self.assertIn("not hit by the bug", report)
+
+    def test_ttl_footnote_when_c5m_present(self):
+        bucket = defaultdict(empty_stats)
+        key = ("-home-developer-gits-example", "abc", date(2026, 4, 13))
+        s = bucket[key]
+        s["models"]["claude-opus-4-6"]["inp"] = 1_000_000
+        s["models"]["claude-opus-4-6"]["out"] = 1_000_000
+        s["models"]["claude-opus-4-6"]["c5m"] = 500_000  # <-- TTL bug hit
+        s["main_turns"] = 1
+        s["first"] = datetime(2026, 4, 13, 10, 0, 0)
+        s["last"] = datetime(2026, 4, 13, 10, 5, 0)
+
+        agg = aggregate(bucket)
+        bucket_meta = dict(agg, unknown_models={})
+        report = build_report(
+            agg["entries"], bucket_meta, 1, date(2026, 4, 13), date(2026, 4, 13), {}
+        )
+        # Must NOT say "not hit by the bug" because we DID see c5m
+        self.assertNotIn("not hit by the bug", report)
+        self.assertIn("ephemeral_5m_input_tokens", report)
+        self.assertIn("500,000", report)
+
+
+class TestIngestStreaming(unittest.TestCase):
+    """Verify ingest() streams files without loading whole thing into memory.
+
+    Indirectly tested: craft a jsonl with a mix of valid and invalid lines,
+    verify that valid entries are bucketed and invalid ones are skipped."""
+
+    def _write_jsonl(self, tmpdir, rel, lines):
+        path = Path(tmpdir) / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n".join(json.dumps(ln) for ln in lines) + "\n")
+        return path
+
+    def test_basic_ingest(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            today = date(2026, 4, 13)
+            start = date(2026, 4, 7)
+
+            valid_line = dict(
+                timestamp="2026-04-13T10:00:00.000Z",
+                message=dict(
+                    model="claude-opus-4-6",
+                    usage=dict(input_tokens=1_000_000, output_tokens=500_000),
+                ),
+            )
+            f = Path(tmp) / "proj" / "uuid.jsonl"
+            f.parent.mkdir(parents=True, exist_ok=True)
+            with f.open("w") as fh:
+                fh.write(json.dumps(valid_line) + "\n")
+                fh.write("not json\n")  # must be skipped
+                fh.write(json.dumps(dict(timestamp=None)) + "\n")  # must be skipped
+
+            bucket = defaultdict(empty_stats)
+            unknown = {}
+            ingest(f, False, root, start, today, bucket, unknown)
+
+            self.assertEqual(len(bucket), 1)
+            key = list(bucket.keys())[0]
+            s = bucket[key]
+            self.assertEqual(s["models"]["claude-opus-4-6"]["inp"], 1_000_000)
+            self.assertEqual(s["main_turns"], 1)
+            self.assertEqual(unknown, {})
+
+    def test_unknown_model_tracked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            today = date(2026, 4, 13)
+            start = date(2026, 4, 7)
+
+            unknown_line = dict(
+                timestamp="2026-04-13T10:00:00.000Z",
+                message=dict(
+                    model="claude-opus-5-0",  # fake future model
+                    usage=dict(input_tokens=100, output_tokens=50),
+                ),
+            )
+            f = Path(tmp) / "proj" / "uuid.jsonl"
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(json.dumps(unknown_line) + "\n")
+
+            bucket = defaultdict(empty_stats)
+            unknown = {}
+            ingest(f, False, root, start, today, bucket, unknown)
+
+            # Bucket populated with no usage, but unknown model tracked
+            self.assertEqual(unknown, {"claude-opus-5-0": 1})
+
+    def test_filters_out_of_window(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            today = date(2026, 4, 13)
+            start = date(2026, 4, 13)  # single-day window
+
+            out_of_window = dict(
+                timestamp="2026-03-01T10:00:00.000Z",  # way outside window
+                message=dict(
+                    model="claude-opus-4-6",
+                    usage=dict(input_tokens=1_000_000, output_tokens=1_000_000),
+                ),
+            )
+            f = Path(tmp) / "proj" / "uuid.jsonl"
+            f.parent.mkdir(parents=True, exist_ok=True)
+            f.write_text(json.dumps(out_of_window) + "\n")
+
+            bucket = defaultdict(empty_stats)
+            unknown = {}
+            ingest(f, False, root, start, today, bucket, unknown)
+
+            # Bucket may be populated with an empty stats entry via defaultdict,
+            # but no models should have been recorded.
+            for s in bucket.values():
+                self.assertEqual(sum(t["turns"] for t in s["models"].values()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

New \`/cost-impact\` skill that computes a Claude Code cost-impact report across a time window (default 7 days), grouped by repo with per-session detail. Complements \`/changelog\` — the latter summarizes *git history*, this one summarizes *Claude session history*, answering \"where did my Claude-time actually go this week.\"

## What it does

Scans every \`~/.claude/projects/*/*.jsonl\` main session and \`*/*/subagents/agent-*.jsonl\` subagent transcript, filters turns by timestamp into the requested window, and bills each turn at its model's published list price. Key design points:

- **Per-turn per-model pricing** — Opus 4.6 \$5/\$25, Sonnet 4.6 \$3/\$15, Haiku 4.5 \$1/\$5, older Opus 4 / 4.1 tiers at their historic \$15/\$75. Table sourced from [platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing).
- **Subagent tokens roll into the parent session's total** — so \"what did this session cost\" reflects all work done on its behalf, not just the main turns.
- **Groups by (project, parent_session_uuid, day)** — a session that spans midnight is split across days so daily totals add up cleanly.
- **Flat pricing across the 1M window for 4.5+** — no 200k threshold, per Anthropic's long-context docs.

## Report shape

1. **Summary** — total \$, total duration, total turns (main/sub/total), sessions in window, cost breakdown (input/output/cache writes 1h+5m/cache reads), without-cache reference, cache savings %
2. **Cost by model** — per-model totals and share
3. **Per day** — sessions, main+sub turns, costs
4. **Per repo summary table** — sessions, actual \$, share %
5. **Sessions grouped by repo** — **collapsible \`<details>\` sections**, one per repo. Summary line shows repo name, total \$, session count, duration, main+sub turns. Expands to a per-session table with clickable PR links extracted from \`gh pr create\` calls in the scrollback.
6. **Footnotes** — methodology, fast-mode/peak-hours/TTL-bug caveats

## Invocation

\`\`\`bash
python3 skills/cost-impact/_impl.py [days]
\`\`\`

The skill prompts the user whether to post the report to a gist or save locally, then runs the right \`gh gist create\` or \`cp\` command.

## Dogfood test results

Ran against my own 7-day window:

\`\`\`
Wrote /tmp/cost-impact.md (16,937 bytes, 64 session-days)
Actual: \$1,248.28 | no-cache ref: \$6,960.82 | savings: 82%
Repos: 11, top 3: activation-energy-game, settings, blog4
\`\`\`

Also ran with \`--days 1\` to verify the short-window path (\$331, 5 repos, 11 session-days).

## Known caveats (surfaced in the report's own footnotes)

- **Fast mode invisible**: \`usage\` field doesn't flag \`/fast\` turns, so if the user hit fast mode those are under-reported by 6×. No current detection path.
- **Peak-hours quota burn** (weekday 5–11am PT, per [Anthropic session limits update 2026-03-26](https://www.reddit.com/r/ClaudeAI/comments/1s4idaq/update_on_session_limits/)) only affects *quota* burn rate, not \$/token. The report prices at list; peak vs off-peak is not reflected in the dollar column.
- **TTL bug** ([anthropics/claude-code#45381](https://github.com/anthropics/claude-code/issues/45381)): if \`DISABLE_TELEMETRY\` or \`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC\` is set, sessions silently fall from 1h to 5m cache tier. Footnote alerts the user.

## Test plan

- [x] Dogfood with 7-day window — produces coherent \$1,248 report
- [x] Dogfood with 1-day window — short-window edge case works
- [x] Verify collapsible \`<details>\` sections render on GitHub (tested on a gist of the output)
- [x] Verify PR link extraction finds \`gh pr create\` commands and shows titles with state
- [x] All pre-commit hooks pass (ruff lint/format, prettier, fast tests)

## Skill structure

- \`skills/cost-impact/SKILL.md\` — entry point with trigger phrases, run/output instructions, hard rules, known caveats
- \`skills/cost-impact/_impl.py\` — standalone Python (~370 lines), safe to run directly: \`python3 skills/cost-impact/_impl.py [days]\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)