### PR TITLE
Fix delegate recipe exclude-path bug; note zsh reserved vars

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -59,6 +59,7 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **`/reload-plugins` does NOT restart running MCP server processes.** It re-reads plugin config but leaves live MCP servers alone. To deploy new MCP code: `pkill -f '<server>'` first, THEN `/reload-plugins` (the next MCP tool call respawns the server from the plugin cache). Confirmed against Claude Code's telegram plugin 2026-04-12.
 - **Non-interactive `git rebase -i` via scripted editors.** For programmatic squashes in sessions without a human editor, write todo to `/tmp/rebase-todo.txt` and message to `/tmp/rebase-msg.txt`, then `GIT_SEQUENCE_EDITOR="cp /tmp/rebase-todo.txt" GIT_EDITOR="cp /tmp/rebase-msg.txt" git rebase -i <base>`. Supports `pick`/`fixup`/`reword`/`squash` in one pass. Always `git tag backup HEAD` first — reflog expires.
 - **Session token / context usage** — when asked "how many tokens am I using" or "how much context is left," read `~/.claude/statusline_last_input.json` with `jq`. The statusline script dumps the harness JSON there every turn; grab `.context_window.used_percentage`, `.context_window.context_window_size`, `.cost.total_cost_usd`. Don't guess from transcript length.
+- **zsh reserved array vars**: `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to shell path resolution. Using them as local string vars fails with "inconsistent type for assignment". Use `wt_path`, `file_path`, `dir` etc. instead.
 
 ## Side-Edit: Preview Files in a Side Pane
 

--- a/skills/delegate-to-other-repo/worktree-recipe.md
+++ b/skills/delegate-to-other-repo/worktree-recipe.md
@@ -125,7 +125,12 @@ path="$T/.worktrees/delegated-$slug"
 # branch-independent, per-repo exclude list documented in gitignore(5).
 # It sits in the shared git dir, applies to all worktrees, survives
 # branch switches, and never touches any branch's history.
-git_common=$(git -C "$T" rev-parse --git-common-dir 2>/dev/null)
+# Use --path-format=absolute. Plain `--git-common-dir` returns a path
+# relative to cwd, and the parent skill forbids `cd`, so the append
+# below would land in whatever repo the parent's cwd happens to be
+# in (verified: first dispatch this session wrote to the wrong repo's
+# exclude and required manual cleanup).
+git_common=$(git -C "$T" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
 exclude_file="$git_common/info/exclude"
 if ! grep -qxF '.worktrees/' "$exclude_file" 2>/dev/null; then
   mkdir -p "$git_common/info"


### PR DESCRIPTION
## Summary

Two independent small fixes in the chop-conventions repo:

### 1. `skills/delegate-to-other-repo/worktree-recipe.md`

The recipe used `git -C \"\$T\" rev-parse --git-common-dir`, which returns a path **relative to cwd** — not to `\$T`. Because the parent skill forbids `cd` (parent always uses `git -C <target>`), the subsequent write to `\"\$git_common/info/exclude\"` would land in whatever repo the parent's cwd happened to be in, not the target's git dir.

Verified empirically: first dispatch this session wrote to the wrong repo's `.git/info/exclude` and required manual cleanup.

Fix: switch to `--path-format=absolute --git-common-dir`, with a comment pointing at the hazard.

### 2. `claude-md/global.md`

Add a short bullet under Important Rules noting that `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to zsh path resolution and can't be used as plain string locals (`inconsistent type for assignment`). Suggests `wt_path` / `file_path` / `dir` as safe alternatives.

## Test plan

- [x] `git rev-parse --path-format=absolute --git-common-dir` returns an absolute path from anywhere (quick local check).
- [x] Pre-commit hooks (ruff, biome, prettier, dasel, fast-test) ran clean on the commit.
- [ ] Next delegation run observed to append to the correct `.git/info/exclude`.