### PR TITLE
docs(CLAUDE.md): warn against editing installed skills through the symlink

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,7 @@ Skills are Claude Code slash commands that live in `skills/<name>/SKILL.md`.
   - Project-level (one project): `<project>/.claude/skills/<name>` -> `<chop-conventions>/skills/<name>`
 - After adding a skill, create the symlink and document it in the README skills table
 - After `/up-to-date` pulls new commits, check the pull delta for newly-added `skills/<name>/` dirs and offer to symlink them into `~/.claude/skills/`. If the delta added no skills, say nothing. Never link automatically.
+- **Editing an installed skill: always use a worktree, never the symlink.** Because `~/.claude/skills/<name>` points directly into the primary `chop-conventions` checkout, editing through that path mutates whichever branch is currently checked out — silently mixing skill-fix work with any unrelated in-flight branch. Before touching any file under `~/.claude/skills/`, run `realpath` to confirm where it resolves, then create a worktree off `upstream/main` (`git -C ~/gits/chop-conventions worktree add .worktrees/<slug> -b delegated/<slug> upstream/main`) and edit there. The self-referential case (editing `delegate-to-other-repo` while using it) does NOT get a free pass.
 
 ### Size Guideline
 


### PR DESCRIPTION
## Summary

Adds one bullet to the `Skills > Conventions` list in `CLAUDE.md` documenting the skill-editing symlink trap — specifically that editing through `~/.claude/skills/<name>` (which symlinks into the primary chop-conventions checkout) mutates whichever branch is currently checked out in that primary.

## Why

The Skills section already documents how skills get installed (symlinks into `~/.claude/skills/`), but **doesn't warn that editing through those symlinks is a trap**. A skill-fix edit lands on whatever branch the primary checkout is currently on, silently mixing with any unrelated in-flight work. Hit this in a recent session where a well-intentioned skill edit would have landed in a `skills/cost-impact` feature branch mid-work if I hadn't caught it.

## What the bullet says

- **Rule**: always use a worktree, never edit through the symlink
- **Why**: direct mutation of the current branch
- **Fix**: `realpath` check + `git worktree add .worktrees/<slug> -b delegated/<slug> upstream/main` + edit in the worktree
- **Call-out**: self-referential cases (editing `delegate-to-other-repo` while using it) do NOT get a free pass

## Relationship to other PRs in this area

- [#88](https://github.com/idvorkin/chop-conventions/pull/88) added a finer-grained warning to `skills/delegate-to-other-repo/SKILL.md` Common Mistakes — specific to that skill. That PR already landed.
- This PR generalizes the rule to all skills in `skills/` at the `CLAUDE.md` level, so future Claude sessions see the warning regardless of which skill they're editing.
- Also companion edit: `~/.claude/CLAUDE.md` (machine-local, not tracked here) gets a terser version pointing at this file for full detail.

## Diff size

1 file changed, 1 insertion. The bullet is deliberately long-ish (one paragraph with the rule, the mechanism, and the fix recipe) because it's replacing the need to scroll into `skills/delegate-to-other-repo/SKILL.md` § Common Mistakes every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)