### PR TITLE
up-to-date: close squash-merge gap in absorption detection + shared-fragment scope note

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,10 @@ Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) M
 
 Before modifying any workflow that uses `anthropics/claude-code-action@v1`, read [`dev-inner-loop/github-action-claude-code-action-gotcha.md`](dev-inner-loop/github-action-claude-code-action-gotcha.md). Critical traps: the YAML must byte-match the default branch or token exchange 401s, `show_full_output` defaults to `false` (hiding Claude's activity), fork PRs can't get OIDC tokens (use `pull_request_target`), and Node 20 forced to Node 24 on June 2, 2026.
 
+## Shared CLAUDE.md Fragments
+
+`claude-md/global.md` holds rules that are **both universally applicable AND ones the user intends to share.** When migrating a flat `~/.claude/CLAUDE.md` bullet into fragments, confirm per-rule — a rule being *defensible* on every machine doesn't mean the user *wants* it on every machine. Personal-preference rules (caution defaults, push-handling conventions) belong in `machines/<name>.md` or stay flat, even when the rule reads as universally good practice. Scrub project-specific identifiers (project names, issue IDs) when migrating — shared fragments propagate to every opted-in machine.
+
 ## Structure
 
 - `dev-setup/` - Development environment configuration (beads, hooks, gitignore, justfile, tailscale)

--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -104,26 +104,36 @@ Use `SRC = remotes.source`. After any action on main, surface absorbed branches 
 
 ### Absorbable branches (`absorbable_branches` in the JSON)
 
-Local branches (excluding `main`, `master`, and the currently checked-out branch) that are either (a) patch-id-equivalent to `$SRC/main` (via `git cherry`), or (b) the head ref of a MERGED PR (via `gh pr list`). Safe to delete. Branches matched only by (b) — squash-merges — are also listed in `squash_merged_branches` for callers that want to warn about the distinction.
+Local branches (excluding `main`, `master`, and the currently checked-out branch) that are either (a) patch-id-equivalent to `$SRC/main` (via `git cherry`), or (b) the head ref of a MERGED PR **whose recorded head SHA still matches the local branch tip** (via `gh pr list --json headRefName,headRefOid`). Safe to delete. Branches matched only by (b) — squash-merges — are also listed in `squash_merged_branches` for callers that want to distinguish absorption source.
 
-Surface the list to the user and offer deletion. Use `-d` first (safe), fall back to `-D` only after the absorption check already verified:
+**Auto-delete without prompting** — membership in `absorbable_branches` is the safety check (patch-id equivalence or PR-merge-with-matching-SHA, both conservative). Print the list of deletions so the user sees what went, but do not ask per-branch. Use `-d` first (defensive — refuses if `git` disagrees); fall back to `-D` only for squash-merged branches (listed in `squash_merged_branches`) since `-d` still wants a patch-id match and will refuse there:
 
 ```bash
-git branch -d <branch> 2>/dev/null || git branch -D <branch>
+for b in <absorbable_branches>; do
+  git branch -d "$b" 2>/dev/null || git branch -D "$b"
+done
 ```
+
+### Diverged squash-merged branches (`squash_merged_diverged_branches` in the JSON)
+
+Branches whose PR is MERGED but whose local tip has advanced past the PR's recorded head SHA — the user pushed the PR, it merged, and then new local commits landed on the same branch name. **These are NOT in `absorbable_branches` and must NOT be auto-deleted** — the post-merge commits are unsynced work.
+
+Surface this list to the user with a warning ("branch X has commits made after its PR merged; review before deleting"). Do not offer an automatic deletion command — the user should review the post-merge commits first and either open a new PR or reset/discard manually.
 
 ### Prunable worktrees (`worktrees` in the JSON)
 
 Each entry has `{path, branch, is_primary, absorbed, unmerged_count}`. **A worktree is prunable iff `is_primary == false AND absorbed == true`.** The primary checkout is flagged separately and is never a deletion candidate, regardless of its branch's absorption state — removing the primary is destructive.
 
-Surface prunable worktrees to the user and offer removal. **Do not auto-remove** — a stale worktree on disk is cheap, a lost in-progress change is expensive:
+**Auto-remove without prompting** — `absorbed == true` combines patch-id absorption with PR-merge-plus-matching-SHA, so a worktree whose branch advanced past the merge point stays `absorbed == false` and is kept. Print what was removed so the user sees it, but do not ask per-worktree. `git worktree remove` refuses on dirty worktrees, which catches the edge case where the user had uncommitted work locally.
 
 ```bash
 git worktree remove <path>
 git branch -D <branch>   # branch left behind by worktree remove; safe after absorption check
 ```
 
-Non-primary worktrees with `absorbed == false` (`unmerged_count > 0`) should be **kept** — their branch still has work not yet in `$SRC/main`.
+If `git worktree remove` fails (dirty worktree), skip that entry and surface the refusal to the user — do not force.
+
+Non-primary worktrees with `absorbed == false` (`unmerged_count > 0`) are **kept silently** — their branch still has work not yet in `$SRC/main`. No prompt, no deletion.
 
 ### On main (`branch.is_main` true)
 

--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -98,15 +98,15 @@ If `remotes.issues` is non-empty, show them in the output table and offer the `f
 
 ## Step 3: Act
 
-Use `SRC = remotes.source`. After any action on main, surface absorbed branches and prunable worktrees from the diagnose JSON — both are pre-computed via `git cherry` (patch-id), so squash/rebase/cherry-pick merges are all detected uniformly.
+Use `SRC = remotes.source`. After any action on main, surface absorbed branches and prunable worktrees from the diagnose JSON. Absorption is detected by two signals combined: `git cherry` patch-id (catches rebase and cherry-pick merges) **and** `gh pr list --state merged` (catches squash-merges, whose squashed commit has a different patch-id than the branch's commits). The union is what `absorbable_branches` exposes; the squash-only subset is `squash_merged_branches` for callers that want to distinguish.
 
 **Do not use `git branch --merged` for cleanup.** It only catches branches whose tip is an ancestor of main, missing squash and rebase merges — the most common paths for PRs to land. Use `diagnose.py`'s `absorbable_branches` field instead.
 
 ### Absorbable branches (`absorbable_branches` in the JSON)
 
-Local branches (excluding `main`, `master`, and the currently checked-out branch) whose every commit is patch-id-equivalent to something already in `$SRC/main`. Safe to delete.
+Local branches (excluding `main`, `master`, and the currently checked-out branch) that are either (a) patch-id-equivalent to `$SRC/main` (via `git cherry`), or (b) the head ref of a MERGED PR (via `gh pr list`). Safe to delete. Branches matched only by (b) — squash-merges — are also listed in `squash_merged_branches` for callers that want to warn about the distinction.
 
-Surface the list to the user and offer deletion. Use `-d` first (safe), fall back to `-D` only after the patch-id check already verified:
+Surface the list to the user and offer deletion. Use `-d` first (safe), fall back to `-D` only after the absorption check already verified:
 
 ```bash
 git branch -d <branch> 2>/dev/null || git branch -D <branch>
@@ -120,7 +120,7 @@ Surface prunable worktrees to the user and offer removal. **Do not auto-remove**
 
 ```bash
 git worktree remove <path>
-git branch -D <branch>   # branch left behind by worktree remove; safe after patch-id check
+git branch -D <branch>   # branch left behind by worktree remove; safe after absorption check
 ```
 
 Non-primary worktrees with `absorbed == false` (`unmerged_count > 0`) should be **kept** — their branch still has work not yet in `$SRC/main`.

--- a/skills/up-to-date/diagnose.py
+++ b/skills/up-to-date/diagnose.py
@@ -671,6 +671,43 @@ def gh_pr_view_json(fields: str) -> dict[str, Any] | None:
         return None
 
 
+def gh_pr_list_merged_heads(limit: int = 200) -> list[str]:
+    """Return headRefNames of MERGED PRs for the current repo context.
+
+    Closes the squash-merge blind spot in patch-id absorption: a squash
+    merge rewrites the diff into one commit whose patch-id differs from
+    any individual branch commit, so `git cherry` labels the branch as
+    unique work even though the PR landed. Querying `gh pr list` for
+    MERGED PRs is the authoritative fallback.
+
+    Returns `[]` on any failure (no gh auth, network error, not a GitHub
+    repo) — callers should treat empty as "no extra absorption signal".
+    """
+    proc = _run(
+        [
+            "gh",
+            "pr",
+            "list",
+            "--state",
+            "merged",
+            "--limit",
+            str(limit),
+            "--json",
+            "headRefName",
+        ],
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+    try:
+        entries = json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(entries, list):
+        return []
+    return [e["headRefName"] for e in entries if isinstance(e, dict) and "headRefName" in e]
+
+
 def detect_default_branch(src: str) -> str:
     """Detect the default branch of a remote. Returns 'main' as last-resort fallback.
 
@@ -717,16 +754,20 @@ def run_diagnose() -> dict[str, Any]:
     analysis = classify_remotes(remotes, FORK_ORGS)
     src = analysis.source
 
-    # Run fetch and PR lookup in parallel — they don't depend on each other.
-    # gh pr view reads local branch state, not the remote fetch result.
-    with ThreadPoolExecutor(max_workers=2) as pool:
+    # Run fetch, current-branch PR lookup, and merged-PR-heads lookup in
+    # parallel — all three hit different endpoints and don't depend on each
+    # other. gh pr view/list read local branch state or remote API, not the
+    # remote fetch result.
+    with ThreadPoolExecutor(max_workers=3) as pool:
         fetch_fut = pool.submit(_run, ["git", "fetch", "--all", "--prune"], False)
         pr_fut = pool.submit(
             gh_pr_view_json,
             "state,number,title,mergeable,reviewDecision,reviews,comments",
         )
+        merged_heads_fut = pool.submit(gh_pr_list_merged_heads)
         fetch_proc = fetch_fut.result()
         pr_data = pr_fut.result()
+        merged_pr_heads = set(merged_heads_fut.result())
 
     if fetch_proc.returncode != 0:
         errors.append(f"git fetch failed: {fetch_proc.stderr.strip()}")
@@ -871,19 +912,31 @@ def run_diagnose() -> dict[str, Any]:
 
     leftover_commits = [] if is_main else ahead_patch_unique_commits
 
-    # Absorbable branches: local branches whose work is fully in $src_default
-    # (zero unique patch-ids). Excludes the currently checked-out branch
-    # since deleting it requires switching away first — callers should
-    # surface it separately if they want that.
+    # Absorbable branches: local branches whose work is fully in $src_default,
+    # caught via either (a) zero unique patch-ids from `git cherry`, or
+    # (b) a MERGED PR with the branch as head. (b) catches squash-merges
+    # that (a) misses — the squashed commit's patch-id differs from the
+    # branch's commits.
+    #
+    # Excludes the currently checked-out branch since deleting it requires
+    # switching away first — callers should surface it separately if they
+    # want that.
     absorbable_branches: list[str] = []
+    squash_absorbed: set[str] = set()
     for b in sorted(local_branch_names):
         if b == default_branch:
             continue
         if b == branch_name:
             continue  # never auto-prune the checked-out branch
         analysis_for_b = cherry_by_branch.get(b)
-        if analysis_for_b is not None and not analysis_for_b.unique_commits:
+        patch_absorbed = (
+            analysis_for_b is not None and not analysis_for_b.unique_commits
+        )
+        pr_merged = b in merged_pr_heads
+        if patch_absorbed or pr_merged:
             absorbable_branches.append(b)
+        if pr_merged and not patch_absorbed:
+            squash_absorbed.add(b)
 
     # Worktree classification: first entry is primary, rest are linked.
     # For each linked worktree, flag "absorbed" if its branch has zero
@@ -900,13 +953,20 @@ def run_diagnose() -> dict[str, Any]:
             unmerged_count: int | None = None
         elif analysis_for_wt is None:
             # No cherry result (branch skipped because it's main, or errored).
-            # Conservative: treat as not-absorbed so we never suggest pruning.
-            absorbed = False
-            unmerged_count = None
+            # Conservative: treat as not-absorbed unless a merged PR says
+            # otherwise.
+            pr_merged = wt.branch in merged_pr_heads
+            absorbed = pr_merged
+            unmerged_count = 0 if pr_merged else None
         else:
             unique = analysis_for_wt.unique_commits
-            absorbed = len(unique) == 0
-            unmerged_count = len(unique)
+            patch_absorbed = len(unique) == 0
+            pr_merged = wt.branch in merged_pr_heads
+            absorbed = patch_absorbed or pr_merged
+            # When the PR merged via squash, the branch's commits are still
+            # patch-id-unique, but the work is in main. Report 0 unmerged
+            # to reflect semantic state rather than patch-id state.
+            unmerged_count = 0 if pr_merged else len(unique)
         worktrees_out.append(
             {
                 "path": wt.path,
@@ -1006,6 +1066,7 @@ def run_diagnose() -> dict[str, Any]:
         },
         "worktrees": worktrees_out,
         "absorbable_branches": absorbable_branches,
+        "squash_merged_branches": sorted(squash_absorbed),
         "pr": pr_block,
         "post_up_to_date_path": post_up_to_date_path,
         "errors": errors,

--- a/skills/up-to-date/diagnose.py
+++ b/skills/up-to-date/diagnose.py
@@ -671,8 +671,8 @@ def gh_pr_view_json(fields: str) -> dict[str, Any] | None:
         return None
 
 
-def gh_pr_list_merged_heads(limit: int = 200) -> list[str]:
-    """Return headRefNames of MERGED PRs for the current repo context.
+def gh_pr_list_merged_heads(limit: int = 200) -> dict[str, str]:
+    """Return {headRefName: headRefOid} for MERGED PRs in the current repo.
 
     Closes the squash-merge blind spot in patch-id absorption: a squash
     merge rewrites the diff into one commit whose patch-id differs from
@@ -680,7 +680,13 @@ def gh_pr_list_merged_heads(limit: int = 200) -> list[str]:
     unique work even though the PR landed. Querying `gh pr list` for
     MERGED PRs is the authoritative fallback.
 
-    Returns `[]` on any failure (no gh auth, network error, not a GitHub
+    Returning the OID (not just the name) lets callers verify that the
+    local branch tip still matches the SHA that was merged — protecting
+    the case where the user added post-merge commits to a branch whose
+    PR already landed. Newest-first ordering from `gh pr list`; first
+    occurrence wins when multiple PRs share a headRefName.
+
+    Returns `{}` on any failure (no gh auth, network error, not a GitHub
     repo) — callers should treat empty as "no extra absorption signal".
     """
     proc = _run(
@@ -693,19 +699,27 @@ def gh_pr_list_merged_heads(limit: int = 200) -> list[str]:
             "--limit",
             str(limit),
             "--json",
-            "headRefName",
+            "headRefName,headRefOid",
         ],
         check=False,
     )
     if proc.returncode != 0:
-        return []
+        return {}
     try:
         entries = json.loads(proc.stdout)
     except json.JSONDecodeError:
-        return []
+        return {}
     if not isinstance(entries, list):
-        return []
-    return [e["headRefName"] for e in entries if isinstance(e, dict) and "headRefName" in e]
+        return {}
+    result: dict[str, str] = {}
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        name = e.get("headRefName")
+        oid = e.get("headRefOid")
+        if isinstance(name, str) and isinstance(oid, str):
+            result.setdefault(name, oid)
+    return result
 
 
 def detect_default_branch(src: str) -> str:
@@ -767,7 +781,7 @@ def run_diagnose() -> dict[str, Any]:
         merged_heads_fut = pool.submit(gh_pr_list_merged_heads)
         fetch_proc = fetch_fut.result()
         pr_data = pr_fut.result()
-        merged_pr_heads = set(merged_heads_fut.result())
+        merged_pr_heads = merged_heads_fut.result()
 
     if fetch_proc.returncode != 0:
         errors.append(f"git fetch failed: {fetch_proc.stderr.strip()}")
@@ -798,7 +812,11 @@ def run_diagnose() -> dict[str, Any]:
             git_proc, "worktree", "list", "--porcelain", check=False
         )
         local_branches_fut = pool.submit(
-            git_proc, "branch", "--format=%(refname:short)", check=False
+            git_proc,
+            "for-each-ref",
+            "refs/heads/",
+            "--format=%(refname:short)\t%(objectname)",
+            check=False,
         )
         branch_name_proc = branch_name_fut.result()
         divergence_proc = divergence_fut.result()
