### PR TITLE
learn-from-session: offer delegate-to-other-repo for cross-repo lessons

### DIFF
--- a/skills/learn-from-session/SKILL.md
+++ b/skills/learn-from-session/SKILL.md
@@ -42,7 +42,7 @@ Walk back through the session and answer these prompts explicitly. Each should h
 
 1. **What environmental constraint surprised us?** (host OS quirk, container limitation, read-only filesystem, PID 1 weirdness, tool shadowed by an alias, binary at an unexpected path)
 2. **What safety gotcha almost shipped?** (lifeline process missing from an exclude list, race condition, signal handler timing, destructive default, missing dep check)
-3. **What was the *right* place for content we initially put in the *wrong* place?** (file choice, module boundary, doc location, skill boundary)
+3. **What was the _right_ place for content we initially put in the _wrong_ place?** (file choice, module boundary, doc location, skill boundary)
 4. **What pattern worked well enough to codify?** (idempotent boot hook, dep check before main loop, smoke test with low thresholds, rebase-before-PR)
 5. **What tool invocation ate time before landing on the right one?** (wrong flag, shadowed binary, pattern that matched unintended targets, subshell trap timing)
 
@@ -61,7 +61,7 @@ Discard:
 - One-off fix narratives ("in this session we fixed X by doing Y")
 - Anything already in the repo's CLAUDE.md, the default system prompt, or shared guardrails
 - Warnings about behavior that a self-aware Claude would discover in one tool call
-- Things that would be true of any Linux/Mac box — CLAUDE.md captures what's *special* about this environment
+- Things that would be true of any Linux/Mac box — CLAUDE.md captures what's _special_ about this environment
 
 ## Step 3: Route Each Lesson to a Scope
 
@@ -78,7 +78,7 @@ If a lesson spans scopes, pick the most specific. If you're unsure which file ow
 
 For each surviving lesson, write the addition in this shape:
 
-```
+````
 ### Update: <absolute path to CLAUDE.md>
 
 **Why:** <one-line justification citing this session's cost or risk>
@@ -86,7 +86,7 @@ For each surviving lesson, write the addition in this shape:
 ​```diff
 + <the addition — ≤5 lines, prefer bullets, no preamble>
 ​```
-```
+````
 
 ### Style rules
 
@@ -109,11 +109,48 @@ Surface these proposals in the Step 6 diff batch alongside CLAUDE.md changes so 
 
 Show all proposed changes in one message, grouped by target file. Include CLAUDE.md diffs, skill updates, and new-skill proposals side by side. End with a single explicit ask: "Apply these?" Wait for explicit approval before editing any file. Do not partial-apply unless the user picks specific items.
 
