### PR TITLE
harden-telegram: watchdog resolves pane via parent chain

### DIFF
--- a/skills/harden-telegram/tools/test_watchdog.py
+++ b/skills/harden-telegram/tools/test_watchdog.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit tests for watchdog.py pure helpers.
+
+Focus: the pane-resolution logic that walks the parent-process chain to find
+the tmux pane containing the caller. The real bug (fixed 2026-04-14) was that
+`reload` used `tmux display-message -p '#{pane_id}'` which returns the
+tmux-*active* pane, not the pane containing the caller — so with multiple
+concurrent Claude sessions the watchdog fired /reload-plugins into whichever
+session happened to be focused. Parent-chain walk is deterministic.
+
+Run with: python3 -m unittest test_watchdog.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from watchdog import (  # noqa: E402
+    find_ancestor_pane,
+    parse_proc_stat,
+)
+
+
+def make_stat_reader(table: dict[int, tuple[str, int]]):
+    """Build a fake stat reader from a {pid: (comm, ppid)} table."""
+
+    def reader(pid: int):
+        return table.get(pid)
+
+    return reader
+
+
+class TestParseProcStat(unittest.TestCase):
+    def test_simple_comm(self):
+        self.assertEqual(
+            parse_proc_stat("123 (bash) S 99 123 99 ...\n"),
+            ("bash", 99),
+        )
+
+    def test_comm_with_space(self):
+        self.assertEqual(
+            parse_proc_stat("123 (my proc) S 99 123 99 ...\n"),
+            ("my proc", 99),
+        )
+
+    def test_comm_with_inner_parens(self):
+        # Anchor on rfind(')') so names like "(weird)" don't truncate.
+        self.assertEqual(
+            parse_proc_stat("123 (weird )name) S 99 123 99 ...\n"),
+            ("weird )name", 99),
+        )
+
+    def test_missing_parens_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 bad line\n"))
+
+    def test_truncated_after_comm_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 (bash)"))
+
+    def test_non_numeric_ppid_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 (bash) S ??? 123 99 ...\n"))
+
+
+class TestFindAncestorPane(unittest.TestCase):
+    """The core fix. Each test mirrors a real scenario from the 2026-04-14 bug."""
+
+    def test_larry_scenario_finds_correct_pane(self):
+        # Real scenario: watchdog spawned inside Larry's Claude session at
+        # pane %35 (shell pid 2594534, pts/7). Another Claude at pane %65
+        # (shell pid 331460, pts/4) is also running on the same box. The
+        # watchdog's pid is 3000000, parent is bash 2800000, whose parent is
+        # the bun server 2700000, whose parent is Claude 2594600, whose
+        # parent is the pane-35 shell 2594534. Parent-chain walk should
+        # land on %35, NOT %65.
+        table = {
+            3000000: ("python3", 2800000),
+            2800000: ("bash", 2700000),
+            2700000: ("bun", 2594600),
+            2594600: ("claude", 2594534),
+            2594534: ("zsh", 1),
+            # Unrelated Claude session tree — must NOT match.
+            331460: ("zsh", 1),
+        }
+        pane_pids = {
+            2594534: "%35",
+            331460: "%65",
+        }
+        self.assertEqual(
+            find_ancestor_pane(3000000, pane_pids, stat_reader=make_stat_reader(table)),
+            "%35",
+        )
+
+    def test_caller_is_the_shell_itself(self):
+        # Edge case: the caller's own pid IS a pane shell (e.g., running
+        # from the interactive shell directly). Include-self is the
+        # documented behavior.
+        table = {99: ("zsh", 1)}
+        self.assertEqual(
+            find_ancestor_pane(99, {99: "%7"}, stat_reader=make_stat_reader(table)),
+            "%7",
+        )
+
+    def test_no_ancestor_in_tmux(self):
+        # Process chain walks up to init but never passes through a tmux
+        # pane shell. Returns None so the caller falls back gracefully.
+        table = {
+            100: ("python3", 50),
+            50: ("bash", 1),
+        }
+        pane_pids = {999: "%1", 888: "%2"}
+        self.assertIsNone(
+            find_ancestor_pane(100, pane_pids, stat_reader=make_stat_reader(table))
+        )
+
+    def test_empty_pane_map_returns_none(self):
+        # tmux not running, or list-panes failed.
+        table = {100: ("bash", 1)}
+        self.assertIsNone(
+            find_ancestor_pane(100, {}, stat_reader=make_stat_reader(table))
+        )
+
+    def test_nearest_pane_wins_on_nested_tmux(self):
+        # Nested tmux: outer pane shell at pid 10, inner tmux server spawns
+        # inner pane shell at pid 20 which is a child (eventually) of 10.
+        # The caller at pid 100 is inside the inner pane — should resolve
+        # to the inner pane, not the outer one.
+        table = {
+            100: ("python3", 20),
+            20: ("bash", 15),
+            15: ("tmux", 10),
+            10: ("bash", 1),
+        }
+        pane_pids = {20: "%inner", 10: "%outer"}
+        self.assertEqual(
+            find_ancestor_pane(100, pane_pids, stat_reader=make_stat_reader(table)),
+            "%inner",
+        )
+
+    def test_process_vanished_mid_walk(self):
+        # A parent exited between `list_tmux_pane_pids()` and our stat read.
+        # Return None rather than crash.
+        table = {
+            200: ("bash", 150),
+            # 150 missing — race
+        }
+        self.assertIsNone(
+            find_ancestor_pane(200, {99: "%1"}, stat_reader=make_stat_reader(table))
+        )
+
+    def test_loop_guard(self):
+        # Impossible in practice but guard against pid-reuse cycles.
+        table = {
+            10: ("a", 20),
+            20: ("b", 10),
+        }
+        self.assertIsNone(
+            find_ancestor_pane(10, {999: "%1"}, stat_reader=make_stat_reader(table))
+        )
+
+    def test_stops_at_init(self):
+        # Walking up hits init (pid 1) without finding a pane — None.
+        table = {
+            100: ("bash", 1),
+        }
+        self.assertIsNone(
+            find_ancestor_pane(100, {999: "%1"}, stat_reader=make_stat_reader(table))
+        )
+
+    def test_max_depth_terminates(self):
+        # Pathologically deep chain (should still terminate and return None).
+        table = {i: ("proc", i - 1) for i in range(2, 200)}
+        # No entry matches any pane pid.
+        self.assertIsNone(
+            find_ancestor_pane(
+                199, {9999: "%1"}, stat_reader=make_stat_reader(table), max_depth=50
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/harden-telegram/tools/watchdog.py
+++ b/skills/harden-telegram/tools/watchdog.py
@@ -22,6 +22,7 @@ import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 PID_FILE = os.path.join(
     os.environ.get("HOME", "/tmp"), ".claude", "channels", "telegram", "watchdog.pid"
@@ -49,6 +50,115 @@ def is_pid_alive(pid: int) -> bool:
         return True
     except OSError:
         return False
+
+
+def parse_proc_stat(data: str) -> tuple[str, int] | None:
+    """Parse /proc/<pid>/stat contents into (comm, ppid).
+
+    The comm field is wrapped in parens and can contain spaces or parens
+    itself, so we anchor on the *last* ')' rather than splitting whitespace
+    naively. Returns None on any malformed input.
+    """
+    rparen = data.rfind(")")
+    lparen = data.find("(")
+    if rparen == -1 or lparen == -1 or rparen < lparen:
+        return None
+    tail = data[rparen + 1 :].split()
+    # tail[0] is state, tail[1] is ppid
+    if len(tail) < 2:
+        return None
+    try:
+        ppid = int(tail[1])
+    except ValueError:
+        return None
+    comm = data[lparen + 1 : rparen]
+    return (comm, ppid)
+
+
+def _read_proc_stat(pid: int) -> tuple[str, int] | None:
+    """Return (comm, ppid) for a PID, or None if the process is gone."""
+    try:
+        data = Path(f"/proc/{pid}/stat").read_text()
+    except (OSError, ValueError):
+        return None
+    return parse_proc_stat(data)
+
+
+def find_ancestor_pane(
+    pid: int,
+    pane_pids: dict[int, str],
+    *,
+    stat_reader=_read_proc_stat,
+    max_depth: int = 32,
+) -> str | None:
+    """Walk the ppid chain from `pid` upward looking for an entry in `pane_pids`.
+
+    `pane_pids` maps a tmux pane's shell pid to its pane_id (e.g. %35).
+    Returns the pane_id of the first ancestor whose pid appears in the map,
+    or None if no ancestor in the chain is a known tmux pane shell.
+
+    The walk includes `pid` itself (edge case: the caller *is* the pane's
+    shell). Loop-guarded against pid-reuse cycles. `stat_reader` injected
+    for tests.
+    """
+    if not pane_pids:
+        return None
+    seen: set[int] = set()
+    current = pid
+    for _ in range(max_depth):
+        if current <= 1:
+            return None
+        if current in seen:
+            return None
+        seen.add(current)
+        if current in pane_pids:
+            return pane_pids[current]
+        info = stat_reader(current)
+        if info is None:
+            return None
+        _comm, ppid = info
+        current = ppid
+    return None
+
+
+def list_tmux_pane_pids() -> dict[int, str]:
+    """Return a {pane_pid: pane_id} map from `tmux list-panes -a`.
+
+    Empty dict on any failure (no tmux, server not running, parse error).
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    out: dict[int, str] = {}
+    for line in result.stdout.strip().splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        try:
+            out[int(parts[1])] = parts[0]
+        except ValueError:
+            continue
+    return out
+
+
+def resolve_pane_for_pid(pid: int) -> str | None:
+    """Find the tmux pane whose shell is an ancestor of `pid`.
+
+    This is the correct way to ask "what pane am I running in?" when the
+    tmux-*active* pane (what `tmux display-message -p '#{pane_id}'` returns)
+    may belong to a different session. Walks ppid from `pid` upward, matches
+    against the set of known tmux pane pids, returns the first hit.
+    """
+    pane_pids = list_tmux_pane_pids()
+    return find_ancestor_pane(pid, pane_pids)
 
 
 def write_pid_file() -> None:
@@ -207,8 +317,15 @@ def do_recovery(tmux_pane: str) -> bool:
     return False
 
 
-def detect_tmux_pane() -> str:
-    """Detect the current tmux pane ID."""
+def tmux_active_pane() -> str:
+    """Return the tmux-active pane ID via `display-message`.
+
+    WARNING: this is the pane currently focused in the attached client,
+    NOT necessarily the pane containing the caller. With multiple Claude
+    sessions on one box, the active pane is often the wrong answer. Use
+    `resolve_pane_for_pid(os.getpid())` first and fall back here only if
+    the parent-chain walk cannot resolve a pane.
+    """
     try:
         result = subprocess.run(
             ["tmux", "display-message", "-p", "#{pane_id}"],
@@ -221,6 +338,25 @@ def detect_tmux_pane() -> str:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
     return ""
+
+
+def detect_tmux_pane() -> str:
+    """Detect the tmux pane containing the caller.
+
+    Prefers parent-chain resolution (correct across concurrent Claude
+    sessions) and falls back to the tmux-active pane only if the walk
+    fails. Logs which path was taken so failures surface.
+    """
+    resolved = resolve_pane_for_pid(os.getpid())
+    if resolved:
+        log(f"resolved pane {resolved} from parent chain (pid {os.getpid()})")
+        return resolved
+    fallback = tmux_active_pane()
+    if fallback:
+        log(
+            f"could not resolve pane from parent chain, falling back to tmux active pane {fallback}"
+        )
+    return fallback
 
 
 def find_claude_pid() -> int | None:
@@ -373,51 +509,14 @@ def _parse_cli():
 
 
 def pane_from_pid(pid: int) -> str | None:
-    """Find the tmux pane containing a given PID by walking pane PIDs."""
-    try:
-        result = subprocess.run(
-            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            return None
-        for line in result.stdout.strip().splitlines():
-            parts = line.split()
-            if len(parts) == 2:
-                pane_id, pane_pid = parts
-                # Check if target PID is a descendant of this pane's shell
-                try:
-                    children = subprocess.run(
-                        ["pgrep", "-P", pane_pid, "--ns", pane_pid],
-                        capture_output=True,
-                        text=True,
-                        timeout=5,
-                    )
-                    # Check pane_pid itself and all descendants
-                    if str(pid) == pane_pid:
-                        return pane_id
-                    if children.returncode == 0 and str(pid) in children.stdout:
-                        return pane_id
-                except (subprocess.TimeoutExpired, FileNotFoundError):
-                    pass
-                # Simpler fallback: check /proc/<pid>/stat for ppid chain
-                try:
-                    check_pid = pid
-                    for _ in range(10):  # walk up max 10 levels
-                        with open(f"/proc/{check_pid}/stat") as f:
-                            ppid = int(f.read().split()[3])
-                        if str(ppid) == pane_pid:
-                            return pane_id
-                        if ppid <= 1:
-                            break
-                        check_pid = ppid
-                except (FileNotFoundError, ValueError, IndexError):
-                    pass
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
-    return None
+    """Find the tmux pane containing a given PID.
+
+    Walks the ppid chain from `pid` upward and matches each ancestor against
+    the set of known tmux pane shell pids. Returns the matching pane_id, or
+    None if no ancestor is a tmux pane shell (e.g., caller isn't running in
+    tmux, or target pid is detached).
+    """
+    return resolve_pane_for_pid(pid)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

- Watchdog's `reload` subcommand now resolves the target pane by walking parent PIDs up to find a match in `tmux list-panes`, instead of querying the tmux-active pane.
- `--pane` flag still overrides.
- Graceful fallback + logging when the parent chain can't resolve.
- Factored the walk into a pure `find_ancestor_pane` helper (injected `stat_reader`); `pane_from_pid` now delegates to the shared resolver.
- Added `test_watchdog.py` with 15 tests covering the Larry scenario, self-is-shell edge case, nested tmux, vanished parent, loop guard, and `parse_proc_stat`.

## Motivation

On 2026-04-14, Igor had two Claude sessions running — Larry (pane %35, pts/7) and an unrelated blog session (pane %65, pts/4). The watchdog fired from Larry's session (where it was actually needed) but `tmux display-message` returned %65 because that was the focused pane. Every recovery attempt reloaded the wrong session's plugins. Larry's bun stayed dead for over an hour.

Parent-chain resolution is deterministic: the watchdog script's own process is always a descendant of the pane's shell, regardless of which pane is "active" in tmux. Walk `os.getpid()` → `ppid` → `ppid` … until a pid appears in `tmux list-panes -a -F '#{pane_pid}'`.

## Test plan

- [x] Unit tests mock tmux output + parent chain, verify correct pane_id (Larry scenario among 15 tests — all pass)
- [x] `--pane` override still works (precedence preserved in `main()`)
- [x] Falls back to `tmux_active_pane()` with warning outside tmux
- [x] `--help` still parses cleanly
- [x] Pre-commit hooks pass (ruff lint + format + fast tests)
- [x] Existing `test_telegram_debug.py` still passes (30/30)

## Files

- `skills/harden-telegram/tools/watchdog.py` — new `parse_proc_stat`, `_read_proc_stat`, `find_ancestor_pane`, `list_tmux_pane_pids`, `resolve_pane_for_pid`, `tmux_active_pane` helpers; `detect_tmux_pane` rewired to prefer parent-chain; `pane_from_pid` simplified to delegate
- `skills/harden-telegram/tools/test_watchdog.py` — new, 15 unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)