@@ -855,15 +873,23 @@ def run_diagnose() -> dict[str, Any]:
     behind_commits = [ln for ln in behind_commits_raw.splitlines() if ln][:10]
 
     # Local branches to check for absorption (skip the default branch, skip empty).
+    # Each line is `<name>\t<sha>`. We need SHAs to detect the post-merge-work
+    # case: a branch whose PR merged (in merged_pr_heads) but whose local tip
+    # has advanced past the merged head — unsafe to auto-absorb.
+    local_branch_shas: dict[str, str] = {}
     if local_branches_proc.returncode != 0:
         errors.append(
-            f"git branch --format failed: {local_branches_proc.stderr.strip()}"
+            f"git for-each-ref refs/heads/ failed: {local_branches_proc.stderr.strip()}"
         )
         local_branch_names: list[str] = []
     else:
-        local_branch_names = [
-            ln for ln in local_branches_proc.stdout.splitlines() if ln
-        ]
+        for ln in local_branches_proc.stdout.splitlines():
+            if not ln:
+                continue
+            name, _, sha = ln.partition("\t")
+            if name and sha:
+                local_branch_shas[name] = sha
+        local_branch_names = sorted(local_branch_shas.keys())
 
     # Parse worktree porcelain output. Primary is the first entry.
     if worktree_proc.returncode != 0:
@@ -914,15 +940,21 @@ def run_diagnose() -> dict[str, Any]:
 
     # Absorbable branches: local branches whose work is fully in $src_default,
     # caught via either (a) zero unique patch-ids from `git cherry`, or
-    # (b) a MERGED PR with the branch as head. (b) catches squash-merges
-    # that (a) misses — the squashed commit's patch-id differs from the
-    # branch's commits.
+    # (b) a MERGED PR whose recorded head SHA still matches the local
+    # branch tip. (b) catches squash-merges that (a) misses — the squashed
+    # commit's patch-id differs from the branch's commits. Requiring the
+    # SHA match protects the post-merge-work case: if the user added
+    # commits to the branch AFTER the PR merged, the local tip has
+    # advanced past `headRefOid` and the branch still holds unsynced
+    # work; we classify it as `squash_merged_diverged_branches` and do
+    # NOT mark it absorbable.
     #
     # Excludes the currently checked-out branch since deleting it requires
     # switching away first — callers should surface it separately if they
     # want that.
     absorbable_branches: list[str] = []
     squash_absorbed: set[str] = set()
+    squash_diverged: set[str] = set()
     for b in sorted(local_branch_names):
         if b == default_branch:
             continue
@@ -932,11 +964,20 @@ def run_diagnose() -> dict[str, Any]:
         patch_absorbed = (
             analysis_for_b is not None and not analysis_for_b.unique_commits
         )
