### PR TITLE
dev-setup: statusline since-write segment + supporting hooks

### DIFF
--- a/dev-setup/claude-code-statusline.md
+++ b/dev-setup/claude-code-statusline.md
@@ -12,14 +12,15 @@ Claude Code's `statusLine` setting accepts an inline command, but inline JSON-qu
 user@host ~/path/to/repo [branch] | Opus 4.6 ctx:12% 125k/1000k $0.42
 ```
 
-| Segment         | Source                                                  | Color                                            |
-| --------------- | ------------------------------------------------------- | ------------------------------------------------ |
-| `user@host`     | `whoami` / `hostname -s`                                | default                                          |
-| `~/path`        | `cwd` (or `workspace.current_dir`), home shortened      | yellow                                           |
-| `[branch]`      | `git symbolic-ref --short HEAD` (skipped if not a repo) | yellow                                           |
-| `Opus 4.6`      | `model.display_name`                                    | default                                          |
-| `ctx:NN% Xk/Yk` | `context_window.{used_percentage, context_window_size}` | green <200k, yellow <400k, pink <600k, red ≥600k |
-| `$X.XX`         | `cost.total_cost_usd`                                   | default                                          |
+| Segment          | Source                                                                                                                                            | Color                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `user@host`      | `whoami` / `hostname -s`                                                                                                                          | default                                          |
+| `~/path`         | `cwd` (or `workspace.current_dir`), home shortened                                                                                                | yellow                                           |
+| `[branch]`       | `git symbolic-ref --short HEAD` (skipped if not a repo)                                                                                           | yellow                                           |
+| `Opus 4.6`       | `model.display_name`                                                                                                                              | default                                          |
+| `ctx:NN% Xk/Yk`  | `context_window.{used_percentage, context_window_size}`                                                                                           | green <200k, yellow <400k, pink <600k, red ≥600k |
+| `$X.XX`          | `cost.total_cost_usd`                                                                                                                             | default                                          |
+| `since-write:Xm` | Delta between now and `~/.claude/last_write.timestamp` mtime (conditional segment — see [Time Since Last Write](#optional-time-since-last-write)) | pink                                             |
 
 The token bucket (`Xk`) snaps to the nearest 10k so the number doesn't jitter on every tick. The total (`Yk`) comes from `context_window.context_window_size` directly — no model-string heuristics, so Sonnet (200k) and Opus `[1m]` render correctly without code changes.
 
@@ -40,6 +41,73 @@ Then add to `~/.claude/settings.json`:
   }
 }
 ```
