### PR TITLE
review: image skills (claude-md-improver + code-review)

### DIFF
--- a/skills/gen-image/SKILL.md
+++ b/skills/gen-image/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gen-image
 description: "Analyze content and generate illustrations via Gemini image API"
-argument-hint: "<post-or-topic> [--style 'description'] [--ref 'image-path'] [--api-url 'gemini-endpoint']"
+argument-hint: "<post-or-topic> [--count N] [--aspect W:H] [--style '...'] [--ref path] [--transparent] [--api-url url]"
 allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion, WebFetch
 ---
 

--- a/skills/gist-image/SKILL.md
+++ b/skills/gist-image/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: gist-image
 description: Use when you need to host images (screenshots, diagrams, PNGs) on GitHub for use in PR descriptions, issues, or markdown docs. Solves the problem that `gh gist create` rejects binary files.
+allowed-tools: Bash, Read, Write
 ---
 
 # Gist Image Upload

--- a/skills/image-explore/SKILL.md
+++ b/skills/image-explore/SKILL.md
@@ -17,7 +17,7 @@ Parse the user's input for:
 - **`--count N`**: Number of directions to brainstorm and generate (default: 5, max: 8)
 - **`--variants N`**: Number of minor variants per direction (default: 1, max: 3). Each variant tweaks the scene (different angle, lighting, composition) while keeping the same concept and shirt text.
 - **`--style 'description'`**: Override the default illustration style (passed through to gen-image)