+## Step 6.5: Cross-repo routing check
+
+**Before writing any edit**, check per target file: does it live in the current session's repo?
+
+```bash
+# Session repo toplevel
+SESSION_REPO=$(git rev-parse --show-toplevel 2>/dev/null)
+
+# Target repo toplevel (run from the directory containing the target CLAUDE.md)
+TARGET_REPO=$(git -C "$(dirname <target-path>)" rev-parse --show-toplevel 2>/dev/null)
+```
+
+Route each target:
+
+- **Same repo** (`SESSION_REPO == TARGET_REPO`) → apply in-session as Step 7 describes. No prompt needed.
+- **No git context** (e.g. `~/.claude/CLAUDE.md` with `TARGET_REPO` empty) → machine-local, apply in-place. No prompt needed.
+- **Different repo** (`SESSION_REPO != TARGET_REPO`, both non-empty) → **STOP and ask the user**. Do not edit. Do not auto-delegate.
+
+The most common different-repo case is a lesson routing to `chop-conventions`' shared fragments (`claude-md/global.md`, `claude-md/machine.md`, `claude-md/dev-machine.md`, `machines/*.md`). Symlinks under `~/.claude/skills/` and `~/.claude/claude-md/` resolve back into `chop-conventions`, so a lesson about a skill's behavior lands here too — the toplevel check catches this correctly as long as you resolve symlinks first (`realpath <target>` before the `git -C` call).
+
+### The cross-repo prompt
+
+For each different-repo target, show this prompt verbatim and wait for the user's choice:
+
+> This lesson would edit `<resolved-path>` in `<other-repo>` (outside the current session's repo). Options:
+>
+> 1. **Delegate** — hand this edit to the `delegate-to-other-repo` skill, which creates an isolated worktree in the target repo and dispatches a subagent to open a PR. The current session stays unpolluted.
+> 2. **Abort** — skip this lesson. You can capture it manually later.
+>
+> Which?
+
+On **delegate**: invoke the `delegate-to-other-repo` skill with a pre-built task description containing (a) the absolute target path, (b) the exact diff / insertion from Step 4, and (c) the one-line justification from Step 4. Do not attempt to edit the file from this session — the subagent owns it. Collect the returned PR URL for the final report.
+
+On **abort**: drop that lesson from the batch. Record it in your final summary as "skipped — cross-repo, user aborted" so nothing silently disappears.
+
+Never auto-delegate. The prompt is load-bearing — `delegate-to-other-repo` opens PRs, and a user who's only reviewing lessons should not have unexpected PRs appear.
+
 ## Step 7: Apply
 
-On approval:
+On approval and after Step 6.5 has been resolved for every target:
 
-0. **Check repo locality first.** For each target file from Step 3, ask: is it inside the current session's repo (the one containing `pwd`)? If **YES**, apply it directly via the steps below. If **NO**, delegate that target via the `delegate-to-other-repo` skill instead of editing in-session. Cross-repo edits via delegation isolate the other repo's CLAUDE.md / conventions / PR flow into a fresh subagent context, so the parent session doesn't get polluted with another repo's state. Do not try to apply cross-repo edits inline — even if it feels easier, you'll end up `cd`-ing into the wrong tree, branching off the wrong base, or missing the target's pre-commit hooks. **For cross-repo CLAUDE.md edits, use `delegate-to-other-repo`, not inline edits.**
+0. Same-repo and machine-local targets proceed here. Cross-repo targets have already been handled by `delegate-to-other-repo` (or dropped), so skip them in this phase — do not try to edit them inline.
 1. **Create a feature branch per repo** — naming: `claude-md-<short-topic>` or `session-learnings-<date>`
 2. **Apply edits** using the Edit tool (not Write — these are targeted insertions)
 3. **Commit per repo** with a descriptive message that cites the lesson itself, not "update CLAUDE.md". Include the standard `Co-Authored-By` trailer.
@@ -139,3 +176,4 @@ Red flags that you're adding noise to CLAUDE.md:
 
 - `claude-md-management:revise-claude-md` — upstream generic version; this skill adds explicit scope routing, voice rules, and skill-update proposals on top
 - `claude-md-management:claude-md-improver` — audits existing CLAUDE.md quality rather than adding new content
+- `delegate-to-other-repo` — invoked from Step 6.5 when a lesson routes to a CLAUDE.md outside the current session's repo (most often `chop-conventions`' shared fragments)


### PR DESCRIPTION
## Summary

- Adds a new **Step 6.5: Cross-repo routing check** to `learn-from-session/SKILL.md` that runs after Step 6 approval and before Step 7 application.
- Per target file, compares `git rev-parse --show-toplevel` in the session cwd against `git -C <target> rev-parse --show-toplevel`. Same-repo and machine-local (no git context) targets proceed normally; cross-repo targets trigger an explicit user prompt.
- The prompt offers two options — **Delegate** (hand off to `delegate-to-other-repo`, which creates an isolated worktree and dispatches a subagent to open a PR) or **Abort** (drop the lesson). Auto-delegation is explicitly forbidden — the user confirmation is load-bearing because delegation opens PRs.
- Updates Step 7 to note that same-repo / machine-local targets are what it handles, and cross-repo targets have already been routed through delegate-to-other-repo (or dropped) in Step 6.5.
- Adds `delegate-to-other-repo` to the Related section.

## Why

The most common cross-repo target for this skill is `chop-conventions`' shared fragments (`claude-md/global.md`, `claude-md/machine.md`, etc.). Without this check, a session running in, say, the blog repo could try to edit chop-conventions' CLAUDE fragments inline — `cd`-ing into the wrong tree, branching off the wrong base, or falling into the `~/.claude/skills/` symlink trap that mutates whichever chop-conventions branch happens to be checked out in the primary worktree.

## Test plan

- [ ] Run `learn-from-session` in a session whose lessons route to chop-conventions' `claude-md/global.md` — verify the prompt appears and that choosing "delegate" dispatches `delegate-to-other-repo` instead of editing inline.
- [ ] Run `learn-from-session` in a session whose lessons route to the session's own repo — verify no prompt appears and edits apply inline as before.
- [ ] Run `learn-from-session` with a lesson targeting `~/.claude/CLAUDE.md` (no enclosing git repo) — verify it applies in-place without prompting.