### PR TITLE
harden-telegram: doctor auto-runs plugin-cache drift check

### DIFF
--- a/skills/harden-telegram/tools/telegram_debug.py
+++ b/skills/harden-telegram/tools/telegram_debug.py
@@ -371,15 +371,57 @@ def check_access_config() -> dict:
         return {"exists": True, "error": str(e)}
 
 
+# Hardcoded fallback for the canonical server.ts source directory.
+# Matches Igor's box layout: the two-process telegram fork lives under
+# ~/gits/igor2/telegram-server. Anyone else either sets TELEGRAM_SOURCE_DIR
+# explicitly or degrades to the legacy "skipped" note.
+_DEFAULT_SOURCE_DIR = Path.home() / "gits" / "igor2" / "telegram-server"
+
+
+def _resolve_source_dir() -> tuple[Path | None, str | None]:
+    """Resolve the canonical server.ts source directory and its lookup source.
+
+    Lookup order (first hit wins):
+      1. `TELEGRAM_SOURCE_DIR` env var — explicit override.
+      2. `~/gits/igor2/telegram-server` — hardcoded default for Igor's layout.
+
+    Returns (path, source) where source is "env", "default", or None. Path is
+    only returned when the resolved dir exists AND contains a `server.ts`;
+    otherwise returns (None, "env"|"default"|None) so the caller can tell the
+    difference between "not configured" and "configured but missing".
+
+    The "env" case short-circuits even if the dir is missing — callers should
+    check `path is None` to decide whether to skip the drift check vs emit a
+    louder warning about an explicitly-set-but-missing source. See
+    `_doctor_check_deploy` for the degrade-gracefully path.
+    """
+    env = os.environ.get("TELEGRAM_SOURCE_DIR")
+    if env:
+        p = Path(env).expanduser()
+        if (p / "server.ts").exists():
+            return p, "env"
+        # Explicitly set but missing — return None path with "env" source so
+        # the doctor can emit the legacy skipped note instead of crashing.
+        return None, "env"
+    if (_DEFAULT_SOURCE_DIR / "server.ts").exists():
+        return _DEFAULT_SOURCE_DIR, "default"
+    return None, None
+
+
 def _source_dir() -> Path | None:
     """Canonical server.ts source directory (for hash-drift check).
 
-    Set TELEGRAM_SOURCE_DIR to the dir containing server.ts. If unset, drift
-    checks degrade to a note — the doctor still runs, it just can't tell you
-    whether the plugin-cache copy matches an upstream source.
+    Lookup order:
+      1. `TELEGRAM_SOURCE_DIR` env var (explicit override)
+      2. `~/gits/igor2/telegram-server` (hardcoded default for Igor's box)
+
+    Returns None if neither resolves to a dir containing `server.ts` — the
+    doctor still runs, it just can't tell you whether the plugin-cache copy
+    matches an upstream source. Callers that need the lookup-source metadata
+    (env vs default) should call `_resolve_source_dir()` directly.
     """
-    env = os.environ.get("TELEGRAM_SOURCE_DIR")
-    return Path(env).expanduser() if env else None
+    path, _ = _resolve_source_dir()
+    return path
 
 
 def _source_server_ts() -> Path | None:
@@ -396,27 +438,74 @@ def _file_hash(path: Path) -> str | None:
 
 
 def check_plugin_deploy() -> dict:
-    """Check if our custom server.ts is deployed and matches source."""
+    """Check if our custom server.ts is deployed and matches source.
+
+    Emits both the legacy fields (installed/version/deploy_path/WARNING_DRIFT/
+    etc. — preserved for any existing consumers) and the structured `deploy`
+    block that --json mode exposes for watchdog parsing:
+
+        {
+            "plugin_cache_path": "...",
+            "plugin_cache_sha256": "...",
+            "source_path": "..." | None,
+            "source_sha256": "..." | None,
+            "source_source": "env" | "default" | None,
+            "drift_detected": True | False,
+            "severity": "ok" | "error" | "skipped"
+        }
+
+    `severity` is the single field automation should key on:
+      - "ok": source == plugin, everything matches
+      - "error": drift detected OR plugin missing — watchdog should alarm
+      - "skipped": no source configured or no plugin cache to compare against
+    """
     # Find the version dir
     if not PLUGIN_DIR.exists():
-        return {"installed": False}
+        return {
+            "installed": False,
+            "deploy": {
+                "plugin_cache_path": None,
+                "plugin_cache_sha256": None,
+                "source_path": None,
+                "source_sha256": None,
+                "source_source": None,
+                "drift_detected": False,
+                "severity": "skipped",
+            },
+        }
     versions = sorted(
         [d for d in PLUGIN_DIR.iterdir() if d.is_dir() and d.name[0].isdigit()],
         reverse=True,
     )
     if not versions:
