### PR TITLE
fix(delegate-to-other-repo): session log resolution bugs + async-by-default dispatch

### DIFF
--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -398,6 +398,25 @@ requires branch-switching (destructive) and breaks on protected
 defaults. Fix: write to `.git/info/exclude` instead — local-only,
 untracked, branch-independent, per-repo (shared across worktrees).
 
+### Editing this skill through the `~/.claude/skills/` symlink
+
+`~/.claude/skills/delegate-to-other-repo/` is usually a symlink into
+the chop-conventions primary checkout at
+`~/gits/chop-conventions/skills/delegate-to-other-repo/`. Editing
+`SKILL.md` or any supporting file directly through the symlink
+mutates whatever branch the primary checkout is currently on —
+silently mixing skill-fix edits with whatever unrelated work is
+checked out there. Verified this session: the primary checkout was
+on a different feature branch with uncommitted Python edits when a
+well-intentioned edit would have polluted both.
+
+**Fix**: when modifying this skill (or any skill in the chop-conventions
+`skills/` tree), **always create a worktree off `upstream/main` first**
+and edit there. Same recipe as the worktrees this skill creates for
+its own delegations — the self-referential case doesn't get a free
+pass. Double-check with `realpath` before editing any file under
+`~/.claude/skills/` to confirm where it actually lives.
+
 ### Trusting `diagnose.py`'s `is_fork_workflow: false`
 
 It misclassifies chop-conventions' real pattern (single fork-as-origin

--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -166,13 +166,24 @@ parameter to the Agent tool.
 # Claude Code hashes the session's *cwd* at launch, not the repo root.
 # If you're running inside a worktree, the hash encodes the worktree
 # path, not the main checkout.
