### PR TITLE
learn-from-session: scope + out-of-band diagnostics + cross-repo delegation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Reusable development conventions, skills, and agent definitions designed to be pulled into multiple projects.
 
+**Scope.** Claude Code workflow tooling and shared dev conventions: git workflows, telegram MCP, image lifecycle, host doctors, scripting defaults, skill packaging. **NOT for**: personal/body/health content for one human, project-specific data, or anything another developer pulling these conventions into their own machine wouldn't get value from. When in doubt, file an issue with the proposal rather than a PR. See open issues #77 (skill grouping) and #83 (back-care wrong-repo proposal) for prior scope discussions.
+
 ## Commands
 
 ```bash
@@ -46,6 +48,10 @@ Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) M
 ## Diagnostics: Code Over Prose
 
 **Diagnostic checks belong in scripts, not in skill/doc prose.** Skills describe WHEN to diagnose and HOW to recover; code describes WHAT to check. Paths move — code errors loudly, prose rots silently. Reference implementation: `skills/harden-telegram/tools/telegram_debug.py` (`--doctor` with `ok`/`warn`/`fail`/`note` accumulators, `--paths` file-map inventory, inline log tails). **Vendor the doctor *into* the skill** (`skills/<name>/tools/`), never into a source repo it diagnoses — source-repo coupling kills portability on any machine without that repo checked out. Parameterize runtime/source paths via env vars (e.g. `LARRY_TELEGRAM_DIR`, `TELEGRAM_SOURCE_DIR`), not constants. If you catch yourself writing "check X at path Y" prose in a skill, stop and move it to the doctor.
+
+## Diagnostics: Out-of-Band Notification
+
+**A diagnostic tool must not depend on the thing it's diagnosing.** A watchdog that notifies via the MCP bridge it's watching, a healthcheck running inside the process it's checking, backup verification using the backup system itself — all foot-guns that go silent at exactly the moment they need to scream. Notify out-of-band. Reference: `skills/harden-telegram` watchdog uses `telegram_debug.py --direct-send` (POSTs straight to Telegram Bot API) for alerts, never the MCP `reply` tool, so it works even when `server.ts` is dead.
 
 ## Abstractions: Wait for N=2
 

--- a/skills/learn-from-session/SKILL.md
+++ b/skills/learn-from-session/SKILL.md
@@ -113,6 +113,7 @@ Show all proposed changes in one message, grouped by target file. Include CLAUDE
 
 On approval:
 
+0. **Check repo locality first.** For each target file from Step 3, ask: is it inside the current session's repo (the one containing `pwd`)? If **YES**, apply it directly via the steps below. If **NO**, delegate that target via the `delegate-to-other-repo` skill instead of editing in-session. Cross-repo edits via delegation isolate the other repo's CLAUDE.md / conventions / PR flow into a fresh subagent context, so the parent session doesn't get polluted with another repo's state. Do not try to apply cross-repo edits inline — even if it feels easier, you'll end up `cd`-ing into the wrong tree, branching off the wrong base, or missing the target's pre-commit hooks. **For cross-repo CLAUDE.md edits, use `delegate-to-other-repo`, not inline edits.**
 1. **Create a feature branch per repo** — naming: `claude-md-<short-topic>` or `session-learnings-<date>`
 2. **Apply edits** using the Edit tool (not Write — these are targeted insertions)
 3. **Commit per repo** with a descriptive message that cites the lesson itself, not "update CLAUDE.md". Include the standard `Co-Authored-By` trailer.


### PR DESCRIPTION
## Summary

Three targeted edits surfaced by a `/learn-from-session` reflection in a parent session.

- **`CLAUDE.md` top-of-file Scope paragraph** — clarifies chop-conventions is for Claude Code workflow tooling and shared dev conventions: git workflows, telegram MCP, image lifecycle, host doctors, scripting defaults, skill packaging. Explicitly NOT for personal/body/health content for one human, project-specific data, or anything another developer pulling these conventions wouldn't get value from. Points at open issues #77 (skill grouping) and #83 (back-care wrong-repo proposal) as prior scope discussions.
- **`CLAUDE.md` new `## Diagnostics: Out-of-Band Notification` section** — codifies the rule that a diagnostic tool must not depend on the thing it's diagnosing. Reference implementation: `skills/harden-telegram` watchdog uses `telegram_debug.py --direct-send` (POSTs straight to Telegram Bot API) for alerts instead of the MCP `reply` tool, so it still fires when `server.ts` is dead. Slots in right after the existing `Diagnostics: Code Over Prose` section.
- **`skills/learn-from-session/SKILL.md` Step 7 repo-locality check** — new pre-step 0 that forces a per-target repo check before applying. If a target CLAUDE.md lives in a different repo than the current session's cwd, delegate via the `delegate-to-other-repo` skill instead of editing inline. Prevents the parent session from getting polluted with another repo's state and avoids the common inline-cross-repo foot-guns (wrong tree, wrong base branch, missing hooks).

## Test plan

- [ ] `CLAUDE.md` renders cleanly on GitHub; Scope paragraph sits just under the opening sentence and before `## Commands`
- [ ] `Diagnostics: Out-of-Band Notification` section is positioned between `Diagnostics: Code Over Prose` and `Abstractions: Wait for N=2`
- [ ] `skills/learn-from-session/SKILL.md` Step 7 shows sub-step 0 before the existing 1-5 numbered list, with `delegate-to-other-repo` called out