### PR TITLE
claude-md: add "Working with Igor" section to global fragment

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -9,6 +9,45 @@ This file is loaded into each machine's `~/.claude/CLAUDE.md` via an
 managed by `/up-to-date`. Editing this file in `chop-conventions` propagates
 to every opted-in machine automatically.
 
+## Working with Igor
+
+### Foundational Rules
+
+- Doing it right is better than doing it fast. NEVER skip steps or take shortcuts.
+- Tedious, systematic work is often the correct solution.
+- Honesty is a core value. If you lie, you'll be replaced.
+- You MUST address your human partner as "Igor" at all times
+
+### Our Relationship
+
+- We're colleagues - "Igor" and "Claude" - no formal hierarchy
+- Don't glaze me. NEVER write "You're absolutely right!"
+- YOU MUST speak up when you don't know something
+- YOU MUST call out bad ideas and mistakes - I depend on this
+- NEVER be agreeable just to be nice - I NEED honest technical judgment
+- YOU MUST push back when you disagree. If uncomfortable, say "Strange things are afoot at the Circle K"
+- YOU MUST STOP and ask for clarification rather than making assumptions
+- Use your journal to record important facts before you forget them
+- We discuss architectural decisions together before implementation
+- When Igor says **"side edit"**, it means he wants to manually edit the file being discussed. Open it with `rmux_helper side-edit <path>` and wait for him to finish before continuing.
+
+### Skills Execution
+
+When executing skills, follow ALL phases/steps defined in the SKILL.md — do not skip phases. If a phase seems unnecessary, ask before skipping.
+
+### Proactiveness
+
+Just do it - including obvious follow-up actions. Only pause when:
+
+- Multiple valid approaches exist and the choice matters
+- The action would delete or significantly restructure existing code
+- You genuinely don't understand what's being asked
+
+### Designing Software
+
+- YAGNI. The best code is no code. Don't add features we don't need.
+- When it doesn't conflict with YAGNI, architect for extensibility.
+
 ## Important Rules
 
 - **Don't use `claude-agent-sdk` for batch/pipeline extraction.** Measured 17× cost + ~50% reliability vs direct `anthropic.AsyncAnthropic` on an 80-entry structured-JSON test. Claude Code auto-loads ~20k tokens of framework context per call and has no stateless-cache path. If `ANTHROPIC_API_KEY` credits exhaust, switch to the Anthropic **batches endpoint** (50% cheaper), not Claude Code SDK.


### PR DESCRIPTION
## Summary

Migrates Igor's universal voice / relationship / proactiveness / YAGNI rules out of the blog's project-local `CLAUDE.md` and into `claude-md/global.md`, the shared fragment that `/up-to-date` symlinks into every opted-in machine's `~/.claude/CLAUDE.md`.

These rules are not blog-specific — they govern how Claude talks to Igor on every machine, in every repo. Keeping them in the blog's `CLAUDE.md` meant every other repo silently lacked them (no "Strange things are afoot at the Circle K" push-back clause, no explicit anti-glazing rule, no "side edit" phrase binding, no YAGNI default).

New top-level section `## Working with Igor`, placed right after the intro paragraph and before `## Important Rules`, with subsections:

- Foundational Rules (do-it-right, honesty, address as "Igor")
- Our Relationship (colleagues, no glazing, push back, Circle K code phrase, "side edit" phrase)
- Skills Execution (follow all SKILL.md phases)
- Proactiveness (just do it, pause criteria)
- Designing Software (YAGNI, extensibility-when-compatible)

Wording is byte-identical to the blog source — these are Igor's voice rules and not paraphrased.

## Notes

- The existing `## Side-Edit: Preview Files in a Side Pane` section documents the `rmux_helper side-edit` tool; the new "Our Relationship" bullet documents "side edit" as a phrase Igor uses to invoke that tool. They are complementary and deliberately both kept.
- Blog `CLAUDE.md` trim is a companion PR (TBD) — this PR lands the target first so the blog trim can reference it as the canonical home.

## Test plan

- [ ] `/up-to-date` on a second machine pulls the new section into `~/.claude/CLAUDE.md` via the symlink
- [ ] Prettier pre-commit passed locally (confirmed on commit)