### PR TITLE
claude-md: migrate flat ~/.claude/CLAUDE.md into shared fragments + fix test pollution

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -9,6 +9,24 @@ This file is loaded into each machine's `~/.claude/CLAUDE.md` via an
 managed by `/up-to-date`. Editing this file in `chop-conventions` propagates
 to every opted-in machine automatically.
 
-<!-- Content migration from the current flat `~/.claude/CLAUDE.md` is
-     tracked as a follow-up; this file starts as a stub and grows as
-     rules are categorized. -->
+## Side-Edit: Preview Files in a Side Pane
+
+Use `rmux_helper side-edit <FILE>` to open a file in a side nvim pane within tmux. This reuses the same pane across calls, so repeated edits don't spawn new splits. Supports `file:line` syntax (e.g. `foo.py:42`).
+
+Use `rmux_helper side-run <CMD>` to run a shell command in the side pane. If nvim is running, use `--force` to kill it first.
+
+Both commands print pane status (pane_id, nvim running, current file) to stdout. Call with no args for status only.
+
+```bash
+rmux_helper side-edit ~/blog/_d/ai-journal.md:42
+rmux_helper side-run "make test"
+rmux_helper side-edit   # status only
+```
+
+## Editing Skills: Symlink Trap
+
+**Files under `~/.claude/skills/` are often symlinks into git working trees.** Run `realpath <path>` before editing any skill file. If it resolves into a working tree (e.g. `~/gits/chop-conventions/skills/...`), **create a worktree off that repo's `upstream/main` and edit there** — editing through the symlink mutates whichever branch is currently checked out in the primary checkout, silently mixing skill edits with unrelated in-flight work.
+
+## Cross-Skill Conventions Live in chop-conventions
+
+General rules for **authoring/editing skills** (Python defaults, diagnostics as code, abstraction thresholds, fork workflow, pre-commit hook behavior, skill install patterns) live in [`~/gits/chop-conventions/CLAUDE.md`](../gits/chop-conventions/CLAUDE.md). When editing any skill in any repo, read that file first — its rules apply universally, not just to chop-conventions-resident skills.

--- a/claude-md/machines/orbstack-dev.md
+++ b/claude-md/machines/orbstack-dev.md
@@ -8,8 +8,6 @@ Ubuntu with systemd).
 Loaded via `@~/.claude/claude-md/machine.md`, where the symlink points at
 this file when `classify_machine` returns `"orbstack-dev"`.
 
-<!-- Content migration from the current flat `~/.claude/CLAUDE.md` is
-     tracked as a follow-up; this file starts as a stub. Typical
-     content: `ls → eza, du → dua, ps → procs` (flags differ from
-     coreutils; use `\ls`/`\du`/`\ps` to bypass the alias), and the
-     side-edit / side-run workflow via `rmux_helper`. -->
+## Shell aliases
+
+- `ps` is aliased to a **pager wrapper** in this shell — invocations with positional args error with `invalid value for '--pager'`. Use `/bin/ps -f` explicitly, or `pgrep -f <pattern>` for PID lookup.

--- a/skills/up-to-date/test_diagnose.py
+++ b/skills/up-to-date/test_diagnose.py
@@ -359,35 +359,25 @@ class TestClassifyMachine(unittest.TestCase):
 
 class TestClassifyDevMachine(unittest.TestCase):
     def test_both_conditions_true(self):
-        dev, reasons = classify_dev_machine(
-            tailscale_present=True, hostname="c-5004"
-        )
+        dev, reasons = classify_dev_machine(tailscale_present=True, hostname="c-5004")
         self.assertTrue(dev)
         self.assertTrue(any("hostname=c-5004" in r for r in reasons))
 
     def test_tailscale_missing(self):
-        dev, _ = classify_dev_machine(
-            tailscale_present=False, hostname="c-5004"
-        )
+        dev, _ = classify_dev_machine(tailscale_present=False, hostname="c-5004")
         self.assertFalse(dev)
 
     def test_hostname_does_not_match(self):
         # Mac with Tailscale installed but human hostname: not a dev machine.
-        dev, _ = classify_dev_machine(
-            tailscale_present=True, hostname="igor-mbp"
-        )
+        dev, _ = classify_dev_machine(tailscale_present=True, hostname="igor-mbp")
         self.assertFalse(dev)
 
     def test_neither_condition(self):
-        dev, _ = classify_dev_machine(
-            tailscale_present=False, hostname="other-host"
-        )
+        dev, _ = classify_dev_machine(tailscale_present=False, hostname="other-host")
         self.assertFalse(dev)
 
     def test_hostname_case_insensitive(self):
-        dev, _ = classify_dev_machine(
-            tailscale_present=True, hostname="C-5004"
-        )
+        dev, _ = classify_dev_machine(tailscale_present=True, hostname="C-5004")
         self.assertTrue(dev)
 
 
@@ -440,15 +430,18 @@ class TestResolveChopRoot(unittest.TestCase):
             root.mkdir()
             home = Path(td) / "home"
             home.mkdir()
-            result = resolve_chop_root(
-                {"CHOP_CONVENTIONS_ROOT": str(root)}, home
-            )
+            result = resolve_chop_root({"CHOP_CONVENTIONS_ROOT": str(root)}, home)
             self.assertIsNone(result)
 
 
 class TestCheckSharedClaudeMd(unittest.TestCase):