-        return {"installed": False}
+        return {
+            "installed": False,
+            "deploy": {
+                "plugin_cache_path": None,
+                "plugin_cache_sha256": None,
+                "source_path": None,
+                "source_sha256": None,
+                "source_source": None,
+                "drift_detected": False,
+                "severity": "skipped",
+            },
+        }
     version_dir = versions[0]  # newest version
     deployed_file = version_dir / "server.ts"
-    source_ts = _source_server_ts()
+    source_path, source_source = _resolve_source_dir()
+    source_ts = (source_path / "server.ts") if source_path else None
     result: dict = {
         "installed": True,
         "version": version_dir.name,
         "deploy_path": str(deployed_file),
         "source_path": str(source_ts) if source_ts else None,
         "source_configured": source_ts is not None,
+        "source_source": source_source,
         "server_ts_exists": deployed_file.exists(),
     }
+    source_hash: str | None = None
+    deploy_hash: str | None = None
+    drift_detected = False
     if deployed_file.exists():
         result["is_symlink"] = deployed_file.is_symlink()
         if deployed_file.is_symlink():
@@ -429,20 +518,41 @@ def check_plugin_deploy() -> dict:
             result["has_heartbeat"] = "heartbeat" in content
         except OSError:
             pass
+        deploy_hash = _file_hash(deployed_file)
         # Compare source vs deployed — only if a source dir is configured.
         if source_ts is not None:
             source_hash = _file_hash(source_ts)
-            deploy_hash = _file_hash(deployed_file)
             result["source_hash"] = source_hash
             result["deploy_hash"] = deploy_hash
             if source_hash and deploy_hash:
                 result["in_sync"] = source_hash == deploy_hash
-                if not result["in_sync"]:
+                drift_detected = source_hash != deploy_hash
+                if drift_detected:
                     result["WARNING_DRIFT"] = (
                         "Source and deployed server.ts differ! "
                         f"Run: cp {source_ts} {deployed_file}"
                     )
             result["source_exists"] = source_ts.exists()
+
+    # Derive severity for the structured deploy block.
+    if deploy_hash is None:
+        severity = "skipped"  # plugin cache unreadable or missing
+    elif source_hash is None:
+        severity = "skipped"  # no source to compare against
+    elif drift_detected:
+        severity = "error"
+    else:
+        severity = "ok"
+
+    result["deploy"] = {
+        "plugin_cache_path": str(deployed_file),
+        "plugin_cache_sha256": deploy_hash,
+        "source_path": str(source_ts) if source_ts else None,
+        "source_sha256": source_hash,
+        "source_source": source_source,
+        "drift_detected": drift_detected,
+        "severity": severity,
+    }
     return result
 
 
@@ -842,8 +952,7 @@ def _doctor_check_server_ts(report: DoctorReport) -> None:
         if orphans:
             pids_str = ", ".join(str(b["pid"]) for b in orphans)
             report.warn(
-                f"{len(orphans)} orphaned bridge(s): {pids_str} — "
-                "owning Claude is gone"
+                f"{len(orphans)} orphaned bridge(s): {pids_str} — owning Claude is gone"
             )
         return
 
@@ -864,9 +973,7 @@ def _doctor_check_server_ts(report: DoctorReport) -> None:
         )
 
     if others:
-        summary = ", ".join(
-            f"{b['pid']}→claude:{b['owning_claude']}" for b in others
-        )
+        summary = ", ".join(f"{b['pid']}→claude:{b['owning_claude']}" for b in others)
         report.note(
             f"{len(others)} bridge(s) in other Claude sessions: {summary} — ignored"
         )
@@ -893,15 +1000,13 @@ def _doctor_check_session_subscription(report: DoctorReport) -> None:
     our_claude = _find_owning_claude(os.getpid())
     if our_claude is None:
         report.note(
-            "doctor not running inside a Claude session — "
-            "subscription check skipped"
+            "doctor not running inside a Claude session — subscription check skipped"
         )
         return
     argv = _read_proc_cmdline(our_claude)
     if argv is None:
         report.warn(
-            f"could not read /proc/{our_claude}/cmdline — "
-            "subscription check skipped"
+            f"could not read /proc/{our_claude}/cmdline — subscription check skipped"
         )
         return
     if session_subscribed_to_telegram(argv):
@@ -957,35 +1062,73 @@ def _find_plugin_server_ts() -> tuple[Path, str | None] | None:
 
 
 def _doctor_check_deploy(report: DoctorReport) -> None:
+    """Auto-run plugin-cache drift check.
+
+    Source dir is resolved in this order:
+      1. `$TELEGRAM_SOURCE_DIR` (explicit override)
+      2. `~/gits/igor2/telegram-server` (hardcoded default for Igor's box)
+      3. skipped — degrades to legacy note for setups without either
+
+    If the source is resolved and the plugin cache is readable, sha256-compares
+    both files:
+      - match   → ✅ green, nothing to worry about
+      - drift   → ❌ red, fails the doctor (exit non-zero) so the hourly
+                   watchdog catches plugin auto-update damage automatically
+      - skipped → legacy "·" note, unchanged behavior for non-Igor setups
+
+    This check existed before but only ran when `TELEGRAM_SOURCE_DIR` was
+    explicitly exported. On 2026-04-14 a plugin auto-update 0.0.5→0.0.6
+    silently replaced the deployed two-process fork with upstream vanilla,
+    re-enabling polling and causing 409 Conflicts with `telegram_bot.py`.
+    Making the check default-on closes that silent-miss.
+    """
     report.section("DEPLOY")
     plugin_info = _find_plugin_server_ts()
-    src = _source_server_ts()
+    source_path, source_source = _resolve_source_dir()
+    src = (source_path / "server.ts") if source_path else None
+
     if src is None:
-        # No canonical source configured — we can still validate the plugin
-        # cache exists, just not whether it's in sync with an upstream copy.
+        # No canonical source resolved (neither env var nor default).
+        # We can still validate the plugin cache exists; we just can't tell
+        # whether it's in sync with an upstream copy. Legacy skipped note.
         if plugin_info is None:
-            report.warn("no plugin-cache server.ts found (TELEGRAM_SOURCE_DIR unset)")
+            report.warn(
+                "no plugin-cache server.ts found "
+                "(set TELEGRAM_SOURCE_DIR or populate ~/gits/igor2/telegram-server)"
+            )
             return
         plugin_path, plugin_hash = plugin_info
-        report.note(
-            f"plugin cache: {plugin_hash} ({plugin_path}) — "
-            "set TELEGRAM_SOURCE_DIR to enable drift check"
-        )
+        # If TELEGRAM_SOURCE_DIR was explicitly set but pointed somewhere that
+        # doesn't contain server.ts, say so loudly — otherwise the operator
+        # thinks the check ran.
+        if source_source == "env":
+            report.note(
+                f"plugin cache: {plugin_hash} ({plugin_path}) — "
+                "TELEGRAM_SOURCE_DIR set but missing server.ts, drift check skipped"
+            )
+        else:
+            report.note(
+                f"plugin cache: {plugin_hash} ({plugin_path}) — "
+                "no source dir resolvable, drift check skipped"
+            )
         return
-    if not src.exists():
-        report.fail(f"source server.ts missing at {src}")
-        return
+
     src_hash = _file_hash(src)
     if plugin_info is None:
         report.warn(f"no plugin-cache server.ts found (src={src_hash})")
         return
     plugin_path, plugin_hash = plugin_info
     if src_hash and plugin_hash and src_hash == plugin_hash:
-        report.ok(f"source == plugin: {src_hash} ({plugin_path})")
+        report.ok(
+            f"plugin cache matches source (sha256: {src_hash}) — "
+            f"source={src} [{source_source}]"
+        )
     else:
-        report.warn(
-            f"source/plugin drift: src={src_hash} plugin={plugin_hash} — "
-            f"redeploy needed ({plugin_path})"
+        # Red X, not warning — doctor exits non-zero and the watchdog will
+        # catch it. This is the whole point of auto-running the check.
+        report.fail(
+            f"plugin cache DRIFT: source={src_hash} cache={plugin_hash} — "
+            f"run: cp {src} {plugin_path}"
         )
 
 
@@ -1219,7 +1362,7 @@ def run_paths() -> int:
         *(
             [
                 (
-                    "Source tree (TELEGRAM_SOURCE_DIR)",
+                    f"Source tree ({_resolve_source_dir()[1] or '?'}: {_source_dir()})",
                     [
                         ("telegram_bot.py", _source_dir() / "telegram_bot.py"),  # type: ignore[operator]
                         ("server.ts", _source_dir() / "server.ts"),  # type: ignore[operator]

--- a/skills/harden-telegram/tools/test_telegram_debug.py
+++ b/skills/harden-telegram/tools/test_telegram_debug.py
@@ -13,12 +13,17 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).parent))
 
+import telegram_debug  # noqa: E402
 from telegram_debug import (  # noqa: E402
+    DoctorReport,
     _default_chat_id,
+    _doctor_check_deploy,
     _find_owning_claude,
     _read_bot_token,
     _redact,
+    _resolve_source_dir,
     build_direct_request,
+    check_plugin_deploy,
     classify_bridges,
     parse_env_token,
     parse_proc_stat,
@@ -28,14 +33,17 @@ from telegram_debug import (  # noqa: E402
 
 def make_stat_reader(table: dict[int, tuple[str, int]]):
     """Build a fake stat reader from a {pid: (comm, ppid)} table."""
+
     def reader(pid: int):
         return table.get(pid)
+
     return reader
 
 
 def make_alive(alive_pids: set[int]):
     def is_alive(pid: int) -> bool:
         return pid in alive_pids
+
     return is_alive
 
 
@@ -85,7 +93,9 @@ class TestFindOwningClaude(unittest.TestCase):
             100: ("bun", 99),
             99: ("claude", 1),
         }
-        self.assertEqual(_find_owning_claude(100, stat_reader=make_stat_reader(table)), 99)
+        self.assertEqual(
+            _find_owning_claude(100, stat_reader=make_stat_reader(table)), 99
+        )
 
     def test_grandchild_through_shell(self):
         table = {
@@ -93,7 +103,9 @@ class TestFindOwningClaude(unittest.TestCase):
             150: ("bash", 99),
             99: ("claude", 1),
         }
-        self.assertEqual(_find_owning_claude(200, stat_reader=make_stat_reader(table)), 99)
+        self.assertEqual(
+            _find_owning_claude(200, stat_reader=make_stat_reader(table)), 99
+        )
 
     def test_no_claude_ancestor(self):
         table = {
@@ -118,7 +130,9 @@ class TestFindOwningClaude(unittest.TestCase):
             200: ("bash", 100),
             100: ("claude", 1),
         }
-        self.assertEqual(_find_owning_claude(300, stat_reader=make_stat_reader(table)), 250)
+        self.assertEqual(
+            _find_owning_claude(300, stat_reader=make_stat_reader(table)), 250
+        )
 
     def test_matches_claude_code_shim(self):
         # Linux truncates comm to 15 chars; launchers like `claude-code` or
@@ -127,7 +141,9 @@ class TestFindOwningClaude(unittest.TestCase):
             100: ("bun", 99),
             99: ("claude-code", 1),
         }
-        self.assertEqual(_find_owning_claude(100, stat_reader=make_stat_reader(table)), 99)
+        self.assertEqual(
+            _find_owning_claude(100, stat_reader=make_stat_reader(table)), 99
+        )
 
     def test_loop_guard(self):
         # Impossible in practice, but a pid-reuse race could in theory produce
@@ -254,9 +270,7 @@ class TestClassifyBridges(unittest.TestCase):
 class TestSessionSubscribedToTelegram(unittest.TestCase):
     def test_plain_claude_is_not_subscribed(self):
         self.assertFalse(
-            session_subscribed_to_telegram(
-                ["claude", "--dangerously-skip-permissions"]
-            )
+            session_subscribed_to_telegram(["claude", "--dangerously-skip-permissions"])
         )
 
     def test_channels_flag_with_telegram_plugin(self):
@@ -305,9 +319,7 @@ class TestSessionSubscribedToTelegram(unittest.TestCase):
 
     def test_channels_flag_with_no_value_is_ignored(self):
         # Trailing --channels with nothing after it shouldn't crash or match.
-        self.assertFalse(
-            session_subscribed_to_telegram(["claude", "--channels"])
-        )
+        self.assertFalse(session_subscribed_to_telegram(["claude", "--channels"]))
 
     def test_empty_argv(self):
         self.assertFalse(session_subscribed_to_telegram([]))
@@ -318,14 +330,10 @@ class TestParseEnvToken(unittest.TestCase):
         self.assertEqual(parse_env_token("TELEGRAM_BOT_TOKEN=123:abc\n"), "123:abc")
 
     def test_double_quoted(self):
-        self.assertEqual(
-            parse_env_token('TELEGRAM_BOT_TOKEN="123:abc"\n'), "123:abc"
-        )
+        self.assertEqual(parse_env_token('TELEGRAM_BOT_TOKEN="123:abc"\n'), "123:abc")
 
     def test_single_quoted(self):
-        self.assertEqual(
-            parse_env_token("TELEGRAM_BOT_TOKEN='123:abc'\n"), "123:abc"
-        )
+        self.assertEqual(parse_env_token("TELEGRAM_BOT_TOKEN='123:abc'\n"), "123:abc")
 
     def test_export_prefix(self):
         # `.env` files copied from shell profiles often carry `export`.
@@ -334,9 +342,7 @@ class TestParseEnvToken(unittest.TestCase):
         )
 
     def test_trailing_whitespace(self):
-        self.assertEqual(
-            parse_env_token("TELEGRAM_BOT_TOKEN=123:abc   \n"), "123:abc"
-        )
+        self.assertEqual(parse_env_token("TELEGRAM_BOT_TOKEN=123:abc   \n"), "123:abc")
 
     def test_inline_comment_unquoted(self):
         # Unquoted values take a `#` as an inline comment boundary.
@@ -347,9 +353,7 @@ class TestParseEnvToken(unittest.TestCase):
 
     def test_hash_inside_quoted_value_kept(self):
         # Quoted values are literal — no comment stripping.
-        self.assertEqual(
-            parse_env_token('TELEGRAM_BOT_TOKEN="abc#def"\n'), "abc#def"
-        )
+        self.assertEqual(parse_env_token('TELEGRAM_BOT_TOKEN="abc#def"\n'), "abc#def")
 
     def test_ignores_comment_lines_before_match(self):
         text = "# leading comment\nOTHER_VAR=foo\nTELEGRAM_BOT_TOKEN=123:abc\n"
@@ -357,9 +361,7 @@ class TestParseEnvToken(unittest.TestCase):
 
     def test_substring_collision_rejected(self):
         # A different var whose name *contains* TELEGRAM_BOT_TOKEN must not match.
-        self.assertIsNone(
-            parse_env_token("OLD_TELEGRAM_BOT_TOKEN=stale\n")
-        )
+        self.assertIsNone(parse_env_token("OLD_TELEGRAM_BOT_TOKEN=stale\n"))
 
     def test_missing_returns_none(self):
         self.assertIsNone(parse_env_token("OTHER=x\n"))
@@ -397,9 +399,7 @@ class TestDefaultChatId(unittest.TestCase):
         tmp = tempfile.TemporaryDirectory()
         db = Path(tmp.name) / "inbound.db"
         con = sqlite3.connect(db)
-        con.execute(
-            "CREATE TABLE inbound (id INTEGER PRIMARY KEY, chat_id INTEGER)"
-        )
+        con.execute("CREATE TABLE inbound (id INTEGER PRIMARY KEY, chat_id INTEGER)")
         con.executemany("INSERT INTO inbound (chat_id) VALUES (?)", rows)
         con.commit()
         con.close()
@@ -464,6 +464,7 @@ class TestBuildDirectRequest(unittest.TestCase):
         _, body = build_direct_request("T", "1", "héllo 🚨")
         # Body must decode back to the same string after urldecode.
         import urllib.parse
+
         decoded = dict(urllib.parse.parse_qsl(body.decode()))
         self.assertEqual(decoded["text"], "[direct-send] héllo 🚨")
 
@@ -487,6 +488,308 @@ class TestRedact(unittest.TestCase):
 
     def test_empty_token_is_noop(self):
         self.assertEqual(_redact("anything", ""), "anything")
+
+
+class TestResolveSourceDir(unittest.TestCase):
+    """Unit tests for the source-dir lookup order used by the drift check.
+
+    The drift check's whole value hinges on this function:
+      1. TELEGRAM_SOURCE_DIR env var wins if set.
+      2. Hardcoded default (~/gits/igor2/telegram-server) is next.
+      3. Neither resolving to a dir with server.ts → (None, None).
+
+    Tests monkeypatch the module-level _DEFAULT_SOURCE_DIR constant and the
+    env var so no real filesystem state outside a tempdir is consulted.
+    """
+
+    def setUp(self):
+        self._saved_env = os.environ.pop("TELEGRAM_SOURCE_DIR", None)
+        self._saved_default = telegram_debug._DEFAULT_SOURCE_DIR
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+
+    def tearDown(self):
+        if self._saved_env is not None:
+            os.environ["TELEGRAM_SOURCE_DIR"] = self._saved_env
+        else:
+            os.environ.pop("TELEGRAM_SOURCE_DIR", None)
+        telegram_debug._DEFAULT_SOURCE_DIR = self._saved_default
+        self.tmp.cleanup()
+
+    def test_env_var_wins_when_valid(self):
+        env_dir = self.tmp_path / "env_source"
+        env_dir.mkdir()
+        (env_dir / "server.ts").write_text("// env content")
+        default_dir = self.tmp_path / "default_source"
+        default_dir.mkdir()
+        (default_dir / "server.ts").write_text("// default content")
+        os.environ["TELEGRAM_SOURCE_DIR"] = str(env_dir)
+        telegram_debug._DEFAULT_SOURCE_DIR = default_dir
+        path, source = _resolve_source_dir()
+        self.assertEqual(path, env_dir)
+        self.assertEqual(source, "env")
+
+    def test_env_var_set_but_missing_server_ts_returns_none_path(self):
+        # Explicitly-set-but-broken path should NOT silently fall through to
+        # the default — that would confuse operators who think they turned
+        # the check off by setting the env var to /tmp/nonexistent.
+        os.environ["TELEGRAM_SOURCE_DIR"] = "/tmp/definitely-does-not-exist-xyz"
+        # Even though the default exists, the explicit override suppresses it.
+        default_dir = self.tmp_path / "default_source"
+        default_dir.mkdir()
+        (default_dir / "server.ts").write_text("// default content")
+        telegram_debug._DEFAULT_SOURCE_DIR = default_dir
+        path, source = _resolve_source_dir()
+        self.assertIsNone(path)
+        self.assertEqual(source, "env")
+
+    def test_falls_back_to_default_when_env_unset(self):
+        default_dir = self.tmp_path / "default_source"
+        default_dir.mkdir()
+        (default_dir / "server.ts").write_text("// default content")
+        telegram_debug._DEFAULT_SOURCE_DIR = default_dir
+        path, source = _resolve_source_dir()
+        self.assertEqual(path, default_dir)
+        self.assertEqual(source, "default")
+
+    def test_returns_none_none_when_nothing_resolves(self):
+        # Env unset, default dir doesn't contain server.ts.
+        telegram_debug._DEFAULT_SOURCE_DIR = self.tmp_path / "nonexistent"
+        path, source = _resolve_source_dir()
+        self.assertIsNone(path)
+        self.assertIsNone(source)
+
+    def test_default_dir_exists_but_no_server_ts(self):
+        # Directory present but file absent — still a skip, not a crash.
+        default_dir = self.tmp_path / "default_source"
+        default_dir.mkdir()
+        telegram_debug._DEFAULT_SOURCE_DIR = default_dir
+        path, source = _resolve_source_dir()
+        self.assertIsNone(path)
+        self.assertIsNone(source)
+
+
+class TestDoctorCheckDeploy(unittest.TestCase):
+    """Tests for the DEPLOY section of the doctor.
+
+    Patches `_resolve_source_dir` and `_find_plugin_server_ts` at the module
+    level to avoid touching the real filesystem / plugin cache. The goal is
+    to verify the branching logic, not the sha256 implementation — that's
+    covered by the file itself being `hashlib.sha256` of `read_bytes()`.
+    """
+
+    def setUp(self):
+        self._orig_resolve = telegram_debug._resolve_source_dir
+        self._orig_find_plugin = telegram_debug._find_plugin_server_ts
+        self._orig_file_hash = telegram_debug._file_hash
+
+    def tearDown(self):
+        telegram_debug._resolve_source_dir = self._orig_resolve
+        telegram_debug._find_plugin_server_ts = self._orig_find_plugin
+        telegram_debug._file_hash = self._orig_file_hash
+
+    def _patch(
+        self,
+        resolve_return,
+        plugin_return,
+        hash_map: dict,
+    ):
+        telegram_debug._resolve_source_dir = lambda: resolve_return
+        telegram_debug._find_plugin_server_ts = lambda: plugin_return
+        telegram_debug._file_hash = lambda p: hash_map.get(str(p))
+
+    def test_match_emits_ok_no_failure(self):
+        src_dir = Path("/fake/source")
+        src_ts = src_dir / "server.ts"
+        plugin_ts = Path("/fake/plugin/server.ts")
+        self._patch(
+            resolve_return=(src_dir, "default"),
+            plugin_return=(plugin_ts, "abc123"),
+            hash_map={str(src_ts): "abc123", str(plugin_ts): "abc123"},
+        )
+        report = DoctorReport()
+        _doctor_check_deploy(report)
+        self.assertEqual(report.failures, 0)
+        joined = "\n".join(report.lines)
+        self.assertIn("plugin cache matches source", joined)
+        self.assertIn("abc123", joined)
+
+    def test_drift_fails_doctor(self):
+        src_dir = Path("/fake/source")
+        src_ts = src_dir / "server.ts"
+        plugin_ts = Path("/fake/plugin/server.ts")
+        self._patch(
+            resolve_return=(src_dir, "default"),
+            plugin_return=(plugin_ts, "cafebabe"),
+            hash_map={str(src_ts): "deadbeef", str(plugin_ts): "cafebabe"},
+        )
+        report = DoctorReport()
+        _doctor_check_deploy(report)
+        # Drift must flip the doctor to non-zero exit — this is the whole
+        # point of making the check auto-run. A silent warn() would be a
+        # regression of the 2026-04-14 incident.
+        self.assertEqual(report.failures, 1)
+        joined = "\n".join(report.lines)
+        self.assertIn("DRIFT", joined)
+        self.assertIn("deadbeef", joined)
+        self.assertIn("cafebabe", joined)
+        self.assertIn("cp", joined)
+
+    def test_no_source_resolvable_degrades_to_note(self):
+        plugin_ts = Path("/fake/plugin/server.ts")
+        self._patch(
+            resolve_return=(None, None),
+            plugin_return=(plugin_ts, "abc123"),
+            hash_map={str(plugin_ts): "abc123"},
+        )
+        report = DoctorReport()
+        _doctor_check_deploy(report)
+        # Legacy skipped path: no failure, but also no ok line — just a note.
+        self.assertEqual(report.failures, 0)
+        joined = "\n".join(report.lines)
+        self.assertIn("plugin cache", joined)
+        self.assertIn("no source dir resolvable", joined)
+
+    def test_env_set_but_missing_degrades_with_pointed_message(self):
+        plugin_ts = Path("/fake/plugin/server.ts")
+        # env was set, but _resolve returned None path with "env" marker —
+        # the doctor should call that out loudly instead of pretending the
+        # check ran.
+        self._patch(
+            resolve_return=(None, "env"),
+            plugin_return=(plugin_ts, "abc123"),
+            hash_map={str(plugin_ts): "abc123"},
+        )
+        report = DoctorReport()
+        _doctor_check_deploy(report)
+        self.assertEqual(report.failures, 0)
+        joined = "\n".join(report.lines)
+        self.assertIn("TELEGRAM_SOURCE_DIR set but missing server.ts", joined)
+
+    def test_plugin_cache_missing_but_source_present_warns(self):
+        src_dir = Path("/fake/source")
+        src_ts = src_dir / "server.ts"
+        self._patch(
+            resolve_return=(src_dir, "default"),
+            plugin_return=None,
+            hash_map={str(src_ts): "deadbeef"},
+        )
+        report = DoctorReport()
+        _doctor_check_deploy(report)
+        # Plugin missing is a warn, not a fail — someone running the doctor
+        # on a machine without the plugin installed shouldn't get a red X.
+        self.assertEqual(report.failures, 0)
+        joined = "\n".join(report.lines)
+        self.assertIn("no plugin-cache server.ts", joined)
+
+    def test_both_missing_warns_with_help_text(self):
+        self._patch(
+            resolve_return=(None, None),
+            plugin_return=None,
+            hash_map={},
+        )
+        report = DoctorReport()
+        _doctor_check_deploy(report)
+        self.assertEqual(report.failures, 0)
+        joined = "\n".join(report.lines)
+        self.assertIn("no plugin-cache server.ts", joined)
+        self.assertIn("TELEGRAM_SOURCE_DIR", joined)
+
+
+class TestCheckPluginDeployJson(unittest.TestCase):
+    """Tests for the structured `deploy` block emitted by check_plugin_deploy.
+
+    This is the block --json mode exposes for watchdog parsing. Verifies
+    field shape and severity classification — actual filesystem paths are
+    stubbed.
+    """
+
+    def setUp(self):
+        self._orig_plugin_dir = telegram_debug.PLUGIN_DIR
+        self._orig_resolve = telegram_debug._resolve_source_dir
+        self._orig_file_hash = telegram_debug._file_hash
+        self.tmp = tempfile.TemporaryDirectory()
+        self.tmp_path = Path(self.tmp.name)
+
+    def tearDown(self):
+        telegram_debug.PLUGIN_DIR = self._orig_plugin_dir
+        telegram_debug._resolve_source_dir = self._orig_resolve
+        telegram_debug._file_hash = self._orig_file_hash
+        self.tmp.cleanup()
+
+    def _make_plugin_cache(self, version: str = "0.0.6") -> Path:
+        """Create a fake plugin cache layout: PLUGIN_DIR/<ver>/server.ts."""
+        cache_root = self.tmp_path / "cache"
+        cache_root.mkdir()
+        ver_dir = cache_root / version
+        ver_dir.mkdir()
+        (ver_dir / "server.ts").write_text("// plugin cache content")
+        telegram_debug.PLUGIN_DIR = cache_root
+        return ver_dir / "server.ts"
+
+    def test_deploy_block_shape_on_match(self):
+        plugin_ts = self._make_plugin_cache()
+        src_dir = self.tmp_path / "src"
+        src_dir.mkdir()
+        src_ts = src_dir / "server.ts"
+        src_ts.write_text("// source")
+        telegram_debug._resolve_source_dir = lambda: (src_dir, "env")
+        telegram_debug._file_hash = lambda p: (
+            "samehash" if str(p) in (str(plugin_ts), str(src_ts)) else None
+        )
+        result = check_plugin_deploy()
+        self.assertIn("deploy", result)
+        deploy = result["deploy"]
+        self.assertEqual(deploy["plugin_cache_sha256"], "samehash")
+        self.assertEqual(deploy["source_sha256"], "samehash")
+        self.assertEqual(deploy["source_source"], "env")
+        self.assertFalse(deploy["drift_detected"])
+        self.assertEqual(deploy["severity"], "ok")
+        self.assertEqual(deploy["plugin_cache_path"], str(plugin_ts))
+        self.assertEqual(deploy["source_path"], str(src_ts))
+
+    def test_deploy_block_severity_error_on_drift(self):
+        plugin_ts = self._make_plugin_cache()
+        src_dir = self.tmp_path / "src"
+        src_dir.mkdir()
+        src_ts = src_dir / "server.ts"
+        src_ts.write_text("// source")
+        telegram_debug._resolve_source_dir = lambda: (src_dir, "default")
+        telegram_debug._file_hash = lambda p: (
+            "srchash"
+            if str(p) == str(src_ts)
+            else "plughash"
+            if str(p) == str(plugin_ts)
+            else None
+        )
+        result = check_plugin_deploy()
+        deploy = result["deploy"]
+        self.assertTrue(deploy["drift_detected"])
+        self.assertEqual(deploy["severity"], "error")
+        self.assertEqual(deploy["source_source"], "default")
+
+    def test_deploy_block_skipped_when_no_source(self):
+        plugin_ts = self._make_plugin_cache()
+        telegram_debug._resolve_source_dir = lambda: (None, None)
+        telegram_debug._file_hash = lambda p: (
+            "plughash" if str(p) == str(plugin_ts) else None
+        )
+        result = check_plugin_deploy()
+        deploy = result["deploy"]
+        self.assertEqual(deploy["severity"], "skipped")
+        self.assertFalse(deploy["drift_detected"])
+        self.assertEqual(deploy["plugin_cache_sha256"], "plughash")
+        self.assertIsNone(deploy["source_sha256"])
+        self.assertIsNone(deploy["source_source"])
+
+    def test_deploy_block_skipped_when_plugin_dir_missing(self):
+        telegram_debug.PLUGIN_DIR = self.tmp_path / "nonexistent"
+        telegram_debug._resolve_source_dir = lambda: (None, None)
+        result = check_plugin_deploy()
+        deploy = result["deploy"]
+        self.assertEqual(deploy["severity"], "skipped")
+        self.assertIsNone(deploy["plugin_cache_path"])
+        self.assertIsNone(deploy["plugin_cache_sha256"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Doctor's DEPLOY drift check now runs by default with a hardcoded fallback to `~/gits/igor2/telegram-server` when `TELEGRAM_SOURCE_DIR` is unset.
- Drift is flagged as red X (doctor exits non-zero) so the hourly watchdog auto-detects plugin auto-update damage.
- JSON mode includes a structured `deploy` block with both hashes, source path, and severity for automation parsing.

## Motivation

On 2026-04-14 a plugin auto-update from telegram@0.0.5 -> 0.0.6 replaced the deployed two-process fork with upstream vanilla, which re-enables polling and collides with `telegram_bot.py` via 409 Conflict. The doctor's existing drift check would have caught this instantly — but it required `TELEGRAM_SOURCE_DIR` to be set, which Igor's environment did not have exported. The check silently degraded to a passive note and the damage went undetected for ~2 hours.

This is the "Plugin auto-update overwrites deployed server.ts" failure mode documented in Tier 3 of the `harden-telegram` skill. Previously it required manual env var setup to catch. Now it's the default.

## Implementation

- New `_resolve_source_dir()` returns `(path, source)` where `source` is `"env"`, `"default"`, or `None`. Env var wins if set; hardcoded `~/gits/igor2/telegram-server` is the fallback; otherwise degrades to the legacy skipped note.
- `_doctor_check_deploy()` auto-runs the sha256 compare and uses `report.fail()` (red X) on drift so the doctor exits non-zero and the watchdog catches it.
- `check_plugin_deploy()` emits a structured `deploy` block in `--json` mode with `plugin_cache_path`, `plugin_cache_sha256`, `source_path`, `source_sha256`, `source_source`, `drift_detected`, and a `severity` enum (`ok`/`error`/`skipped`) for automation parsing.
- Explicitly-set-but-missing env var degrades with a pointed message (not a crash) — legacy skipped behavior for non-Igor setups is preserved.
- 15 new unit tests cover source-dir resolution (env/default/missing) and the doctor's match/drift/skip branches via module-level monkeypatching — no real filesystem dependencies.

## Test plan

- [x] `python3 telegram_debug.py --doctor` prints drift check in DEPLOY section by default (verified on Igor's box: match with `source=... [default]`)
- [x] JSON mode includes new `deploy` block with both hashes and severity (verified structured fields)
- [x] `TELEGRAM_SOURCE_DIR=/tmp/nonexistent` degrades to "set but missing server.ts" note, doctor exits 0
- [x] Explicit `TELEGRAM_SOURCE_DIR=<real path>` shows `[env]` marker in DEPLOY output
- [x] 70/70 unit tests pass (55 existing + 15 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] `just fast-test` passes via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)