-- **`--aspect 'W:H'`**: Aspect ratio (default: 3:4). Valid: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `9:16`, `16:9`
+- **`--aspect 'W:H'`**: Aspect ratio (default: 3:4). Valid: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`
 - **`--ref 'path'`**: Override reference image (default: raccoon canonical ref)
 
 ## Workflow
@@ -172,7 +172,7 @@ After generation, **verify each image actually matches its scene description** b
 3. **Write verification results back to the directions JSON** — for each entry, add:
    - `_verification`: `"pass"` or `"fail"`
    - `_verification_reason`: short explanation (e.g., "Solo raccoon portrait, no soccer field or group scene")
-   These fields are rendered in the comparison page's collapsible debug details.
+     These fields are rendered in the comparison page's collapsible debug details.
 4. For any **failures**, retry up to 2 times:
    - Strengthen the scene description (be more explicit, add emphasis)
    - Re-run `generate.py` for just the failed entries (write a temporary batch JSON)
@@ -181,11 +181,13 @@ After generation, **verify each image actually matches its scene description** b
 5. After retries, report any still-failing images to the user rather than silently including bad results
 
 **What counts as a failure:**
+
 - Single character when scene calls for a group (or vice versa)
 - Missing the core concept entirely (e.g., "split-screen" rendered as single scene)
 - Wrong setting (indoor when outdoor was specified)
 
 **What does NOT count as a failure:**
+
 - Shirt text slightly wrong (Gemini often struggles with exact text)
 - Style differences from the reference
 - Minor composition differences (angle, lighting)
@@ -256,9 +258,10 @@ If the user picks a winner, offer to:
 
 ## Default Raccoon Style
 
-When no `--style` is given, use this base style (same as gen-image):
-
-> Cute anthropomorphic raccoon character with chibi proportions (oversized head, small body), dark raccoon mask markings around eyes, big friendly dark eyes, small black nose, round brown ears with lighter inner ear, soft brown felt/plush fur, striped ringed tail with brown and dark brown bands. Wearing big round rainbow-colored glasses (frames cycle through red, orange, yellow, green, blue, purple), green t-shirt with bold white text, blue denim shorts, IMPORTANT: mismatched Crocs shoes — one BLUE Croc on the left foot and one YELLOW Croc on the right foot (never the same color on both feet). Soft plush 3D/vinyl toy illustration style, studio softbox lighting, clean warm pastel background, subtle vintage film grain, children's book style. Full body.
+When no `--style` is given, `generate.py` reads the canonical style from
+[`../gen-image/raccoon-style.txt`](../gen-image/raccoon-style.txt). Edit that
+file to change the default for both `gen-image` and `image-explore` — do not
+duplicate the style text here (drifted copies rot silently).
 
 ## Error Handling
 

--- a/skills/image-explore/generate.py
+++ b/skills/image-explore/generate.py
@@ -141,10 +141,14 @@ def remove_background(image_path):
     try:
         result = subprocess.run(
             [
-                magick, image_path,
-                "-fuzz", "30%",
-                "-transparent", "#FF00FF",
-                "-quality", "90",
+                magick,
+                image_path,
+                "-fuzz",
+                "30%",
+                "-transparent",
+                "#FF00FF",
+                "-quality",
+                "90",
                 tmp_path,
             ],
             capture_output=True,
@@ -271,7 +275,7 @@ def main():
         "--transparent",
         action="store_true",
         default=False,
-        help="Generate on magenta greenscreen, then remove background with rembg",
+        help="Generate on magenta chroma-key background, then strip it via ImageMagick -fuzz -transparent",
     )
 
     args = parser.parse_args()
@@ -304,9 +308,7 @@ def main():
     )
 
     if is_single:
-        direction = Direction(
-            scene=args.scene, shirt=args.shirt, output=args.output
-        )
+        direction = Direction(scene=args.scene, shirt=args.shirt, output=args.output)
         result = generate_one(direction, config)
         if not result.success:
             print(f"Error: {result.error}", file=sys.stderr)
@@ -327,7 +329,9 @@ def main():
             print("Error: No directions in batch file", file=sys.stderr)
             sys.exit(1)
 
-        print(f"Generating {len(raw_directions)} images in parallel...", file=sys.stderr)
+        print(
+            f"Generating {len(raw_directions)} images in parallel...", file=sys.stderr
+        )
         failures = []
 
         # Map output filename -> raw dict for augmenting with debug info
@@ -367,9 +371,15 @@ def main():
             json.dump(raw_directions, f, indent=2)
 
         if failures:
-            print(f"\n{len(failures)}/{len(raw_directions)} failed ({batch_duration}s total)", file=sys.stderr)
+            print(
+                f"\n{len(failures)}/{len(raw_directions)} failed ({batch_duration}s total)",
+                file=sys.stderr,
+            )
             sys.exit(1)
-        print(f"\nAll {len(raw_directions)} images generated ({batch_duration}s total)", file=sys.stderr)
+        print(
+            f"\nAll {len(raw_directions)} images generated ({batch_duration}s total)",
+            file=sys.stderr,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Scope

Group G2 (image) audit — two-pass review on `skills/gen-image`, `skills/gist-image`, `skills/image-explore`, `skills/showboat`. Pass 1 applies claude-md-improver criteria; pass 2 is code-review on the cumulative diff.

## Skills audited

- [x] `gen-image` — changed (argument-hint sync)
- [x] `gist-image` — changed (missing `allowed-tools` frontmatter)
- [x] `image-explore` — changed (drifted-style removal, aspect-ratio list, stale help text)
- [x] `showboat` — audited, no changes

## Changes per skill

### `gen-image`
`argument-hint` listed only 3 flags; the Arguments section documents 6 (`--count`, `--aspect`, `--transparent` were missing). Brought the completion-surface hint in line with the skill's actual contract.

### `gist-image`
Added `allowed-tools: Bash, Read, Write` to the YAML frontmatter. Every other SKILL.md in the repo declares one — `gist-image` was the sole omission. Matches repo convention (`CLAUDE.md` → Skills → Conventions).

### `image-explore`
1. **Dropped a drifted copy of the raccoon style.** `SKILL.md` embedded a quoted base style "same as gen-image" — but the text diverged from the canonical `gen-image/raccoon-style.txt` (pastel background vs magenta chroma-key). Replaced the quote with a link to the source-of-truth file that `generate.py` actually reads. Prevents future silent drift.
2. **Completed the `--aspect` valid-values list.** `4:5`, `5:4`, `21:9` were missing; `gemini-image.sh` accepts them and `gen-image/SKILL.md` documents them.
3. **Fixed stale `--transparent` help text in `generate.py`.** argparse help said "remove background with rembg"; implementation uses ImageMagick `-fuzz -transparent` (and the `remove_background` docstring already explained why rembg was rejected).

### `showboat`
Read through SKILL.md, pandoc-template.html, and every cross-reference (`gist-image` skill, `deployment/surge.md`, `~/go/bin` paths, Playwright Chrome discovery). No stale paths, flags, or tool names. No changes warranted.

## Code-review pass

Self-review on the cumulative diff against upstream/main: CLAUDE.md compliance (frontmatter, no duplication — see "Abstractions: Wait for N=2"), shallow bug scan, historical context, inline-comment alignment. No issues ≥ 80 confidence. Ruff/prettier reformatted unrelated lines on commit; preserved per the repo rule not to fight formatters.

## Test plan

- [ ] `generate.py --transparent --help` shows the ImageMagick description
- [ ] Slash-command autocompletion for `/gen-image` shows all six flags
- [ ] `gist-image` skill loads with declared `allowed-tools`
- [ ] No dead link in `image-explore/SKILL.md` "Default Raccoon Style" section