### PR TITLE
docs(claude-md): add GH issue signing convention for external repos

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -59,6 +59,19 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **`/reload-plugins` does NOT restart running MCP server processes.** It re-reads plugin config but leaves live MCP servers alone. To deploy new MCP code: `pkill -f '<server>'` first, THEN `/reload-plugins` (the next MCP tool call respawns the server from the plugin cache). Confirmed against Claude Code's telegram plugin 2026-04-12.
 - **Non-interactive `git rebase -i` via scripted editors.** For programmatic squashes in sessions without a human editor, write todo to `/tmp/rebase-todo.txt` and message to `/tmp/rebase-msg.txt`, then `GIT_SEQUENCE_EDITOR="cp /tmp/rebase-todo.txt" GIT_EDITOR="cp /tmp/rebase-msg.txt" git rebase -i <base>`. Supports `pick`/`fixup`/`reword`/`squash` in one pass. Always `git tag backup HEAD` first — reflog expires.
 - **Session token / context usage** — when asked "how many tokens am I using" or "how much context is left," read `~/.claude/statusline_last_input.json` with `jq`. The statusline script dumps the harness JSON there every turn; grab `.context_window.used_percentage`, `.context_window.context_window_size`, `.cost.total_cost_usd`. Don't guess from transcript length.
+- **Signing GitHub issues and comments on external repos.** When filing issues or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), append this signature:
+
+  ```
+  Files with ♥ via [Igor's Claw](https://idvork.in/claw)
+  ```
+
+  This makes the AI-agent origin explicit and links back to Igor's writeup on the claw concept. **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — they're self-authored and attribution is implied.
+
+  **Example issue comment:**
+
+  > Confirmed — `--dangerously-skip-permissions` has intentional carve-outs (sensitive-file writes, outside-cwd writes, shell metachars). Worth a docs update since the flag name implies full bypass. Happy to PR if useful.
+  >
+  > Files with ♥ via [Igor's Claw](https://idvork.in/claw)
 
 ## Side-Edit: Preview Files in a Side Pane
 

--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -66,7 +66,7 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **Signing GitHub issues and comments on external repos.** When filing issues or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), append this signature:
 
   ```
-  @idvorkin — Created w/♥ via [Igor's Claws](https://idvork.in/igors-claws)
+  Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
   ```
 
   This tags Igor for notification, makes the AI-agent origin explicit, and deep-links to the page about his claws. **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — they're self-authored and attribution is implied.
@@ -75,7 +75,7 @@ Just do it - including obvious follow-up actions. Only pause when:
 
   > Confirmed — `--dangerously-skip-permissions` has intentional carve-outs (sensitive-file writes, outside-cwd writes, shell metachars). Worth a docs update since the flag name implies full bypass. Happy to PR if useful.
   >
-  > @idvorkin — Created w/♥ via [Igor's Claws](https://idvork.in/igors-claws)
+  > Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
 - **zsh reserved array vars**: `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to shell path resolution. Using them as local string vars fails with "inconsistent type for assignment". Use `wt_path`, `file_path`, `dir` etc. instead.
 
 ## Side-Edit: Preview Files in a Side Pane

--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -66,16 +66,16 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **Signing GitHub issues and comments on external repos.** When filing issues or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), append this signature:
 
   ```
-  Files with ♥ via [Igor's Claw](https://idvork.in/claw)
+  @idvorkin — Created w/♥ via [Igor's Claws](https://idvork.in/igors-claws)
   ```
 
-  This makes the AI-agent origin explicit and links back to Igor's writeup on the claw concept. **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — they're self-authored and attribution is implied.
+  This tags Igor for notification, makes the AI-agent origin explicit, and deep-links to the page about his claws. **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — they're self-authored and attribution is implied.
 
   **Example issue comment:**
 
   > Confirmed — `--dangerously-skip-permissions` has intentional carve-outs (sensitive-file writes, outside-cwd writes, shell metachars). Worth a docs update since the flag name implies full bypass. Happy to PR if useful.
   >
-  > Files with ♥ via [Igor's Claw](https://idvork.in/claw)
+  > @idvorkin — Created w/♥ via [Igor's Claws](https://idvork.in/igors-claws)
 - **zsh reserved array vars**: `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to shell path resolution. Using them as local string vars fails with "inconsistent type for assignment". Use `wt_path`, `file_path`, `dir` etc. instead.
 
 ## Side-Edit: Preview Files in a Side Pane


### PR DESCRIPTION
## Summary

Adds a global CLAUDE.md rule: when filing GitHub issues or comments on repos **outside** `idvorkin/*` and `idvorkin-ai-tools/*`, append:

```
Files with ♥ via [Igor's Claw](https://idvork.in/claw)
```

Skip the signature on self-authored repos — attribution is implied.

## Why

Makes AI-agent origin explicit on external repos and links to Igor's claw writeup. Keeps self-authored repos noise-free.

## What's in the PR

- One edit to `claude-md/global.md` under **Important Rules**
- Includes an example issue comment so future agents have a concrete pattern to copy