-    def _setup(self, td: str, enabled: bool = False, machine: str = "orbstack-dev",
-              dev_machine: bool = True) -> tuple[Path, Path, MachineInfo]:
+    def _setup(
+        self,
+        td: str,
+        enabled: bool = False,
+        machine: str = "orbstack-dev",
+        dev_machine: bool = True,
+    ) -> tuple[Path, Path, MachineInfo]:
         chop = Path(td) / "chop-conventions"
         (chop / "claude-md" / "machines").mkdir(parents=True)
         (chop / "claude-md" / "global.md").write_text("# global", encoding="utf-8")
@@ -533,9 +526,7 @@ class TestCheckSharedClaudeMd(unittest.TestCase):
             )
             block, _ = check_shared_claude_md(chop, home, True, info)
             kinds_by_slot = {a["slot"]: a["kind"] for a in block["actions"]}
-            self.assertEqual(
-                kinds_by_slot["dev_machine"], "remove_obsolete_symlink"
-            )
+            self.assertEqual(kinds_by_slot["dev_machine"], "remove_obsolete_symlink")
 
     def test_partial_installation(self):
         # Only global symlinked; machine + dev_machine missing.
@@ -564,9 +555,7 @@ class TestCheckSharedClaudeMd(unittest.TestCase):
             target = Path(td) / "hostile"
             target.mkdir()
             (home / ".claude" / "claude-md").symlink_to(target)
-            info = MachineInfo(
-                machine="orbstack-dev", dev_machine=True, reasons=[]
-            )
+            info = MachineInfo(machine="orbstack-dev", dev_machine=True, reasons=[])
             _, errors = check_shared_claude_md(chop, home, True, info)
             self.assertTrue(
                 any(e.get("code") == "claude_md_dir_is_symlink" for e in errors)
@@ -636,9 +625,7 @@ class TestCheckPostUpToDate(unittest.TestCase):
             hook.symlink_to(real)
             path, errors = check_post_up_to_date(repo)
             self.assertIsNone(path)
-            self.assertTrue(
-                any(e.get("code") == "hook_is_symlink" for e in errors)
-            )
+            self.assertTrue(any(e.get("code") == "hook_is_symlink" for e in errors))
 
     def test_subdirectory_does_not_affect_resolution(self):
         # The function takes an already-resolved toplevel, so running it
@@ -678,13 +665,21 @@ class TestRunDiagnoseChopRootUnresolved(unittest.TestCase):
             fake_home = Path(td) / "fake-home"
             fake_home.mkdir()
             # Minimal git repo — runtime of `diagnose.py` shells out
-            # to git, so it needs a repo to run against.
+            # to git, so it needs a repo to run against. Scrub GIT_*
+            # env vars so a `GIT_DIR` set by pre-commit runners (prek)
+            # doesn't redirect these subprocess calls into whichever
+            # outer repo is running the hook — that silently pollutes
+            # the host `.git/config` with `user.email = test@test` and
+            # `core.worktree = <tempdir>` and wedges the whole repo.
+            git_env = {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
             def _git(*args: str) -> None:
                 subprocess.run(
                     ["git", *args],
                     cwd=repo,
                     check=True,
                     capture_output=True,
+                    env=git_env,
                 )
 
             _git("init", "-q")


### PR DESCRIPTION
## Summary

- Populate `claude-md/global.md` and `claude-md/machines/orbstack-dev.md` stubs with the content that had lived in each machine's flat `~/.claude/CLAUDE.md`. Once `/up-to-date` installs the symlinks, edits to these files propagate to every opted-in machine automatically.
- Fix a latent bug in `test_diagnose.TestRunDiagnoseChopRootUnresolved` that silently corrupted the host repo's `.git/config` whenever the test ran under pre-commit (prek).

## Placement rationale

| File | Content |
| --- | --- |
| `global.md` | Side-Edit (`rmux_helper`), Editing Skills symlink trap, Cross-Skill Conventions pointer |
| `machines/orbstack-dev.md` | `ps` pager-wrapper alias (shell-specific to this VM) |
| `dev-machine.md` | unchanged (still a stub; no dev-machine-specific content in the flat file yet) |

## Test-pollution bug

The `chop_root_unresolved` test spins up a tempdir repo and calls `subprocess.run(["git", ...], cwd=repo)`. Under bare `just fast-test` that works. Under prek, `prek` exports `GIT_DIR` pointing at the host repo's gitdir and those env vars leak into the subprocess — git then obeys `GIT_DIR` over `cwd=` and writes `user.email = test@test`, `user.name = test`, `commit.gpgsign = false`, **and** `core.worktree = <tempdir>` into the HOST `.git/config`. Once the tempdir is cleaned up, every subsequent git invocation in the host repo dies with `fatal: Invalid path <tempdir>/repo: No such file or directory`.

Fix: strip `GIT_*` env vars before invoking git inside the helper.

## Test plan

- [x] `python3 -m unittest test_diagnose.py` passes
- [x] `env GIT_DIR=/tmp/fake python3 -m unittest test_diagnose.TestRunDiagnoseChopRootUnresolved` passes (reproduction of the bug; failed before the fix)
- [x] Pre-commit hooks pass end-to-end on both commits
- [ ] After merge, run `/up-to-date` on a fresh machine and confirm the shared symlinks + `@`-imports load the migrated content

🤖 Generated with [Claude Code](https://claude.com/claude-code)