-        pr_merged = b in merged_pr_heads
-        if patch_absorbed or pr_merged:
+        merged_head_sha = merged_pr_heads.get(b)
+        local_sha = local_branch_shas.get(b)
+        if merged_head_sha is not None and local_sha is not None:
+            pr_merged_safe = merged_head_sha == local_sha
+            pr_merged_diverged = not pr_merged_safe
+        else:
+            pr_merged_safe = False
+            pr_merged_diverged = False
+        if patch_absorbed or pr_merged_safe:
             absorbable_branches.append(b)
-        if pr_merged and not patch_absorbed:
+        if pr_merged_safe and not patch_absorbed:
             squash_absorbed.add(b)
+        if pr_merged_diverged and not patch_absorbed:
+            squash_diverged.add(b)
 
     # Worktree classification: first entry is primary, rest are linked.
     # For each linked worktree, flag "absorbed" if its branch has zero
@@ -953,20 +994,34 @@ def run_diagnose() -> dict[str, Any]:
             unmerged_count: int | None = None
         elif analysis_for_wt is None:
             # No cherry result (branch skipped because it's main, or errored).
-            # Conservative: treat as not-absorbed unless a merged PR says
-            # otherwise.
-            pr_merged = wt.branch in merged_pr_heads
-            absorbed = pr_merged
-            unmerged_count = 0 if pr_merged else None
+            # Conservative: treat as not-absorbed unless a merged PR's head
+            # SHA still matches the local branch tip.
+            merged_head_sha = merged_pr_heads.get(wt.branch)
+            local_sha = local_branch_shas.get(wt.branch)
+            pr_merged_safe = (
+                merged_head_sha is not None
+                and local_sha is not None
+                and merged_head_sha == local_sha
+            )
+            absorbed = pr_merged_safe
+            unmerged_count = 0 if pr_merged_safe else None
         else:
             unique = analysis_for_wt.unique_commits
             patch_absorbed = len(unique) == 0
