### PR TITLE
docs(CLAUDE.md): grep after resolving fix-style PR rebase conflicts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,7 @@ gh pr create --repo idvorkin/chop-conventions
 
 - **`.git/info/exclude` for local-only ignores.** Ephemeral or per-machine ignore entries (worktree dirs, caches, editor state) that must NOT touch branch history go in `.git/info/exclude`, not `.gitignore`. Untracked, branch-independent, shared across linked worktrees via `git rev-parse --git-common-dir`. `git check-ignore` respects it the same as `.gitignore`.
 - **`git fetch origin` does NOT refresh `refs/remotes/origin/HEAD`.** Run `git remote set-head origin --auto` before reading `git symbolic-ref --short refs/remotes/origin/HEAD` or you'll get stale values when the default branch was renamed (e.g. master → main) since clone. Idempotent no-op if origin/HEAD already matches.
+- **Fix-style PR rebases: grep after resolving.** Conflict markers only cover regions both sides touched — a concurrent refactor can introduce new instances of the anti-pattern the fix PR was replacing in non-conflicting code the PR author never saw. After clearing `<<<<<<<` markers, grep the whole file for the pattern and fix every hit before `rebase --continue`.
 
 ## Process-Signaling Safety
 


### PR DESCRIPTION
## Summary

Adds one bullet to the **Git Inner-Loop** section capturing a lesson from resolving PR #93's merge conflicts.

## Why

While rebasing #93 (`detect default branch`) onto current `upstream/main`, the upstream refactor (`9786334` — worktree + branch absorption) had added **three new hardcoded `{src}/main` usages in the new parallel-cherry block** that the PR author never saw. Those instances lived in non-conflicting code, so `<<<<<<<` markers did not flag them. Clearing only the marker regions would have shipped a half-fix where `master`-default repos still broke on the new parallel cherry call.

The general pattern: conflict markers only cover overlapping edits. A fix-style PR that replaces an anti-pattern needs to be re-propagated across the whole file after rebase, because concurrent refactors can introduce new instances of the very pattern the PR is eliminating.

## Content

One bullet in `CLAUDE.md` → `## Git Inner-Loop`:

> **Fix-style PR rebases: grep after resolving.** Conflict markers only cover regions both sides touched — a concurrent refactor can introduce new instances of the anti-pattern the fix PR was replacing in non-conflicting code the PR author never saw. After clearing `<<<<<<<` markers, grep the whole file for the pattern and fix every hit before `rebase --continue`.

## Test plan

- [x] Pre-commit hooks pass (prettier, ruff, biome, dasel, fast tests)
- [x] Diff is +1 line, no unrelated edits
- [x] Bullet matches voice and length of surrounding Git Inner-Loop entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)