### PR TITLE
harden-telegram: 2026-04-14 Telegram-meltdown debugging fixes (consolidated)

### DIFF
--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -107,6 +107,36 @@ Use it when:
 
 The watchdog cron scheduled by `/startup-larry` step 3 item 4 uses this exclusively — that's the design principle: **the thing watching Telegram must not depend on Telegram's MCP bridge.**
 
+### Recovery Protocol (interactive session)
+
+When an interactive Claude session detects the Telegram MCP has died — `mcp__plugin_telegram_telegram__*` tools vanish from the available tool list, or a `reply` call fails, or the doctor shows red — **follow this order. Do not skip the first direct-send.**
+
+1. **Ping Igor's phone FIRST via `--direct-send`, before diagnosing.** One second of cost, guarantees Igor knows something is happening even if he's on Telegram-only and not watching the terminal:
+   ```bash
+   python3 ~/.claude/skills/harden-telegram/tools/telegram_debug.py \
+     --direct-send "⚠️ Larry: Telegram MCP down. Starting recovery."
+   ```
+
+2. **Diagnose.** Run `telegram_debug.py --doctor` (or `--doctor --json` if parsing). Identify the specific failure mode.
+
+3. **Walk Tier 2 recovery.** Kill stale process if needed, restart, fire `/reload-plugins` (via the background watchdog pattern — never foreground).
+
+4. **Ping again on outcome** — same direct-send path:
+   - Success: `--direct-send "✅ Recovered — <what was fixed>"`
+   - Failure: `--direct-send "❌ Still broken — <details>"` AND append a timestamped line to `/tmp/larry_telegram_recovery.log`
+
+5. **Verify via an untagged MCP reply.** After MCP comes back, send a normal `reply` tool call to confirm the bridge is live. The **absence** of the `[direct-send]` prefix on the next message Igor sees proves MCP is back — that's the semantic signal.
+
+**Why the first direct-send is mandatory.** Silent recovery looks identical to "Claude crashed" from Igor's perspective. A 1-second notification is cheap insurance against a 30-minute silence. This is the same principle as the hourly watchdog cron documented above: **the thing watching Telegram must not depend on Telegram's MCP bridge.** The cron already follows this principle; the interactive recovery path must too.
+
+**What counts as "detecting MCP is down".** Any of:
+- System-reminder arrives saying `plugin:telegram:telegram` has disconnected
+- `mcp__plugin_telegram_telegram__reply` or related tools are no longer in the tool list
+- A reply-tool call returns a "tool not available" or transport error
+- `telegram_debug.py --doctor` shows any red section
+
+Any one of these triggers the protocol. Do not wait for confirmation across multiple signals — ping first, confirm after.
+
 ---
 
 ## Tier 2: Reload (`/harden-telegram reload`)

--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -176,8 +176,13 @@ kill -TERM <pid-from-doctor>
 ### 2c. Watchdog reload (from a background shell — NEVER foreground)
 
 ```bash
-# %25 → your pane id (tmux display-message -p '#{pane_id}')
-python3 ~/.claude/skills/harden-telegram/tools/watchdog.py reload --pane %25 \
+# Omit --pane to auto-resolve the caller's pane via parent-chain walk.
+# NEVER pass `tmux display-message -p '#{pane_id}'` here — from a
+# backgrounded, disowned subprocess with a stale TMUX_PANE env var,
+# unscoped display-message falls back to the session's most-recently-active
+# pane, which on a box with concurrent Claude sessions is routinely wrong.
+# Let watchdog.py walk /proc/<pid>/stat ppid chain itself.
+python3 ~/.claude/skills/harden-telegram/tools/watchdog.py reload \
   2>/tmp/watchdog_reload.log &
 disown
 ```