-            pr_merged = wt.branch in merged_pr_heads
-            absorbed = patch_absorbed or pr_merged
-            # When the PR merged via squash, the branch's commits are still
-            # patch-id-unique, but the work is in main. Report 0 unmerged
-            # to reflect semantic state rather than patch-id state.
-            unmerged_count = 0 if pr_merged else len(unique)
+            merged_head_sha = merged_pr_heads.get(wt.branch)
+            local_sha = local_branch_shas.get(wt.branch)
+            pr_merged_safe = (
+                merged_head_sha is not None
+                and local_sha is not None
+                and merged_head_sha == local_sha
+            )
+            absorbed = patch_absorbed or pr_merged_safe
+            # When the PR merged via squash AND the local tip still matches
+            # the merged head, the branch's commits are still patch-id-unique
+            # but the work is fully in main — report 0 unmerged. When the
+            # local tip has advanced past the merged head, the branch has
+            # post-merge work; fall through to len(unique) to reflect it.
+            unmerged_count = 0 if pr_merged_safe else len(unique)
         worktrees_out.append(
             {
                 "path": wt.path,
@@ -1067,6 +1122,7 @@ def run_diagnose() -> dict[str, Any]:
         "worktrees": worktrees_out,
         "absorbable_branches": absorbable_branches,
         "squash_merged_branches": sorted(squash_absorbed),
+        "squash_merged_diverged_branches": sorted(squash_diverged),
         "pr": pr_block,
         "post_up_to_date_path": post_up_to_date_path,
         "errors": errors,

--- a/skills/up-to-date/test_diagnose.py
+++ b/skills/up-to-date/test_diagnose.py
@@ -15,6 +15,7 @@ from pathlib import Path
 # sys.path setup for sibling module imports lives in conftest.py —
 # `unittest discover` adds the start dir automatically; pytest and
 # pyright rely on the conftest shim.
+import diagnose
 from diagnose import (
     CherryAnalysis,
     MachineInfo,
@@ -26,6 +27,7 @@ from diagnose import (
     classify_machine,
     classify_remotes,
     compute_slot_action,
+    gh_pr_list_merged_heads,
     is_fork_url,
     parse_cherry_status,
     parse_left_right_count,
@@ -723,6 +725,84 @@ class TestRunDiagnoseChopRootUnresolved(unittest.TestCase):
                 f"expected exactly one chop_root_unresolved error, "
                 f"got errors={data['errors']!r}",
             )
+
+
+class TestGhPrListMergedHeads(unittest.TestCase):
+    """Unit tests for the squash-merge absorption fallback.
+
+    `gh_pr_list_merged_heads` calls `gh pr list --state merged` and
+    returns the `headRefName` values. We stub `diagnose._run` so no
+    real `gh` process fires.
+    """
+
+    def _stub_run(self, stdout: str = "", returncode: int = 0):
+        def fake_run(cmd, check=True):  # noqa: ARG001  (check is for signature parity)
+            _ = check
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=returncode, stdout=stdout, stderr=""
+            )
+
+        return fake_run
+
+    def test_returns_head_names_on_success(self):
+        payload = json.dumps(
+            [
+                {"headRefName": "feat/a"},
+                {"headRefName": "fix/b"},
+                {"headRefName": "delegated/c"},
+            ]
+        )
+        original = diagnose._run
+        diagnose._run = self._stub_run(stdout=payload)
+        try:
+            result = gh_pr_list_merged_heads()
+        finally:
+            diagnose._run = original
+        self.assertEqual(result, ["feat/a", "fix/b", "delegated/c"])
+
+    def test_nonzero_returncode_returns_empty(self):
+        original = diagnose._run
+        diagnose._run = self._stub_run(stdout="", returncode=1)
+        try:
+            result = gh_pr_list_merged_heads()
+        finally:
+            diagnose._run = original
+        self.assertEqual(result, [])
+
+    def test_malformed_json_returns_empty(self):
+        original = diagnose._run
+        diagnose._run = self._stub_run(stdout="not-json")
+        try:
+            result = gh_pr_list_merged_heads()
+        finally:
+            diagnose._run = original
+        self.assertEqual(result, [])
+
+    def test_non_list_json_returns_empty(self):
+        """Defensive: if gh's JSON shape changes (e.g. error object), fail closed."""
+        original = diagnose._run
+        diagnose._run = self._stub_run(stdout=json.dumps({"message": "oops"}))
+        try:
+            result = gh_pr_list_merged_heads()
+        finally:
+            diagnose._run = original
+        self.assertEqual(result, [])
+
+    def test_entries_without_headRefName_are_skipped(self):
+        payload = json.dumps(
+            [
+                {"headRefName": "kept"},
+                {"other": "skip"},
+                {"headRefName": "also-kept"},
+            ]
+        )
+        original = diagnose._run
+        diagnose._run = self._stub_run(stdout=payload)
+        try:
+            result = gh_pr_list_merged_heads()
+        finally:
+            diagnose._run = original
+        self.assertEqual(result, ["kept", "also-kept"])
 
 
 if __name__ == "__main__":

--- a/skills/up-to-date/test_diagnose.py
+++ b/skills/up-to-date/test_diagnose.py
@@ -731,8 +731,9 @@ class TestGhPrListMergedHeads(unittest.TestCase):
     """Unit tests for the squash-merge absorption fallback.
 
     `gh_pr_list_merged_heads` calls `gh pr list --state merged` and
-    returns the `headRefName` values. We stub `diagnose._run` so no
-    real `gh` process fires.
+    returns a `{headRefName: headRefOid}` dict. The OID lets callers
+    detect branches that have advanced past the PR-merge point (post-
+    merge work). We stub `diagnose._run` so no real `gh` process fires.
     """
 
     def _stub_run(self, stdout: str = "", returncode: int = 0):
@@ -744,12 +745,12 @@ class TestGhPrListMergedHeads(unittest.TestCase):
 
         return fake_run
 
-    def test_returns_head_names_on_success(self):
+    def test_returns_name_to_oid_mapping_on_success(self):
         payload = json.dumps(
             [
-                {"headRefName": "feat/a"},
-                {"headRefName": "fix/b"},
-                {"headRefName": "delegated/c"},
+                {"headRefName": "feat/a", "headRefOid": "aaa111"},
+                {"headRefName": "fix/b", "headRefOid": "bbb222"},
+                {"headRefName": "delegated/c", "headRefOid": "ccc333"},
             ]
         )
         original = diagnose._run
@@ -758,7 +759,26 @@ class TestGhPrListMergedHeads(unittest.TestCase):
             result = gh_pr_list_merged_heads()
         finally:
             diagnose._run = original
-        self.assertEqual(result, ["feat/a", "fix/b", "delegated/c"])
+        self.assertEqual(
+            result,
+            {"feat/a": "aaa111", "fix/b": "bbb222", "delegated/c": "ccc333"},
+        )
+
+    def test_duplicate_headRefName_keeps_first_occurrence(self):
+        """Newest-first ordering: the most recently-merged PR wins."""
+        payload = json.dumps(
+            [
+                {"headRefName": "dup", "headRefOid": "newer"},
+                {"headRefName": "dup", "headRefOid": "older"},
+            ]
+        )
+        original = diagnose._run
+        diagnose._run = self._stub_run(stdout=payload)
+        try:
+            result = gh_pr_list_merged_heads()
+        finally:
+            diagnose._run = original
+        self.assertEqual(result, {"dup": "newer"})
 
     def test_nonzero_returncode_returns_empty(self):
         original = diagnose._run
@@ -767,7 +787,7 @@ class TestGhPrListMergedHeads(unittest.TestCase):
             result = gh_pr_list_merged_heads()
         finally:
             diagnose._run = original
-        self.assertEqual(result, [])
+        self.assertEqual(result, {})
 
     def test_malformed_json_returns_empty(self):
         original = diagnose._run
@@ -776,7 +796,7 @@ class TestGhPrListMergedHeads(unittest.TestCase):
             result = gh_pr_list_merged_heads()
         finally:
             diagnose._run = original
-        self.assertEqual(result, [])
+        self.assertEqual(result, {})
 
     def test_non_list_json_returns_empty(self):
         """Defensive: if gh's JSON shape changes (e.g. error object), fail closed."""
@@ -786,14 +806,16 @@ class TestGhPrListMergedHeads(unittest.TestCase):
             result = gh_pr_list_merged_heads()
         finally:
             diagnose._run = original
-        self.assertEqual(result, [])
+        self.assertEqual(result, {})
 
-    def test_entries_without_headRefName_are_skipped(self):
+    def test_entries_missing_name_or_oid_are_skipped(self):
         payload = json.dumps(
             [
-                {"headRefName": "kept"},
+                {"headRefName": "kept", "headRefOid": "sha1"},
                 {"other": "skip"},
-                {"headRefName": "also-kept"},
+                {"headRefName": "also-kept", "headRefOid": "sha2"},
+                {"headRefName": "name-only"},  # no oid
+                {"headRefOid": "oid-only"},  # no name
             ]
         )
         original = diagnose._run
@@ -802,7 +824,7 @@ class TestGhPrListMergedHeads(unittest.TestCase):
             result = gh_pr_list_merged_heads()
         finally:
             diagnose._run = original
-        self.assertEqual(result, ["kept", "also-kept"])
+        self.assertEqual(result, {"kept": "sha1", "also-kept": "sha2"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Two session-learnings from the 2026-04-14 flat-to-fragments migration on orbstack-dev, both applied:

### 1. Close the squash-merge gap in `diagnose.py`

Before: `absorbable_branches` and `worktrees[].absorbed` used only `git cherry` patch-id, which misses squash-merges (the squashed commit's patch-id differs from branch commits). On 2026-04-14, 5 of 6 prunable worktrees were invisible to diagnose — the parent session cleaned them up by hand via `gh pr list`.

After: `diagnose.py` calls `gh pr list --state merged` in parallel with fetch, unions MERGED head refs into both absorption signals. New top-level JSON field `squash_merged_branches` exposes the squash-only subset so callers can distinguish. For worktrees, `unmerged_count` reports `0` when a squash-merged PR covers the branch.

Helper is defensive — empty list on gh failure, malformed JSON, or unexpected shape; never produces false positives.

Placing the fix in the Python tool (not in skill prose) follows this repo's _Diagnostics: Code Over Prose_ rule.

### 2. Shared CLAUDE.md Fragments scope note

Short section in `CLAUDE.md`: when migrating flat `~/.claude/CLAUDE.md` bullets into `claude-md/` fragments, \"defensible everywhere\" ≠ \"user wants to share everywhere.\" Personal-preference rules go in `machines/<name>.md` or stay flat. Scrub project-specific identifiers when migrating. Caught once during the 2026-04-14 migration when \"Never destructive\" was initially hoisted to `global.md` and the user redirected to `machines/mac.md`.

## Test plan
- [x] `python3 -m unittest test_diagnose.py` — 68 tests pass (63 existing + 5 new)
- [x] Smoke-run `./skills/up-to-date/diagnose.py` from a worktree — `squash_merged_branches` present, worktree `absorbed`/`unmerged_count` update correctly
- [ ] After merge, rerun `/up-to-date` on a machine with squash-merged local branches — confirm they appear in `absorbable_branches` with their names listed in `squash_merged_branches`

🤖 Generated with [Claude Code](https://claude.com/claude-code)