### PR TITLE
fix(cost-impact): simplify per-day report tables

### DIFF
--- a/skills/cost-impact/SKILL.md
+++ b/skills/cost-impact/SKILL.md
@@ -103,7 +103,7 @@ don't know the ID.
    without-cache reference, cache savings %
 2. **Cost by model** — each model's share of the total
 3. **Per day** — actual $, sessions, main+sub turns, no-cache reference, plus
-   a separate daily details table splitting fresh input, output, 1h cache
+   a separate daily details table splitting input, output, 1h cache
    writes, 5m cache writes, and cache reads
 4. **Per repo summary table** — sessions, actual $, share %
 5. **Sessions grouped by repo** — collapsible `<details>` sections, one per

--- a/skills/cost-impact/SKILL.md
+++ b/skills/cost-impact/SKILL.md
@@ -102,8 +102,9 @@ don't know the ID.
    sessions in window, cost breakdown (input/output/cache writes/reads),
    without-cache reference, cache savings %
 2. **Cost by model** — each model's share of the total
-3. **Per day** — sessions, main+sub turns, actual $, 1h cache $, cache read $,
-   output $, no-cache reference
+3. **Per day** — actual $, sessions, main+sub turns, no-cache reference, plus
+   a separate daily details table splitting fresh input, output, 1h cache
+   writes, 5m cache writes, and cache reads
 4. **Per repo summary table** — sessions, actual $, share %
 5. **Sessions grouped by repo** — collapsible `<details>` sections, one per
    repo, each showing its sessions sorted by actual $ descending. Per-session

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -339,7 +339,7 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
         f"| **Total turns** (main / sub / total) | **{tot_main_turns:,} / {tot_sub_turns:,} / {tot_main_turns + tot_sub_turns:,}** |"
     )
     L.append(f"| Sessions in window | {len(entries)} |")
-    L.append(f"| — Input (uncached) | ${tot_comps['inp']:,.2f} |")
+    L.append(f"| — Input | ${tot_comps['inp']:,.2f} |")
     L.append(f"| — Output | ${tot_comps['out']:,.2f} |")
     L.append(f"| — Cache writes (1h TTL) | ${tot_comps['c1h']:,.2f} |")
     L.append(f"| — Cache writes (5m TTL) | ${tot_comps['c5m']:,.2f} |")
@@ -375,11 +375,11 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
     L.append("### Daily cost details")
     L.append("")
     L.append(
-        "*Actual = fresh input + output + 1h cache writes + 5m cache writes + cache reads.*"
+        "*Actual = input + output + 1h cache writes + 5m cache writes + cache reads.*"
     )
     L.append("")
     L.append(
-        "| Day | Fresh input $ | Output $ | 1h cache write $ | 5m cache write $ | Cache read $ |"
+        "| Day | Input $ | Output $ | 1h cache write $ | 5m cache write $ | Cache read $ |"
     )
     L.append("|---|---:|---:|---:|---:|---:|")
     for day in sorted(per_day):