--- a/skills/harden-telegram/tools/test_watchdog.py
+++ b/skills/harden-telegram/tools/test_watchdog.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Unit tests for watchdog.py pure helpers.
+
+Focus: the pane-resolution logic that walks the parent-process chain to find
+the tmux pane containing the caller. The real bug (fixed 2026-04-14) was that
+`reload` used `tmux display-message -p '#{pane_id}'` which returns the
+tmux-*active* pane, not the pane containing the caller — so with multiple
+concurrent Claude sessions the watchdog fired /reload-plugins into whichever
+session happened to be focused. Parent-chain walk is deterministic.
+
+Run with: python3 -m unittest test_watchdog.py
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from watchdog import (  # noqa: E402
+    find_ancestor_pane,
+    parse_proc_stat,
+)
+
+
+def make_stat_reader(table: dict[int, tuple[str, int]]):
+    """Build a fake stat reader from a {pid: (comm, ppid)} table."""
+
+    def reader(pid: int):
+        return table.get(pid)
+
+    return reader
+
+
+class TestParseProcStat(unittest.TestCase):
+    def test_simple_comm(self):
+        self.assertEqual(
+            parse_proc_stat("123 (bash) S 99 123 99 ...\n"),
+            ("bash", 99),
+        )
+
+    def test_comm_with_space(self):
+        self.assertEqual(
+            parse_proc_stat("123 (my proc) S 99 123 99 ...\n"),
+            ("my proc", 99),
+        )
+
+    def test_comm_with_inner_parens(self):
+        # Anchor on rfind(')') so names like "(weird)" don't truncate.
+        self.assertEqual(
+            parse_proc_stat("123 (weird )name) S 99 123 99 ...\n"),
+            ("weird )name", 99),
+        )
+
+    def test_missing_parens_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 bad line\n"))
+
+    def test_truncated_after_comm_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 (bash)"))
+
+    def test_non_numeric_ppid_returns_none(self):
+        self.assertIsNone(parse_proc_stat("123 (bash) S ??? 123 99 ...\n"))
+
+
+class TestFindAncestorPane(unittest.TestCase):
+    """The core fix. Each test mirrors a real scenario from the 2026-04-14 bug."""
+
+    def test_larry_scenario_finds_correct_pane(self):
+        # Real scenario: watchdog spawned inside Larry's Claude session at
+        # pane %35 (shell pid 2594534, pts/7). Another Claude at pane %65
+        # (shell pid 331460, pts/4) is also running on the same box. The
+        # watchdog's pid is 3000000, parent is bash 2800000, whose parent is
+        # the bun server 2700000, whose parent is Claude 2594600, whose
+        # parent is the pane-35 shell 2594534. Parent-chain walk should
+        # land on %35, NOT %65.
+        table = {
+            3000000: ("python3", 2800000),
+            2800000: ("bash", 2700000),
+            2700000: ("bun", 2594600),
+            2594600: ("claude", 2594534),
+            2594534: ("zsh", 1),
+            # Unrelated Claude session tree — must NOT match.
+            331460: ("zsh", 1),
+        }
+        pane_pids = {
+            2594534: "%35",
+            331460: "%65",
+        }
+        self.assertEqual(
+            find_ancestor_pane(3000000, pane_pids, stat_reader=make_stat_reader(table)),
+            "%35",
+        )
+
+    def test_caller_is_the_shell_itself(self):
+        # Edge case: the caller's own pid IS a pane shell (e.g., running
+        # from the interactive shell directly). Include-self is the
+        # documented behavior.
+        table = {99: ("zsh", 1)}
+        self.assertEqual(
+            find_ancestor_pane(99, {99: "%7"}, stat_reader=make_stat_reader(table)),
+            "%7",
+        )
+
+    def test_no_ancestor_in_tmux(self):
+        # Process chain walks up to init but never passes through a tmux
+        # pane shell. Returns None so the caller falls back gracefully.
+        table = {
+            100: ("python3", 50),
+            50: ("bash", 1),
+        }
+        pane_pids = {999: "%1", 888: "%2"}
+        self.assertIsNone(
+            find_ancestor_pane(100, pane_pids, stat_reader=make_stat_reader(table))
+        )
+
+    def test_empty_pane_map_returns_none(self):
+        # tmux not running, or list-panes failed.
+        table = {100: ("bash", 1)}
+        self.assertIsNone(
+            find_ancestor_pane(100, {}, stat_reader=make_stat_reader(table))
+        )
+
+    def test_nearest_pane_wins_on_nested_tmux(self):
+        # Nested tmux: outer pane shell at pid 10, inner tmux server spawns
+        # inner pane shell at pid 20 which is a child (eventually) of 10.
+        # The caller at pid 100 is inside the inner pane — should resolve
+        # to the inner pane, not the outer one.
+        table = {
+            100: ("python3", 20),
+            20: ("bash", 15),
+            15: ("tmux", 10),
+            10: ("bash", 1),
+        }
+        pane_pids = {20: "%inner", 10: "%outer"}
+        self.assertEqual(
+            find_ancestor_pane(100, pane_pids, stat_reader=make_stat_reader(table)),
+            "%inner",
+        )
+
+    def test_process_vanished_mid_walk(self):
+        # A parent exited between `list_tmux_pane_pids()` and our stat read.
+        # Return None rather than crash.
+        table = {
+            200: ("bash", 150),
+            # 150 missing — race
+        }
+        self.assertIsNone(
+            find_ancestor_pane(200, {99: "%1"}, stat_reader=make_stat_reader(table))
+        )
+
+    def test_loop_guard(self):
+        # Impossible in practice but guard against pid-reuse cycles.
+        table = {
+            10: ("a", 20),
+            20: ("b", 10),
+        }
+        self.assertIsNone(
+            find_ancestor_pane(10, {999: "%1"}, stat_reader=make_stat_reader(table))
+        )
+
+    def test_stops_at_init(self):
+        # Walking up hits init (pid 1) without finding a pane — None.
+        table = {
+            100: ("bash", 1),
+        }
+        self.assertIsNone(
+            find_ancestor_pane(100, {999: "%1"}, stat_reader=make_stat_reader(table))
+        )
+
+    def test_max_depth_terminates(self):
+        # Pathologically deep chain (should still terminate and return None).
+        table = {i: ("proc", i - 1) for i in range(2, 200)}
+        # No entry matches any pane pid.
+        self.assertIsNone(
+            find_ancestor_pane(
+                199, {9999: "%1"}, stat_reader=make_stat_reader(table), max_depth=50
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/harden-telegram/tools/test_watchdog.py
+++ b/skills/harden-telegram/tools/test_watchdog.py
@@ -3,10 +3,12 @@
 
 Focus: the pane-resolution logic that walks the parent-process chain to find
 the tmux pane containing the caller. The real bug (fixed 2026-04-14) was that
-`reload` used `tmux display-message -p '#{pane_id}'` which returns the
-tmux-*active* pane, not the pane containing the caller — so with multiple
-concurrent Claude sessions the watchdog fired /reload-plugins into whichever
-session happened to be focused. Parent-chain walk is deterministic.
+`reload` used unscoped `tmux display-message -p '#{pane_id}'` from a
+backgrounded, disowned watchdog subprocess — by then `TMUX_PANE` was stale
+and display-message fell back to the session's most-recently-active pane,
+which with multiple concurrent Claude sessions was routinely the wrong one.
+Parent-chain walk via /proc/<pid>/stat derives the answer from the kernel
+process tree, so it's deterministic regardless of env-var hygiene.
 
 Run with: python3 -m unittest test_watchdog.py
 """

--- a/skills/harden-telegram/tools/test_watchdog.py
+++ b/skills/harden-telegram/tools/test_watchdog.py
@@ -13,15 +13,20 @@ process tree, so it's deterministic regardless of env-var hygiene.
 Run with: python3 -m unittest test_watchdog.py
 """
 
+import subprocess
 import sys
 import unittest
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 from watchdog import (  # noqa: E402
+    _FALLBACK,
+    _resolve_pane_via_rmux_helper,
     find_ancestor_pane,
     parse_proc_stat,
+    resolve_pane_for_pid,
 )
 
 
@@ -178,6 +183,144 @@ class TestFindAncestorPane(unittest.TestCase):
                 199, {9999: "%1"}, stat_reader=make_stat_reader(table), max_depth=50
             )
         )
