### PR TITLE
review: dev-workflow skills (claude-md-improver + code-review)

### DIFF
--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -102,8 +102,10 @@ Run `/bin/ls ~/gits/` and present the list. Let the user pick.
 
 Compare the resolved target's toplevel against the current session's toplevel:
 
+```bash
 target_top=$(git -C "$T" rev-parse --show-toplevel)
 session_top=$(git rev-parse --show-toplevel)
+```
 
 If they match, the target is the current repo. Delegation still has value
 (fresh subagent context, isolation from in-session uncommitted work), but

--- a/skills/delegate-to-other-repo/worktree-recipe.md
+++ b/skills/delegate-to-other-repo/worktree-recipe.md
@@ -173,7 +173,9 @@ On success:
 
 - Worktree at `$T/.worktrees/delegated-<slug>` checked out to
   `delegated/<slug>` branch, based on `origin/<default-branch>`
-- (Maybe) one new commit on the target's default branch adding
-  `.worktrees/` to `.gitignore`
+- Possibly one new line appended to `.git/info/exclude` ensuring
+  `.worktrees/` is ignored. This is local-only, untracked, and
+  shared across all worktrees via the common git dir — no branch
+  history is mutated.
 
 Pass `$path` and `$branch` forward to Phase 3 (brief construction).

--- a/skills/up-to-date/SKILL.md
+++ b/skills/up-to-date/SKILL.md
@@ -47,6 +47,11 @@ The JSON output has this shape:
     "uncommitted": ["M  foo.py", ...],
     "stashes": ["stash@{0}: ...", ...]
   },
+  "worktrees": [
+    {"path": "/path/to/repo", "branch": "main", "is_primary": true, "absorbed": false, "unmerged_count": null},
+    {"path": "/path/to/repo/.worktrees/feature", "branch": "feature", "is_primary": false, "absorbed": true, "unmerged_count": 0}
+  ],
+  "absorbable_branches": ["old-feature", ...],
   "pr": {
     "state": "MERGED",
     "number": 42,
@@ -72,7 +77,7 @@ The JSON output has this shape:
 `shared_claude_md` is **omitted entirely** when `diagnose.py` cannot
 resolve a chop-conventions checkout. In that case `errors[]` carries a
 `{subsystem: "shared_claude_md", code: "chop_root_unresolved"}` entry
-and Step 3.5 is skipped without blocking the rest of `/up-to-date`.
+and Step 4 is skipped without blocking the rest of `/up-to-date`.
 
 `post_up_to_date_path` is `null` when no `.claude/post-up-to-date.md`
 exists at the repo toplevel; symlinked hooks are refused and surface as
@@ -195,7 +200,7 @@ If `worktree.stashes` is non-empty, list them and inform the user.
 | Behind source/main | N commits        | Will pull                                    |
 | Stashes            | N stashes        | Listed below                                 |
 
-## Step 3.5 — Shared CLAUDE.md setup / resync
+## Step 4 — Shared CLAUDE.md setup / resync
 
 Consult `shared_claude_md` in the diagnose JSON. Skip this step entirely
 when any `errors[]` entry has `subsystem == "shared_claude_md"` — that
@@ -239,12 +244,12 @@ empty, the user has never opted in on this machine. Offer opt-in:
 
 For each action in `shared_claude_md.actions`:
 
-| Kind                      | Command                 | Auto?        |
-| ------------------------- | ----------------------- | ------------ |
-| `create_symlink`          | `ln -s <target> <path>` | Ask user     |
+| Kind                      | Command                   | Auto?      |
+| ------------------------- | ------------------------- | ---------- |
+| `create_symlink`          | `ln -s <target> <path>`   | Ask user   |
 | `replace_stale_symlink`   | `ln -sfn <target> <path>` | Ask user   |
-| `remove_obsolete_symlink` | report only             | Never auto   |
-| `report_user_file`        | report only             | Never auto   |
+| `remove_obsolete_symlink` | report only               | Never auto |
+| `report_user_file`        | report only               | Never auto |
 
 `create_symlink` uses plain `-s` (NOT `-sfn`) so a race-condition real
 file at `<path>` fails loudly rather than being clobbered. Stay silent


### PR DESCRIPTION
## Summary

Group G1 audit of five dev-workflow skills via the `claude-md-improver` rubric (applied to SKILL.md as the skill's CLAUDE.md analog), followed by a code-review pass on the cumulative diff. Two skills had actionable issues; three were clean.

## Skills audited

| Skill | Status |
| ----- | ------ |
| `architect-review` | audited, no changes |
| `delegate-to-other-repo` | changed |
| `docs` | audited, no changes |
| `learn-from-session` | audited, no changes |
| `up-to-date` | changed |

## Changes per skill

### `delegate-to-other-repo`

- **SKILL.md** Phase 1c-bis: the two-line shell snippet comparing target vs. session toplevel was un-fenced, so it rendered as paragraph text. Added a `bash` code fence.
- **worktree-recipe.md** Output section: prose still claimed "(Maybe) one new commit on the target's default branch adding `.worktrees/` to `.gitignore`" — but the recipe already migrated to appending `.worktrees/` to `.git/info/exclude` (local-only, untracked, no branch mutation). Rewrote the bullet to match the recipe's actual behavior.

### `up-to-date`

- Step numbering jumped `3 → 3.5 → (nothing) → 5`. Renumbered `Step 3.5` to `Step 4` (both the heading and the one internal reference in the JSON-schema preamble).
- JSON schema block didn't document the `worktrees` or `absorbable_branches` top-level fields, even though Step 3 instructs the skill to read both for branch/worktree cleanup. Added both to the schema example (verified against `diagnose.py` — these fields are emitted at the top level of the output JSON).
- Prettier reformatted the `action loop` table pipes on commit; kept the reformatted version.

## Test plan

- [x] `claude-md-improver` criteria applied to each SKILL.md
- [x] Cross-links verified against actual code (`diagnose.py` field names, `.git/info/exclude` recipe)
- [x] Pre-commit hooks pass (prettier, ruff, fast tests)
- [x] Manual review of cumulative diff — doc-only, no logic changes

No deferred reviewer comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)