@@ -459,7 +459,7 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
         "- **Per-model pricing**: each turn is billed at its model's listed rate (Opus 4.6/4.5 $5/$25, Sonnet 4.6/4.5 $3/$15, Haiku 4.5 $1/$5, older Opus tiers at their higher historic rates). Opus 4.6 and Sonnet 4.6 are flat-priced across the full 1M context window — no 200k threshold."
     )
     L.append(
-        "- **Without-cache reference** = `input + cache_read + cache_create` all billed as fresh input at that model's base input rate, plus output. Shows what you'd pay if caching were disabled entirely. Not a prediction — a reference point."
+        "- **Without-cache reference** = `input + cache_read + cache_create` all billed at that model's base input rate, plus output. Shows what you'd pay if caching were disabled entirely. Not a prediction — a reference point."
     )
     L.append(
         "- **Cache savings** = reference − actual. Represents the value your session got from prompt caching."

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -7,6 +7,7 @@ https://platform.claude.com/docs/en/about-claude/pricing
 """
 
 import argparse
+import concurrent.futures
 import json
 import re
 import subprocess
@@ -29,6 +30,7 @@ PRICING = {
 }
 
 MAX_PLAN_MONTHLY = 200.00
+MAX_PR_TITLE_FETCH_WORKERS = 8
 
 # Match `gh pr create` anywhere in a command, including compound commands
 # like `cd ~/gits/foo && gh pr create ...` or `git push && gh pr create ...`.
@@ -246,36 +248,39 @@ def ingest(f, is_sub, root, start_date, today, bucket, unknown_models):
                             s["prs_referenced"].add(k)
 
 
+def _fetch_one_pr_title(pr_key):
+    owner, repo, num = pr_key
+    try:
+        r = subprocess.run(
+            [
+                "gh",
+                "pr",
+                "view",
+                str(num),
+                "--repo",
+                f"{owner}/{repo}",
+                "--json",
+                "title,state",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if r.returncode == 0:
+            data = json.loads(r.stdout)
+            return pr_key, (data.get("title", ""), data.get("state", ""))
+    except Exception:
+        pass
+    return pr_key, (None, None)
+
+
 def fetch_pr_titles(all_prs):
-    titles = {}
-    for owner, repo, num in sorted(all_prs):
-        try:
-            r = subprocess.run(
-                [
-                    "gh",
-                    "pr",
-                    "view",
-                    str(num),
-                    "--repo",
-                    f"{owner}/{repo}",
-                    "--json",
-                    "title,state",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=15,
-            )
-            if r.returncode == 0:
-                data = json.loads(r.stdout)
-                titles[(owner, repo, num)] = (
-                    data.get("title", ""),
-                    data.get("state", ""),
-                )
-            else:
-                titles[(owner, repo, num)] = (None, None)
-        except Exception:
-            titles[(owner, repo, num)] = (None, None)
-    return titles
+    prs = sorted(all_prs)
+    if not prs:
+        return {}
+    max_workers = min(MAX_PR_TITLE_FETCH_WORKERS, len(prs))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        return dict(pool.map(_fetch_one_pr_title, prs))
 
 
 # ---------- Report builder ----------

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -421,9 +421,9 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
         )
         L.append("")
         L.append(
-            "| Day | Dur | Session | Turns (main/sub) | Actual $ | 1h $ | Read $ | Out $ | PRs shipped |"
+            "| Day | Dur | Session | Turns (main/sub) | Input $ | Output $ | 1h cache write $ | 5m cache write $ | Cache read $ | Actual $ | PRs shipped |"
         )
-        L.append("|---|---:|---|---:|---:|---:|---:|---:|---|")
+        L.append("|---|---:|---|---:|---:|---:|---:|---:|---:|---:|---|")
         for e in es:
             sess = e["puuid"][:8]
             pr_links = []
@@ -438,8 +438,9 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
             L.append(
                 f"| {e['day']} | {e['dur']:.0f}m | {sess} | "
                 f"{e['main_turns']}/{e['sub_turns']} | "
-                f"${e['total']:.2f} | ${e['comps']['c1h']:.2f} | "
-                f"${e['comps']['cread']:.2f} | ${e['comps']['out']:.2f} | {pr_str} |"
+                f"${e['comps']['inp']:.2f} | ${e['comps']['out']:.2f} | "
+                f"${e['comps']['c1h']:.2f} | ${e['comps']['c5m']:.2f} | "
+                f"${e['comps']['cread']:.2f} | ${e['total']:.2f} | {pr_str} |"
             )
         L.append("")
         L.append("</details>")

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -355,16 +355,36 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
 
     L.append("## Per day")
     L.append("")
-    L.append(
-        "| Day | Sessions | Main turns | Sub turns | Actual $ | 1h cache $ | Cache read $ | Output $ | No-cache ref $ |"
-    )
-    L.append("|---|---:|---:|---:|---:|---:|---:|---:|---:|")
+    L.append("| Day | Actual $ | Sessions | Main turns | Sub turns | No-cache ref $ |")
+    L.append("|---|---:|---:|---:|---:|---:|")
     for day in sorted(per_day):
         d = per_day[day]
         L.append(
-            f"| {day} | {d['sess']} | {d['main']} | {d['sub']} | "
-            f"${d['actual']:.2f} | ${d['c1h']:.2f} | ${d['cread']:.2f} | ${d['out']:.2f} | ${d['naive']:.2f} |"
+            f"| {day} | ${d['actual']:.2f} | {d['sess']} | {d['main']} | {d['sub']} | ${d['naive']:.2f} |"
         )
+    L.append(
+        f"| **Total** | **${tot_actual:,.2f}** | **{len(entries)}** | **{tot_main_turns:,}** | **{tot_sub_turns:,}** | **${tot_naive:,.2f}** |"
+    )
+    L.append("")
+
+    L.append("### Daily cost details")
+    L.append("")
+    L.append(
+        "*Actual = fresh input + output + 1h cache writes + 5m cache writes + cache reads.*"
+    )
+    L.append("")
+    L.append(
+        "| Day | Fresh input $ | Output $ | 1h cache write $ | 5m cache write $ | Cache read $ |"
+    )
+    L.append("|---|---:|---:|---:|---:|---:|")
+    for day in sorted(per_day):
+        d = per_day[day]
+        L.append(
+            f"| {day} | ${d['inp']:.2f} | ${d['out']:.2f} | ${d['c1h']:.2f} | ${d['c5m']:.2f} | ${d['cread']:.2f} |"
+        )
+    L.append(
+        f"| **Total** | **${tot_comps['inp']:,.2f}** | **${tot_comps['out']:,.2f}** | **${tot_comps['c1h']:,.2f}** | **${tot_comps['c5m']:,.2f}** | **${tot_comps['cread']:,.2f}** |"
+    )
     L.append("")
 
     L.append("## Per repo")
@@ -531,14 +551,26 @@ def aggregate(bucket):
 
     per_day = defaultdict(
         lambda: dict(
-            actual=0, naive=0, c1h=0, cread=0, out=0, turns=0, sub=0, main=0, sess=0
+            actual=0,
+            naive=0,
+            inp=0,
+            out=0,
+            c1h=0,
+            c5m=0,
+            cread=0,
+            turns=0,
+            sub=0,
+            main=0,
+            sess=0,
         )
     )
     for e in entries:
         d = per_day[e["day"]]
         d["actual"] += e["total"]
         d["naive"] += e["naive"]
+        d["inp"] += e["comps"]["inp"]
         d["c1h"] += e["comps"]["c1h"]
+        d["c5m"] += e["comps"]["c5m"]
         d["cread"] += e["comps"]["cread"]
         d["out"] += e["comps"]["out"]
         d["main"] += e["main_turns"]

--- a/skills/cost-impact/test_impl.py
+++ b/skills/cost-impact/test_impl.py
@@ -355,7 +355,7 @@ class TestBuildReportWithData(unittest.TestCase):
         )
         self.assertIn("### Daily cost details", report)
         self.assertIn(
-            "| Day | Fresh input $ | Output $ | 1h cache write $ | 5m cache write $ | Cache read $ |",
+            "| Day | Input $ | Output $ | 1h cache write $ | 5m cache write $ | Cache read $ |",
             report,
         )
         self.assertIn(

--- a/skills/cost-impact/test_impl.py
+++ b/skills/cost-impact/test_impl.py
@@ -8,6 +8,7 @@ import json
 import sys
 import tempfile
 import unittest
+from unittest import mock
 from collections import defaultdict
 from datetime import date, datetime, timezone
 from pathlib import Path
@@ -23,6 +24,7 @@ from _impl import (  # noqa: E402
     build_report,
     cost_breakdown,
     empty_stats,
+    fetch_pr_titles,
     fmt_duration,
     humanize_project,
     ingest,
@@ -232,6 +234,38 @@ class TestRegexes(unittest.TestCase):
         self.assertEqual(m.group(1), "owner")
         self.assertEqual(m.group(2), "repo")
         self.assertEqual(m.group(3), "42")
+
+
+class TestFetchPrTitles(unittest.TestCase):
+    def test_returns_titles_and_states(self):
+        def fake_run(args, capture_output, text, timeout):
+            self.assertEqual(args[:3], ["gh", "pr", "view"])
+            self.assertEqual(capture_output, True)
+            self.assertEqual(text, True)
+            self.assertEqual(timeout, 15)
+            payload = {
+                "1": {"title": "One", "state": "OPEN"},
+                "2": {"title": "Two", "state": "MERGED"},
+            }[args[3]]
+            return mock.Mock(returncode=0, stdout=json.dumps(payload))
+
+        with mock.patch("_impl.subprocess.run", side_effect=fake_run):
+            got = fetch_pr_titles({("o", "r", 2), ("o", "r", 1)})
+
+        self.assertEqual(got[("o", "r", 1)], ("One", "OPEN"))
+        self.assertEqual(got[("o", "r", 2)], ("Two", "MERGED"))
+
+    def test_falls_back_to_none_on_error(self):
+        def fake_run(args, capture_output, text, timeout):
+            if args[3] == "1":
+                raise RuntimeError("boom")
+            return mock.Mock(returncode=1, stdout="")
+
+        with mock.patch("_impl.subprocess.run", side_effect=fake_run):
+            got = fetch_pr_titles({("o", "r", 1), ("o", "r", 2)})
+
+        self.assertEqual(got[("o", "r", 1)], (None, None))
+        self.assertEqual(got[("o", "r", 2)], (None, None))
 
 
 class TestAggregateEmpty(unittest.TestCase):

--- a/skills/cost-impact/test_impl.py
+++ b/skills/cost-impact/test_impl.py
@@ -311,6 +311,23 @@ class TestBuildReportWithData(unittest.TestCase):
         # Non-crashing rendering
         self.assertIn("$30.50", report)
         self.assertIn("example", report)  # humanized project name
+        self.assertIn(
+            "| Day | Actual $ | Sessions | Main turns | Sub turns | No-cache ref $ |",
+            report,
+        )
+        self.assertIn(
+            "| **Total** | **$30.50** | **1** | **5** | **0** | **$35.00** |",
+            report,
+        )
+        self.assertIn("### Daily cost details", report)
+        self.assertIn(
+            "| Day | Fresh input $ | Output $ | 1h cache write $ | 5m cache write $ | Cache read $ |",
+            report,
+        )
+        self.assertIn(
+            "| **Total** | **$5.00** | **$25.00** | **$0.00** | **$0.00** | **$0.50** |",
+            report,
+        )
         # Cache savings: (35 - 30.50) / 35 = 12.857% -> "13%"
         self.assertIn("13%", report)
         # TTL footnote: zero c5m tokens -> "not hit by the bug"

--- a/skills/cost-impact/test_impl.py
+++ b/skills/cost-impact/test_impl.py
@@ -362,6 +362,14 @@ class TestBuildReportWithData(unittest.TestCase):
             "| **Total** | **$5.00** | **$25.00** | **$0.00** | **$0.00** | **$0.50** |",
             report,
         )
+        self.assertIn(
+            "| Day | Dur | Session | Turns (main/sub) | Input $ | Output $ | 1h cache write $ | 5m cache write $ | Cache read $ | Actual $ | PRs shipped |",
+            report,
+        )
+        self.assertIn(
+            "| 2026-04-13 | 30m | abc12345 | 5/0 | $5.00 | $25.00 | $0.00 | $0.00 | $0.50 | $30.50 | — |",
+            report,
+        )
         # Cache savings: (35 - 30.50) / 35 = 12.857% -> "13%"
         self.assertIn("13%", report)
         # TTL footnote: zero c5m tokens -> "not hit by the bug"


### PR DESCRIPTION
## Summary
- move daily actual cost to the main per-day table for faster scanning
- add a totals row at the end of the per-day table
- split the daily price breakdown into a separate details table with fresh input, output, 1h cache write, 5m cache write, and cache read columns
- parallelize GitHub PR title lookups with a bounded worker pool to cut report generation latency

## Verification
- python3 -m unittest skills/cost-impact/test_impl.py
- time python3 skills/cost-impact/_impl.py 7
- direct additive audit across entry, per-day, per-repo, and global totals: 0 mismatches

## Timing
- before: about 17.9s wall clock
- after: about 2.6s wall clock