-cwd_hash=$(pwd | sed 's|/|-|g')
+#
+# Two gotchas in the hash rule — both bite in practice:
+#   1. The project-dir hash converts BOTH `/` AND `.` to `-`. A repo
+#      at `/home/foo/gits/bar.github.io` hashes to
+#      `-home-foo-gits-bar-github-io`, NOT `-home-foo-gits-bar.github.io`.
+#      The sed below uses `[/.]` to catch both.
+#   2. `pwd` returns the LOGICAL cwd (may be a symlink like
+#      `/home/foo/blog → /home/foo/gits/bar.github.io`). Claude Code
+#      hashes the physical path, so use `pwd -P` to resolve symlinks
+#      before hashing. Without `-P`, a session launched from a
+#      symlinked shortcut produces a bogus hash matching no project dir.
+cwd_hash=$(pwd -P | sed 's|[/.]|-|g')
 newest=$(/bin/ls -t "$HOME/.claude/projects/$cwd_hash"/*.jsonl 2>/dev/null | head -1)
 
-# Fallback: try the repo toplevel hash.
+# Fallback: try the repo toplevel hash (same two gotchas apply).
 if [ -z "$newest" ]; then
   toplevel=$(git rev-parse --show-toplevel)
-  toplevel_hash=$(echo "$toplevel" | sed 's|/|-|g')
+  toplevel_hash=$(echo "$toplevel" | sed 's|[/.]|-|g')
   newest=$(/bin/ls -t "$HOME/.claude/projects/$toplevel_hash"/*.jsonl 2>/dev/null | head -1)
 fi
 ```
@@ -189,16 +200,54 @@ Agent tool:
   description: "Delegated work in <target-repo>"
   subagent_type: "general-purpose"
   prompt: <the substituted brief from Phase 3>
-  run_in_background: false
+  run_in_background: true
 ```
 
-**Foreground by default.** Only pass `run_in_background: true` if the
-user explicitly asked ("dispatch in background", "I want to keep
-working while this runs"). Foreground means you wait for the result
-message before continuing — that's fine.
+**Async by default.** Delegated work is usually long-running
+(minutes). Blocking the parent on it wastes the user's time and
+burns the parent's context budget while it sits idle. The harness
+sends a `<task-notification>` when the subagent completes — that
+notification is your trigger for Phase 5. No polling required.
 
-**Never retry automatically.** If the subagent fails, escalate to the
-user (see Phase 5).
+### After dispatch
+
+1. **Summarize what you dispatched** to the user in one short
+   message — worktree path, branch, key checkpoints from the brief.
+   This gives the user a chance to course-correct before the
+   subagent burns minutes in the wrong direction.
+2. **End the turn.** The parent is now free to accept other
+   unrelated work while the subagent runs.
+3. **When the `<task-notification>` arrives**, resume at Phase 5
+   automatically (relay the result, offer follow-ups).
+
+### Monitoring
+
+- **Default**: trust the completion notification. Simple, reliable,
+  no overhead. Do NOT poll, do NOT sleep, do NOT `Read` the agent's
+  output JSONL — the tool explicitly warns that reading the
+  transcript will overflow the parent's context.
+- **Heartbeat (opt-in)**: for long-running or risky delegations
+  where the user wants progress checks, run
+  `/loop 2m "status check on delegation to <target-repo>"`. The
+  loop wakes the parent every 2 minutes to summarize state from
+  memory (what was dispatched, how long ago, what's expected).
+  The parent answers from its recollection of the brief — NOT by
+  reading the output file. When the completion notification
+  arrives, the parent processes the real result and the loop
+  self-terminates on the next tick.
+- **Never**: tail the output file, sleep in a bash loop, call the
+  Agent tool again with the same prompt, or claim "done" before
+  the notification arrives.
+
+### If the user explicitly asked for sync
+
+If the user said "wait for it" or "block until done", pass
+`run_in_background: false` instead — but note that the harness may
+still dispatch async regardless. Either way, the parent's Phase 5
+trigger is the final message, wherever it arrives from.
+
+**Never retry automatically.** If the subagent fails, escalate to
+the user (see Phase 5).
 
 ## Phase 5: Relay the result and offer follow-ups
 


### PR DESCRIPTION
## Summary

Two durable fixes to the \`delegate-to-other-repo\` skill, dogfooded in a session this afternoon.

## 1. Session log resolution — two sed/pwd bugs

Phase 3's session-log resolution silently returned nonexistent paths whenever the repo name contained a \`.\` OR the cwd was a symlink. Both bit a real delegation this session.

**Bug 1 — sed misses \`.\` → \`-\` conversion.** Claude Code's project-dir hash converts BOTH \`/\` and \`.\` to \`-\`. A repo at \`~/gits/bar.github.io\` hashes to \`-home-foo-gits-bar-github-io\`, NOT \`-home-foo-gits-bar.github.io\`. The skill's \`sed 's|/|-|g'\` only got the slashes. Fix: \`sed 's|[/.]|-|g'\` in both the primary path and the toplevel fallback.

**Bug 2 — \`pwd\` returns logical cwd, follows symlinks.** A session launched from \`~/blog → ~/gits/bar.github.io\` sees \`pwd == ~/blog\`, which hashes to \`-home-foo-blog\` — a project dir that doesn't exist. Claude Code hashes the *physical* path. Fix: \`pwd -P\` resolves symlinks before hashing.

The combined fix is one line in the primary resolution and one line in the fallback. The inline comment in the script now documents both gotchas so future readers understand why the sed character class is \`[/.]\` and why \`-P\` is load-bearing.

## 2. Phase 4 — async by default

Prior SKILL.md said "Foreground by default" and told the parent to block on the Agent tool's inline return, then proceed to Phase 5 immediately with the result. **Observed reality**: Claude Code's Agent tool commonly dispatches async even when \`run_in_background: false\` is passed (or omitted), returning an agent ID and a promise of a later \`<task-notification>\` instead of an inline result. A parent following the old contract literally would be confused about what to say during the gap.

**More importantly**: blocking the parent on foreground is the wrong default anyway. It burns the parent's context budget sitting idle and prevents the user from interleaving other work.

**New contract**:

- Dispatch with \`run_in_background: true\`
- Parent summarizes what was dispatched (worktree path, branch, brief checkpoints) — gives user a chance to course-correct
- Parent ends its turn
- When the \`<task-notification>\` arrives, parent resumes at Phase 5 automatically
- For heartbeats on long-running delegations, user or parent can fire \`/loop 2m \"status check on delegation to <target>\"\` — wakes the parent every 2 minutes to summarize state *from memory* (never by reading the output file)
- Explicit prohibitions: no polling, no sleep, no \`Read\`/\`tail\` on the agent's output JSONL (overflows parent context), no duplicate dispatch, no premature "done"
- Escape hatch: if the user said "wait for it", pass \`run_in_background: false\` — but note the harness may still dispatch async regardless

## Testing

Both fixes verified against this session's actual dispatch — a delegation to chop-conventions earlier today that hit the session-log bugs (sed couldn't find the JSONL for my repo with a dot in the name, AND my cwd was a symlink) and also hit the async-behavior mismatch (Agent tool dispatched async despite the old skill's foreground guarantee).

## Diff size

1 file changed, 59 insertions(+), 10 deletions(-). One file: \`skills/delegate-to-other-repo/SKILL.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated delegation orchestration guidance to clarify async-by-default task dispatch and completion notification-driven workflow.
  * Expanded monitoring instructions with explicit guidelines on notification handling and prohibited behaviors.
  * Clarified sync override options for users requiring blocking execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->