### PR TITLE
docs(claude-md): add GH issue signing convention for external repos

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -63,6 +63,19 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **`/reload-plugins` does NOT restart running MCP server processes.** It re-reads plugin config but leaves live MCP servers alone. To deploy new MCP code: `pkill -f '<server>'` first, THEN `/reload-plugins` (the next MCP tool call respawns the server from the plugin cache). Confirmed against Claude Code's telegram plugin 2026-04-12.
 - **Non-interactive `git rebase -i` via scripted editors.** For programmatic squashes in sessions without a human editor, write todo to `/tmp/rebase-todo.txt` and message to `/tmp/rebase-msg.txt`, then `GIT_SEQUENCE_EDITOR="cp /tmp/rebase-todo.txt" GIT_EDITOR="cp /tmp/rebase-msg.txt" git rebase -i <base>`. Supports `pick`/`fixup`/`reword`/`squash` in one pass. Always `git tag backup HEAD` first — reflog expires.
 - **Session token / context usage** — when asked "how many tokens am I using" or "how much context is left," read `~/.claude/statusline_last_input.json` with `jq`. The statusline script dumps the harness JSON there every turn; grab `.context_window.used_percentage`, `.context_window.context_window_size`, `.cost.total_cost_usd`. Don't guess from transcript length.
+- **Signing GitHub issues and comments on external repos.** When filing issues or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), append this signature:
+
+  ```
+  Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
+  ```
+
+  This tags Igor for notification, makes the AI-agent origin explicit, and deep-links to the page about his claws. **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — they're self-authored and attribution is implied.
+
+  **Example issue comment:**
+
+  > Confirmed — `--dangerously-skip-permissions` has intentional carve-outs (sensitive-file writes, outside-cwd writes, shell metachars). Worth a docs update since the flag name implies full bypass. Happy to PR if useful.
+  >
+  > Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
 - **zsh reserved array vars**: `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to shell path resolution. Using them as local string vars fails with "inconsistent type for assignment". Use `wt_path`, `file_path`, `dir` etc. instead.
 
 ## Side-Edit: Preview Files in a Side Pane


### PR DESCRIPTION
## Summary

When filing issues or comments on repos **outside** `idvorkin/*` and `idvorkin-ai-tools/*`, append:

```
Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
```

Tags @idvorkin for notification, makes AI-agent origin explicit, deep-links to `/igors-claws` ([idvorkin/idvorkin.github.io#518](https://github.com/idvorkin/idvorkin.github.io/pull/518)).

## Relationship to #125

**Supersedes #125.** That PR accumulated 3 signature revisions through merge commits ("Files with ♥" → em-dash variant → compact variant), which blocks GitHub's "Rebase and merge" style. This is a single clean commit off current `main` — rebase-mergeable.

Closing #125 alongside this.

## Note on the claude-review check

Will likely show UNSTABLE because this PR is from a fork (OIDC token policy prevents `id-token: write` from working for fork PRs). The workflow file is correctly configured. Admin-merge bypass or a `pull_request_target` workflow refactor are the two paths to a clean green.