### PR TITLE
docs(claude-md): add rule — close stale PRs/issues yourself

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -75,6 +75,7 @@ Just do it - including obvious follow-up actions. Only pause when:
   > Confirmed — `--dangerously-skip-permissions` has intentional carve-outs (sensitive-file writes, outside-cwd writes, shell metachars). Worth a docs update since the flag name implies full bypass. Happy to PR if useful.
   >
   > — Keeping my human friend @idvorkin in the loop!
+- **Close PRs and issues you opened that become stale or superseded.** If Claude filed a PR or issue and it's no longer relevant (work redirected, approach pivoted, superseded by another PR, spec changed before review), close it yourself with a clear comment explaining why. Don't leave orphan PRs/issues for Igor to clean up — they accumulate and lose context. Always include a pointer to the replacement work (bead ID, superseding PR, or updated design doc).
 - **zsh reserved array vars**: `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to shell path resolution. Using them as local string vars fails with "inconsistent type for assignment". Use `wt_path`, `file_path`, `dir` etc. instead.
 
 ## Side-Edit: Preview Files in a Side Pane


### PR DESCRIPTION
## Summary

Adds a rule to `claude-md/global.md` under "Important Rules": if Claude filed a PR or issue that becomes stale (work redirected, approach pivoted, superseded), close it with a comment + pointer to replacement. Don't leave orphan PRs/issues accumulating.

## Relationship to #124

**Supersedes #124.** That PR picked up a merge commit resolving a global.md conflict with upstream, which blocks GitHub's "Rebase and merge". This is a single clean commit off current `main` — rebase-mergeable.

Closing #124 alongside this — which neatly demonstrates the rule.

## Check note

UNSTABLE state expected because fork-PR (same OIDC limitation as #125, #126 earlier). Admin-merge bypass works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for managing stale or superseded work items, including instructions for adding closure comments and referencing replacement work or updated resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->