+
+## Optional: Time Since Last Write
+
+The `since-write:Xm` segment surfaces long stretches where Claude has been reading, grepping, or thinking without actually writing any code — useful as a "have I been on a tangent for an hour?" nudge. It stays hidden during normal editing and only appears once the idle-since-write delta crosses a threshold.
+
+### How It Works
+
+The script reads the mtime of `~/.claude/last_write.timestamp` and computes `now - mtime`. Two hooks keep that file current:
+
+- **`PostToolUse` on `Write|Edit|NotebookEdit`** — touches the file after every file-writing tool call, resetting the clock
+- **`SessionStart`** — touches the file at session start so a fresh session doesn't inherit a stale timestamp from the previous one
+
+Add them to `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "sh $HOME/.claude/statusline-command.sh",
+    "refreshInterval": 30
+  },
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "touch $HOME/.claude/last_write.timestamp"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "touch $HOME/.claude/last_write.timestamp"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+`refreshInterval: 30` is load-bearing — event-driven status line updates only fire on tool calls, so without the interval the counter stalls whenever Claude is thinking or waiting on you. 30 seconds is frequent enough that the segment appears within half a minute of crossing the threshold.
+
+### Tuning the Threshold
+
+The threshold lives at the top of the time-since-write block in `statusline-command.sh`:
+
+```sh
+write_threshold=3600   # 1 hour; drop to 60 for quick verification
+```
+
+The default (3600 = 1 hour) is picked to surface long non-writing stretches without nagging during normal editing. Drop to `60` temporarily when you first install the feature so you can confirm the segment renders within a minute of your last edit, then restore 3600 once you trust the wiring.
+
+### Formatting
+
+| Delta         | Display            |
+| ------------- | ------------------ |
+| `< threshold` | (hidden)           |
+| `< 1 hour`    | `since-write:Xm`   |
+| `< 24 hours`  | `since-write:XhYm` |
+| `≥ 24 hours`  | `since-write:Xd`   |
 
 ## Requirements
 

--- a/dev-setup/statusline-command.sh
+++ b/dev-setup/statusline-command.sh
@@ -58,4 +58,30 @@ if [ -n "$used" ] && [ -n "$ctx_size" ]; then
 fi
 [ -n "$cost_usd" ] && prompt="${prompt} \$$(printf '%.2f' "$cost_usd")"
 
+# Time since last file write — updated by PostToolUse/SessionStart hooks
+# that touch ~/.claude/last_write.timestamp (see claude-code-statusline.md).
+# Segment appears only when the delta exceeds write_threshold seconds, so
+# the prompt stays quiet during normal editing. 3600 (1 hour) is tuned to
+# surface long read/think/bash stretches without writes; drop to 60 (1m)
+# when verifying the display works.
+write_ts_file="$HOME/.claude/last_write.timestamp"
+write_threshold=3600
+if [ -f "$write_ts_file" ]; then
+  last_mtime=$(stat -c %Y "$write_ts_file" 2>/dev/null || stat -f %m "$write_ts_file" 2>/dev/null)
+  if [ -n "$last_mtime" ]; then
+    now=$(date +%s)
+    delta=$((now - last_mtime))
+    if [ "$delta" -gt "$write_threshold" ]; then
+      if [ "$delta" -lt 3600 ]; then
+        write_str="$((delta / 60))m"
+      elif [ "$delta" -lt 86400 ]; then
+        write_str="$((delta / 3600))h$(((delta % 3600) / 60))m"
+      else
+        write_str="$((delta / 86400))d"
+      fi
+      prompt="${prompt} ${PINK}since-write:${write_str}${RESET}"
+    fi
+  fi
+fi
+
 printf '%s' "$prompt"


### PR DESCRIPTION
## Summary

- Add a conditional `since-write:Xm` segment to `dev-setup/statusline-command.sh` that surfaces stretches where Claude has been reading / grepping / thinking without writing any code. The segment is hidden during normal editing and only appears once `now - mtime(~/.claude/last_write.timestamp)` exceeds `write_threshold` (default **3600s / 1h**).
- Document the supporting hook wiring in `dev-setup/claude-code-statusline.md`: `PostToolUse` on `Write|Edit|NotebookEdit` resets the clock on every file-writing tool call, `SessionStart` touches the file so a fresh session doesn't inherit a stale timestamp from the previous one, and `statusLine.refreshInterval: 30` is called out as load-bearing so the counter ticks during pure-idle stretches where no tool calls fire.
- Pre-existing `printf '%s' "$input" > ~/.claude/statusline_last_input.json` debug tap is preserved unchanged; the new block is additive.

## Why

During long sessions it's easy to drift into a multi-hour read/grep/think tangent without actually writing any code. The segment is meant as a passive "have I been on a tangent for an hour?" nudge — quiet by default, visible only when you're past the threshold.

## Test plan

- [x] Dry-run the script against an isolated `HOME` with a 2-hour-stale timestamp file — segment renders as `since-write:2h0m` in pink
- [x] Dry-run with a fresh timestamp — segment hidden (no noise during normal editing)
- [x] In-turn proof that `PostToolUse` on `Edit` fires: seeded timestamp to 10 minutes ago, ran an Edit, confirmed the file's mtime jumped to ~now
- [x] `jq -e` validation of the hook JSON shape (both `PostToolUse` and `SessionStart` nestings + `statusLine.refreshInterval`)
- [x] `prek` pre-commit pipeline (prettier, fast tests) passes
- [ ] Reviewer: install the snippet, drop `write_threshold` to `60`, confirm segment appears within ~30s of last edit, then restore `3600`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status line segment displaying time elapsed since the last file write operation, formatted as compact values (minutes/hours/days) and appearing only after a configurable threshold.

* **Documentation**
  * Expanded documentation with configuration guidance for the new time-since-write status line segment, including threshold customization and setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->