### PR TITLE
harden-telegram: add prescriptive Recovery Protocol for interactive sessions

### DIFF
--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -84,6 +84,36 @@ Use it when:
 
 The watchdog cron scheduled by `/startup-larry` step 3 item 4 uses this exclusively — that's the design principle: **the thing watching Telegram must not depend on Telegram's MCP bridge.**
 
+### Recovery Protocol (interactive session)
+
+When an interactive Claude session detects the Telegram MCP has died — `mcp__plugin_telegram_telegram__*` tools vanish from the available tool list, or a `reply` call fails, or the doctor shows red — **follow this order. Do not skip the first direct-send.**
+
+1. **Ping Igor's phone FIRST via `--direct-send`, before diagnosing.** One second of cost, guarantees Igor knows something is happening even if he's on Telegram-only and not watching the terminal:
+   ```bash
+   python3 ~/.claude/skills/harden-telegram/tools/telegram_debug.py \
+     --direct-send "⚠️ Larry: Telegram MCP down. Starting recovery."
+   ```
+
+2. **Diagnose.** Run `telegram_debug.py --doctor` (or `--doctor --json` if parsing). Identify the specific failure mode.
+
+3. **Walk Tier 2 recovery.** Kill stale process if needed, restart, fire `/reload-plugins` (via the background watchdog pattern — never foreground).
+
+4. **Ping again on outcome** — same direct-send path:
+   - Success: `--direct-send "✅ Recovered — <what was fixed>"`
+   - Failure: `--direct-send "❌ Still broken — <details>"` AND append a timestamped line to `/tmp/larry_telegram_recovery.log`
+
+5. **Verify via an untagged MCP reply.** After MCP comes back, send a normal `reply` tool call to confirm the bridge is live. The **absence** of the `[direct-send]` prefix on the next message Igor sees proves MCP is back — that's the semantic signal.
+
+**Why the first direct-send is mandatory.** Silent recovery looks identical to "Claude crashed" from Igor's perspective. A 1-second notification is cheap insurance against a 30-minute silence. This is the same principle as the hourly watchdog cron documented above: **the thing watching Telegram must not depend on Telegram's MCP bridge.** The cron already follows this principle; the interactive recovery path must too.
+
+**What counts as "detecting MCP is down".** Any of:
+- System-reminder arrives saying `plugin:telegram:telegram` has disconnected
+- `mcp__plugin_telegram_telegram__reply` or related tools are no longer in the tool list
+- A reply-tool call returns a "tool not available" or transport error
+- `telegram_debug.py --doctor` shows any red section
+
+Any one of these triggers the protocol. Do not wait for confirmation across multiple signals — ping first, confirm after.
+
 ---
 
 ## Tier 2: Reload (`/harden-telegram reload`)


### PR DESCRIPTION
## Summary

- Adds a prescriptive "Recovery Protocol (interactive session)" subsection to `harden-telegram` SKILL.md, inside Tier 1 right after Emergency Direct-Send.
- Fixes the gap where the model had no prescribed order when MCP dies mid-session — previously the skill said "you can use --direct-send" but never said "you must use it first, before diagnosing".
- Matches the principle the hourly watchdog cron already follows: the thing watching Telegram must not depend on Telegram's MCP bridge.

## Motivation

Observed 2026-04-14 during a live Larry session on Hood Canal vacation day 2: Telegram MCP died after `/reload-plugins`. The model diagnosed, found the root cause (Apr 12 commit 317031a fixed a bun-killing bug in telegram_bot.py that was never deployed), killed + restarted telegram_bot, reloaded plugins, and recovered — all over ~30 minutes — but never proactively pinged Igor's phone via `--direct-send`. Igor had to ask "are we fixed?" via terminal. If he'd been on Telegram-only, he'd have seen nothing.

The fix is a 5-step prescribed order, not new code. Future sessions now have a checklist.

## Test plan

- [ ] SKILL.md renders correctly (nested code blocks don't break the outer markdown)
- [ ] Section lands in the right place (inside Tier 1, after Emergency Direct-Send, before the Tier 2 `---` separator)
- [ ] Commands in the new section are executable as shown
- [ ] Cross-reference to the watchdog-cron design principle is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added recovery protocol documentation for interactive sessions when Telegram MCP is unavailable. The guide includes diagnostic procedures, recovery steps with verification criteria, and success/failure confirmation methods for operators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->