+
+
+def _completed_process(returncode: int, stdout: str = "", stderr: str = ""):
+    """Build a fake CompletedProcess for subprocess.run mocks."""
+    return subprocess.CompletedProcess(
+        args=["rmux_helper", "parent-pid-tree", "--pid", "999"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class TestResolvePaneViaRmuxHelper(unittest.TestCase):
+    """Unit tests for the rmux_helper subprocess path.
+
+    The primary path of ``resolve_pane_for_pid`` shells out to
+    ``rmux_helper parent-pid-tree --pid <pid>``. These tests mock
+    ``subprocess.run`` to cover each exit-code branch so we don't
+    depend on rmux_helper being installed in the test environment.
+    """
+
+    def test_happy_path_returns_pane_id(self):
+        with mock.patch(
+            "watchdog.subprocess.run",
+            return_value=_completed_process(0, stdout="%35\n"),
+        ):
+            self.assertEqual(_resolve_pane_via_rmux_helper(999), "%35")
+
+    def test_exit_1_returns_none_not_sentinel(self):
+        # Exit 1 is a definitive "no pane in ancestor chain" — caller
+        # must NOT fall back, the answer is None.
+        with mock.patch(
+            "watchdog.subprocess.run",
+            return_value=_completed_process(
+                1, stderr="no tmux pane found for pid 999\n"
+            ),
+        ):
+            self.assertIsNone(_resolve_pane_via_rmux_helper(999))
+
+    def test_file_not_found_returns_fallback(self):
+        # rmux_helper not on PATH → fall back to Python walker.
+        with mock.patch(
+            "watchdog.subprocess.run",
+            side_effect=FileNotFoundError("rmux_helper"),
+        ):
+            self.assertIs(_resolve_pane_via_rmux_helper(999), _FALLBACK)
+
+    def test_timeout_returns_fallback(self):
+        # rmux_helper hangs → fall back to Python walker.
+        with mock.patch(
+            "watchdog.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="rmux_helper", timeout=2.0),
+        ):
+            self.assertIs(_resolve_pane_via_rmux_helper(999), _FALLBACK)
+
+    def test_exit_2_returns_fallback(self):
+        # Exit 2 = tmux not running. Fall back — rmux_helper's tmux
+        # detection may be wrong on this box.
+        with mock.patch(
+            "watchdog.subprocess.run",
+            return_value=_completed_process(2, stderr="tmux not running\n"),
+        ):
+            self.assertIs(_resolve_pane_via_rmux_helper(999), _FALLBACK)
+
+    def test_exit_3_returns_fallback(self):
+        # Exit 3 = /proc unreadable. Fall back.
+        with mock.patch(
+            "watchdog.subprocess.run",
+            return_value=_completed_process(3, stderr="/proc unreadable\n"),
+        ):
+            self.assertIs(_resolve_pane_via_rmux_helper(999), _FALLBACK)
+
+    def test_empty_stdout_on_exit_0_returns_fallback(self):
+        # Exit 0 with empty stdout is malformed — fall back defensively.
+        with mock.patch(
+            "watchdog.subprocess.run",
+            return_value=_completed_process(0, stdout="\n"),
+        ):
+            self.assertIs(_resolve_pane_via_rmux_helper(999), _FALLBACK)
+
+
+class TestResolvePaneForPid(unittest.TestCase):
+    """Integration tests for the two-tier resolver.
+
+    ``resolve_pane_for_pid`` tries ``rmux_helper`` first and only falls
+    back to the Python walker on sentinel responses. These tests verify
+    the dispatch logic between the two paths.
+    """
+
+    def test_falls_back_to_python_walker_when_rmux_helper_missing(self):
+        with (
+            mock.patch(
+                "watchdog.subprocess.run",
+                side_effect=FileNotFoundError("rmux_helper"),
+            ),
+            mock.patch(
+                "watchdog._resolve_pane_via_python_walker",
+                return_value="%99",
+            ) as mock_walker,
+        ):
+            self.assertEqual(resolve_pane_for_pid(999), "%99")
+            mock_walker.assert_called_once_with(999)
+
+    def test_primary_path_wins_python_walker_not_called(self):
+        # When rmux_helper succeeds, the Python walker must never run.
+        # Mock it to raise so the test fails loudly if the fallback is
+        # invoked by mistake.
+        with (
+            mock.patch(
+                "watchdog.subprocess.run",
+                return_value=_completed_process(0, stdout="%35\n"),
+            ),
+            mock.patch(
+                "watchdog._resolve_pane_via_python_walker",
+                side_effect=AssertionError(
+                    "fallback must not be called on primary success"
+                ),
+            ) as mock_walker,
+        ):
+            self.assertEqual(resolve_pane_for_pid(999), "%35")
+            mock_walker.assert_not_called()
+
+    def test_exit_1_does_not_fall_back(self):
+        # Exit 1 from rmux_helper is a definitive "no match". The Python
+        # walker must NOT be called — if it were, the two implementations
+        # could disagree on the same process tree.
+        with (
+            mock.patch(
+                "watchdog.subprocess.run",
+                return_value=_completed_process(1),
+            ),
+            mock.patch(
+                "watchdog._resolve_pane_via_python_walker",
+                return_value="%99",
+            ) as mock_walker,
+        ):
+            self.assertIsNone(resolve_pane_for_pid(999))
+            mock_walker.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/skills/harden-telegram/tools/watchdog.py
+++ b/skills/harden-telegram/tools/watchdog.py
@@ -152,10 +152,15 @@ def list_tmux_pane_pids() -> dict[int, str]:
 def resolve_pane_for_pid(pid: int) -> str | None:
     """Find the tmux pane whose shell is an ancestor of `pid`.
 
-    This is the correct way to ask "what pane am I running in?" when the
-    tmux-*active* pane (what `tmux display-message -p '#{pane_id}'` returns)
-    may belong to a different session. Walks ppid from `pid` upward, matches
-    against the set of known tmux pane pids, returns the first hit.
+    This is the correct way to ask "what pane am I running in?" from a
+    backgrounded/disowned subprocess where `TMUX_PANE` may be stale and
+    the unscoped `tmux display-message -p '#{pane_id}'` fallback can
+    land on the wrong pane — specifically, tmux's session-most-recent
+    active pane rather than the caller's own pane. Walks ppid from
+    `pid` upward through `/proc/<pid>/stat` and matches each ancestor
+    against the set of known tmux pane shell pids, returning the first
+    hit. Derives the answer from the kernel process tree so it's
+    resilient to env-var staleness, nested tmux, and pane reparenting.
     """
     pane_pids = list_tmux_pane_pids()
     return find_ancestor_pane(pid, pane_pids)
@@ -318,13 +323,17 @@ def do_recovery(tmux_pane: str) -> bool:
 
 
 def tmux_active_pane() -> str:
-    """Return the tmux-active pane ID via `display-message`.
+    """Fallback: ask tmux for a pane ID via unscoped `display-message`.
 
-    WARNING: this is the pane currently focused in the attached client,
-    NOT necessarily the pane containing the caller. With multiple Claude
-    sessions on one box, the active pane is often the wrong answer. Use
-    `resolve_pane_for_pid(os.getpid())` first and fall back here only if
-    the parent-chain walk cannot resolve a pane.
+    WARNING: this is unreliable from backgrounded/disowned subprocesses.
+    Without `-t "$TMUX_PANE"`, `display-message` uses whatever pane
+    context tmux can infer from the caller — and for a long-lived
+    backgrounded process whose `TMUX_PANE` env has gone stale (or whose
+    parent shell has exited), that falls back to the session's
+    most-recently-active pane, which is often the wrong one on a box
+    with multiple concurrent tmux clients. Use
+    `resolve_pane_for_pid(os.getpid())` first and fall back here only
+    if the parent-chain walk cannot resolve a pane.
     """
     try:
         result = subprocess.run(
@@ -343,9 +352,11 @@ def tmux_active_pane() -> str:
 def detect_tmux_pane() -> str:
     """Detect the tmux pane containing the caller.
 
-    Prefers parent-chain resolution (correct across concurrent Claude
-    sessions) and falls back to the tmux-active pane only if the walk
-    fails. Logs which path was taken so failures surface.
+    Prefers parent-PID chain resolution (derives the answer from the
+    kernel process tree, so it survives backgrounding, disown, and
+    stale `TMUX_PANE`). Falls back to unscoped `display-message` only
+    if the walk can't resolve a pane. Logs which path was taken so
+    failures surface.
     """
     resolved = resolve_pane_for_pid(os.getpid())
     if resolved:

--- a/skills/harden-telegram/tools/watchdog.py
+++ b/skills/harden-telegram/tools/watchdog.py
@@ -22,6 +22,7 @@ import signal
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 PID_FILE = os.path.join(
     os.environ.get("HOME", "/tmp"), ".claude", "channels", "telegram", "watchdog.pid"
@@ -49,6 +50,115 @@ def is_pid_alive(pid: int) -> bool:
         return True
     except OSError:
         return False
+
+
+def parse_proc_stat(data: str) -> tuple[str, int] | None:
+    """Parse /proc/<pid>/stat contents into (comm, ppid).
+
+    The comm field is wrapped in parens and can contain spaces or parens
+    itself, so we anchor on the *last* ')' rather than splitting whitespace
+    naively. Returns None on any malformed input.
+    """
+    rparen = data.rfind(")")
+    lparen = data.find("(")
+    if rparen == -1 or lparen == -1 or rparen < lparen:
+        return None
+    tail = data[rparen + 1 :].split()
+    # tail[0] is state, tail[1] is ppid
+    if len(tail) < 2:
+        return None
+    try:
+        ppid = int(tail[1])
+    except ValueError:
+        return None
+    comm = data[lparen + 1 : rparen]
+    return (comm, ppid)
+
+
+def _read_proc_stat(pid: int) -> tuple[str, int] | None:
+    """Return (comm, ppid) for a PID, or None if the process is gone."""
+    try:
+        data = Path(f"/proc/{pid}/stat").read_text()
+    except (OSError, ValueError):
+        return None
+    return parse_proc_stat(data)
+
+
+def find_ancestor_pane(
+    pid: int,
+    pane_pids: dict[int, str],
+    *,
+    stat_reader=_read_proc_stat,
+    max_depth: int = 32,
+) -> str | None:
+    """Walk the ppid chain from `pid` upward looking for an entry in `pane_pids`.
+
+    `pane_pids` maps a tmux pane's shell pid to its pane_id (e.g. %35).
+    Returns the pane_id of the first ancestor whose pid appears in the map,
+    or None if no ancestor in the chain is a known tmux pane shell.
+
+    The walk includes `pid` itself (edge case: the caller *is* the pane's
+    shell). Loop-guarded against pid-reuse cycles. `stat_reader` injected
+    for tests.
+    """
+    if not pane_pids:
+        return None
+    seen: set[int] = set()
+    current = pid
+    for _ in range(max_depth):
+        if current <= 1:
+            return None
+        if current in seen:
+            return None
+        seen.add(current)
+        if current in pane_pids:
+            return pane_pids[current]
+        info = stat_reader(current)
+        if info is None:
+            return None
+        _comm, ppid = info
+        current = ppid
+    return None
+
+
+def list_tmux_pane_pids() -> dict[int, str]:
+    """Return a {pane_pid: pane_id} map from `tmux list-panes -a`.
+
+    Empty dict on any failure (no tmux, server not running, parse error).
+    """
+    try:
+        result = subprocess.run(
+            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    out: dict[int, str] = {}
+    for line in result.stdout.strip().splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        try:
+            out[int(parts[1])] = parts[0]
+        except ValueError:
+            continue
+    return out
+
+
+def resolve_pane_for_pid(pid: int) -> str | None:
+    """Find the tmux pane whose shell is an ancestor of `pid`.
+
+    This is the correct way to ask "what pane am I running in?" when the
+    tmux-*active* pane (what `tmux display-message -p '#{pane_id}'` returns)
+    may belong to a different session. Walks ppid from `pid` upward, matches
+    against the set of known tmux pane pids, returns the first hit.
+    """
+    pane_pids = list_tmux_pane_pids()
+    return find_ancestor_pane(pid, pane_pids)
 
 
 def write_pid_file() -> None:
@@ -207,8 +317,15 @@ def do_recovery(tmux_pane: str) -> bool:
     return False
 
 
-def detect_tmux_pane() -> str:
-    """Detect the current tmux pane ID."""
+def tmux_active_pane() -> str:
+    """Return the tmux-active pane ID via `display-message`.
+
+    WARNING: this is the pane currently focused in the attached client,
+    NOT necessarily the pane containing the caller. With multiple Claude
+    sessions on one box, the active pane is often the wrong answer. Use
+    `resolve_pane_for_pid(os.getpid())` first and fall back here only if
+    the parent-chain walk cannot resolve a pane.
+    """
     try:
         result = subprocess.run(
             ["tmux", "display-message", "-p", "#{pane_id}"],
@@ -221,6 +338,25 @@ def detect_tmux_pane() -> str:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
     return ""
+
+
+def detect_tmux_pane() -> str:
+    """Detect the tmux pane containing the caller.
+
+    Prefers parent-chain resolution (correct across concurrent Claude
+    sessions) and falls back to the tmux-active pane only if the walk
+    fails. Logs which path was taken so failures surface.
+    """
+    resolved = resolve_pane_for_pid(os.getpid())
+    if resolved:
+        log(f"resolved pane {resolved} from parent chain (pid {os.getpid()})")
+        return resolved
+    fallback = tmux_active_pane()
+    if fallback:
+        log(
+            f"could not resolve pane from parent chain, falling back to tmux active pane {fallback}"
+        )
+    return fallback
 
 
 def find_claude_pid() -> int | None:
@@ -373,51 +509,14 @@ def _parse_cli():
 
 
 def pane_from_pid(pid: int) -> str | None:
-    """Find the tmux pane containing a given PID by walking pane PIDs."""
-    try:
-        result = subprocess.run(
-            ["tmux", "list-panes", "-a", "-F", "#{pane_id} #{pane_pid}"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            return None
-        for line in result.stdout.strip().splitlines():
-            parts = line.split()
-            if len(parts) == 2:
-                pane_id, pane_pid = parts
-                # Check if target PID is a descendant of this pane's shell
-                try:
-                    children = subprocess.run(
-                        ["pgrep", "-P", pane_pid, "--ns", pane_pid],
-                        capture_output=True,
-                        text=True,
-                        timeout=5,
-                    )
-                    # Check pane_pid itself and all descendants
-                    if str(pid) == pane_pid:
-                        return pane_id
-                    if children.returncode == 0 and str(pid) in children.stdout:
-                        return pane_id
-                except (subprocess.TimeoutExpired, FileNotFoundError):
-                    pass
-                # Simpler fallback: check /proc/<pid>/stat for ppid chain
-                try:
-                    check_pid = pid
-                    for _ in range(10):  # walk up max 10 levels
-                        with open(f"/proc/{check_pid}/stat") as f:
-                            ppid = int(f.read().split()[3])
-                        if str(ppid) == pane_pid:
-                            return pane_id
-                        if ppid <= 1:
-                            break
-                        check_pid = ppid
-                except (FileNotFoundError, ValueError, IndexError):
-                    pass
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
-    return None
+    """Find the tmux pane containing a given PID.
+
+    Walks the ppid chain from `pid` upward and matches each ancestor against
+    the set of known tmux pane shell pids. Returns the matching pane_id, or
+    None if no ancestor is a tmux pane shell (e.g., caller isn't running in
+    tmux, or target pid is detached).
+    """
+    return resolve_pane_for_pid(pid)
 
 
 def main() -> None:

--- a/skills/harden-telegram/tools/watchdog.py
+++ b/skills/harden-telegram/tools/watchdog.py
@@ -34,8 +34,15 @@ NEW_BUN_TIMEOUT = 60  # seconds to wait for new bun to appear
 # Sentinel returned by _resolve_pane_via_rmux_helper when the caller should
 # fall back to the Python walker. Distinct from None (which is a *definitive*
 # no-match from rmux_helper exit 1) so we can tell "unavailable" apart from
-# "answer is: no pane".
-_FALLBACK = object()
+# "answer is: no pane". Defined as a class-based singleton so Pyright can
+# narrow the union type (`str | _FallbackSentinel | None`) via `isinstance`.
+class _FallbackSentinel:
+    """Singleton marker for 'rmux_helper path unavailable — use the Python walker'."""
+
+    __slots__ = ()
+
+
+_FALLBACK = _FallbackSentinel()
 
 # Timeout for the rmux_helper subprocess. The binary is fast (µs-level walks),
 # so 2s is a generous ceiling that still protects us against a hung process.
@@ -159,7 +166,7 @@ def list_tmux_pane_pids() -> dict[int, str]:
     return out
 
 
-def _resolve_pane_via_rmux_helper(pid: int):
+def _resolve_pane_via_rmux_helper(pid: int) -> "str | None | _FallbackSentinel":
     """Try to resolve the pane by shelling out to ``rmux_helper parent-pid-tree``.
 
     Returns:
@@ -256,11 +263,12 @@ def resolve_pane_for_pid(pid: int) -> str | None:
     is wrong.
     """
     result = _resolve_pane_via_rmux_helper(pid)
-    if result is _FALLBACK:
+    if isinstance(result, _FallbackSentinel):
         return _resolve_pane_via_python_walker(pid)
-    if isinstance(result, str):
+    # result is now narrowed to str | None
+    if result is not None:
         log(f"rmux_helper resolved pane {result} for pid {pid}")
-    return result  # str (match) or None (definitive no-match)
+    return result
 
 
 def write_pid_file() -> None:

--- a/skills/harden-telegram/tools/watchdog.py
+++ b/skills/harden-telegram/tools/watchdog.py
@@ -31,6 +31,16 @@ POLL_INTERVAL = 5  # seconds between liveness checks
 SETTLE_DELAY = 2  # seconds to wait after bun death before recovery
 NEW_BUN_TIMEOUT = 60  # seconds to wait for new bun to appear
 
+# Sentinel returned by _resolve_pane_via_rmux_helper when the caller should
+# fall back to the Python walker. Distinct from None (which is a *definitive*
+# no-match from rmux_helper exit 1) so we can tell "unavailable" apart from
+# "answer is: no pane".
+_FALLBACK = object()
+
+# Timeout for the rmux_helper subprocess. The binary is fast (µs-level walks),
+# so 2s is a generous ceiling that still protects us against a hung process.
+_RMUX_HELPER_TIMEOUT = 2.0
+
 
 def log(msg: str) -> None:
     """Log to stderr with timestamp and PID."""
@@ -149,6 +159,77 @@ def list_tmux_pane_pids() -> dict[int, str]:
     return out
 
 
+def _resolve_pane_via_rmux_helper(pid: int):
+    """Try to resolve the pane by shelling out to ``rmux_helper parent-pid-tree``.
+
+    Returns:
+        str: the pane id (e.g. ``"%35"``) if rmux_helper found a match.
+        None: if rmux_helper definitively said "no match" (exit 1) — caller
+              must NOT fall back, this is a real answer.
+        _FALLBACK: sentinel meaning "try the Python fallback" (rmux_helper
+                   unavailable, timed out, or returned an unexpected code).
+
+    Exit-code semantics from the Rust ``rmux_helper parent-pid-tree``:
+      0 — match found, pane id on stdout
+      1 — no match (definitive; don't fall back)
+      2 — tmux not running → fall back
+      3 — /proc unreadable → fall back
+    """
+    try:
+        result = subprocess.run(
+            ["rmux_helper", "parent-pid-tree", "--pid", str(pid)],
+            capture_output=True,
+            text=True,
+            timeout=_RMUX_HELPER_TIMEOUT,
+        )
+    except FileNotFoundError:
+        log("rmux_helper unavailable — falling back to Python walker")
+        return _FALLBACK
+    except subprocess.TimeoutExpired:
+        log("rmux_helper timed out — falling back to Python walker")
+        return _FALLBACK
+
+    if result.returncode == 0:
+        pane = result.stdout.strip()
+        if not pane:
+            # Exit 0 with empty stdout is weird — treat defensively.
+            log(
+                "rmux_helper returned exit 0 with empty stdout — falling back to Python walker"
+            )
+            return _FALLBACK
+        return pane
+    if result.returncode == 1:
+        # Definitive "no pane in ancestor chain". Don't fall back — the
+        # Python walker is looking at the same process tree and would give
+        # the same answer.
+        return None
+
+    # Exit 2 (tmux not running) or 3 (/proc unreadable) — these could be
+    # transient quirks of the rmux_helper build on this box. Fall back to
+    # the Python walker as a safety net.
+    log(
+        f"rmux_helper returned exit {result.returncode} — falling back to Python walker"
+    )
+    return _FALLBACK
+
+
+def _resolve_pane_via_python_walker(pid: int) -> str | None:
+    """Find the tmux pane whose shell is an ancestor of `pid` (Python impl).
+
+    This is the fallback path for ``resolve_pane_for_pid``. It derives the
+    answer from the kernel process tree by walking ppid from `pid` upward
+    through ``/proc/<pid>/stat`` and matching each ancestor against the
+    set of known tmux pane shell pids. Resilient to env-var staleness,
+    nested tmux, and pane reparenting.
+
+    Kept as a safety net even though ``rmux_helper parent-pid-tree``
+    reimplements the same algorithm in Rust — the Python walker runs
+    without external dependencies and has its own test coverage.
+    """
+    pane_pids = list_tmux_pane_pids()
+    return find_ancestor_pane(pid, pane_pids)
+
+
 def resolve_pane_for_pid(pid: int) -> str | None:
     """Find the tmux pane whose shell is an ancestor of `pid`.
 
@@ -156,14 +237,30 @@ def resolve_pane_for_pid(pid: int) -> str | None:
     backgrounded/disowned subprocess where `TMUX_PANE` may be stale and
     the unscoped `tmux display-message -p '#{pane_id}'` fallback can
     land on the wrong pane — specifically, tmux's session-most-recent
-    active pane rather than the caller's own pane. Walks ppid from
-    `pid` upward through `/proc/<pid>/stat` and matches each ancestor
-    against the set of known tmux pane shell pids, returning the first
-    hit. Derives the answer from the kernel process tree so it's
-    resilient to env-var staleness, nested tmux, and pane reparenting.
+    active pane rather than the caller's own pane.
+
+    Primary path: shells out to ``rmux_helper parent-pid-tree --pid <pid>``
+    (the Rust implementation from idvorkin/Settings PR #76). This matches
+    the repo convention added in d8431ad to prefer rmux_helper for
+    tmux/proc primitives instead of re-implementing them inline.
+
+    Fallback path: the existing Python parent-chain walker
+    (``_resolve_pane_via_python_walker``). Invoked only if rmux_helper is
+    missing from PATH, times out, or returns an unexpected exit code.
+    rmux_helper exit 1 (definitive "no pane in ancestor chain") is NOT
+    treated as a fall-back trigger — the two implementations walk the
+    same ``/proc`` tree and would give the same answer.
+
+    See ``skills/harden-telegram/SKILL.md`` and the 2026-04-14 Telegram
+    meltdown debug session for why ``tmux display-message -p '#{pane_id}'``
+    is wrong.
     """
-    pane_pids = list_tmux_pane_pids()
-    return find_ancestor_pane(pid, pane_pids)
+    result = _resolve_pane_via_rmux_helper(pid)
+    if result is _FALLBACK:
+        return _resolve_pane_via_python_walker(pid)
+    if isinstance(result, str):
+        log(f"rmux_helper resolved pane {result} for pid {pid}")
+    return result  # str (match) or None (definitive no-match)
 
 
 def write_pid_file() -> None:


### PR DESCRIPTION
## Summary

Consolidation of four related fixes from the 2026-04-14 Telegram-meltdown debug session (~2h of silent MCP failure caused by a plugin auto-update + stale running telegram_bot.py + wrong-pane watchdog reloads). Supersedes #99, #100, #101, and #102 — same commits, one PR for easier review.

## Commits

1. **Recovery Protocol for interactive sessions** (was #99) — adds a prescriptive 5-step order to the harden-telegram SKILL.md: ping via `--direct-send` FIRST, then diagnose, walk Tier 2, ping outcome, verify via untagged MCP reply. The hourly watchdog cron already follows this pattern; this makes the interactive-session path match.
2. **Doctor auto-runs drift check by default** (was #100) — removes the `TELEGRAM_SOURCE_DIR` env-var gate on the plugin-cache drift check. Falls back to a hardcoded `~/gits/igor2/telegram-server` path, flags drift as red so the doctor exits non-zero, includes a structured `deploy` block in `--json` mode. Would have caught today's 0.0.5 → 0.0.6 auto-update in seconds.
3. **Watchdog resolves pane via parent chain** (was #101) — replaces unscoped `tmux display-message -p '#{pane_id}'` (which, from a backgrounded / disowned subprocess with stale `TMUX_PANE`, falls back to the session's most-recently-active pane rather than the caller's pane) with a parent-PID walk. Fixes the wrong-pane reload bug that cost ~45 minutes of debugging today when two Claude sessions were running concurrently.
4. **CLAUDE.md: point at `rmux_helper` for tmux/proc primitives** (was #102) — adds a repo-root convention that future tmux/proc/system primitives should be encapsulated in `rmux_helper` subcommands (new `parent-pid-tree` command landing in a companion PR on `idvorkin/settings`) rather than re-implemented inline.

## Why one PR instead of four

All four commits were authored in one debug session, target the same skill area (except #102 which is a short convention note), and review together more naturally than separately. The original four PRs were atomic by design but Igor asked for consolidation after reviewing them.

## Review fixes (self-review pass)

Two review-fix commits on top of the four cherry-picks. Neither rewrites the atomic commits — they're additions.

- **`review: update SKILL.md to reflect default-on drift check + parent-chain pane`** — cherry-pick #100 made the drift check default-on, but four narrative references in SKILL.md still described `TELEGRAM_SOURCE_DIR` as a required toggle. Fixed the tool-locations table, env-var description, Tier 2a deploy section, and Tier 3 "Plugin auto-update" failure-mode entry. Tier 2c's `watchdog.py reload` example also told the reader to grab a pane id with `tmux display-message -p '#{pane_id}'` — the exact anti-pattern #101 was replacing. Replaced with an omit-the-flag example (watchdog.py auto-resolves via the new parent-chain walk).
- **`review: tighten display-message technical claim in pane-resolution docs`** — CodeRabbit flagged the stated rationale in CLAUDE.md, `watchdog.py`, and `test_watchdog.py` for preferring parent-PID walk over `tmux display-message`. The original claim oversimplified: plain `display-message` does use the caller's pane context when tmux can infer it. The real 2026-04-14 failure was subtler — from a backgrounded, disowned Python subprocess whose `TMUX_PANE` had gone stale, unscoped `display-message` falls back to the session's most-recently-active pane, which on a box with multiple concurrent Claude sessions is routinely wrong. Parent-PID walk is still the right primitive because it derives the answer from the kernel process tree and survives env-var staleness / reparenting; the docs now explain *that* rather than the oversimplified version. No logic changes.

## Follow-up commit (post-review)

- `473ea7d` — **watchdog calls `rmux_helper parent-pid-tree` with Python fallback** (Option B migration). Applies the repo-level "use rmux_helper for tmux/proc primitives" convention (added in d8431ad) to the watchdog itself. `resolve_pane_for_pid` now shells out to `rmux_helper parent-pid-tree --pid <pid>` as the primary path and falls back to the existing Python walker if rmux_helper is missing from PATH, times out, or returns an unexpected exit code. Exit 1 from rmux_helper (definitive "no pane in ancestor chain") is NOT treated as a fall-back trigger — the two implementations walk the same `/proc` tree and would give the same answer. Added 10 new tests for the rmux_helper subprocess path. The Python walker (`_resolve_pane_via_python_walker`, renamed from the previous top-level) keeps all its existing test coverage as the fallback. Depends on `idvorkin/Settings#76` for the rmux_helper binary at runtime, but gracefully falls back if unavailable — so this commit is safe to merge even before the settings PR lands.

## Test plan

- [x] All existing tests pass after cherry-pick (85 harden-telegram tests, full `just fast-test` suite)
- [x] New tests from #100 (`TestResolveSourceDir`, `TestDoctorCheckDeploy`, `TestCheckPluginDeployJson`) and #101 (`TestParseProcStat`, `TestFindAncestorPane`) still cover their original cases
- [x] 10 new tests added in `473ea7d` for the rmux_helper subprocess path (`TestResolvePaneViaRmuxHelper` + `TestResolvePaneForPid`) — 95 harden-telegram tests total, all pass
- [x] No regression in `telegram_debug.py --doctor` on Igor's live box — DEPLOY section now reports `plugin cache matches source (sha256: ...) — source=... [default]`, proving default-path resolution works
- [x] `ruff check` / `ruff format --check` clean on all touched Python files
- [x] Commit history is clean (4 atomic cherry-picks + 2 review-fix commits + 1 follow-up, no merge noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
