### PR TITLE
cost-impact: add hostname, ask destination up front, privacy-guard gists

### DIFF
--- a/skills/cost-impact/SKILL.md
+++ b/skills/cost-impact/SKILL.md
@@ -33,6 +33,23 @@ If the user names a specific day ("yesterday", "last Friday"), compute the
 integer offset from today and pass that — the underlying script is
 window-based, not date-based.
 
+## Ask destination FIRST
+
+**Before running `_impl.py`, ask the user where the report should go:**
+
+> "Where should this go — public gist, or local save to
+> `~/tmp/cost-impact-YYYY-MM-DD.md`?"
+
+Ask this up front so (a) the user doesn't have to context-switch after
+waiting for the script, and (b) the privacy guard below can short-circuit
+the run if a gist is selected and the content is sensitive. The destination
+answer is the only thing that gates how the script's output is routed — it
+does NOT change what `_impl.py` computes.
+
+If the user already has a cost-impact gist they want updated in place, ask
+which gist ID (see "Updating an existing gist" below). Treat an in-place
+edit as a gist publish for the purposes of the privacy guard.
+
 ## How to run
 
 ```bash
@@ -64,15 +81,13 @@ Repos: 11, top 3: activation-energy-game, settings, blog4
 If you see `Actual: $0.00` the window is probably wrong — check that
 `date` shows today and that session JSONLs have fresh timestamps.
 
-## Output destination
+## Routing the output
 
-**After the script writes `/tmp/cost-impact.md`, ask the user** where
-they want it:
+Destination was chosen up front (see "Ask destination FIRST"). After
+`_impl.py` writes `/tmp/cost-impact.md`:
 
-> "Report is in `/tmp/cost-impact.md`. Post to a public gist or save
-> locally to `~/tmp/cost-impact-YYYY-MM-DD.md`?"
-
-**Gist path** (user says gist / g / post it / share it):
+**If the user chose gist: run the privacy guard first (see below). Only if
+the guard passes, publish:**
 
 ```bash
 gh gist create --public \
@@ -82,7 +97,8 @@ gh gist create --public \
 
 Relay the gist URL back.
 
-**Local path** (user says local / l / save / file):
+**If the user chose local save** (always allowed — it's their own disk, no
+privacy check needed):
 
 ```bash
 mkdir -p ~/tmp
@@ -91,16 +107,51 @@ cp /tmp/cost-impact.md ~/tmp/cost-impact-$(date +%Y-%m-%d).md
 
 Relay the absolute path back.
 
+### Updating an existing gist
+
 **If the user already has a cost-impact gist** and the new report
 supersedes it, prefer `gh gist edit <id> /tmp/cost-impact.md` to update
 in place so shared links don't break. Ask which gist to update if you
-don't know the ID.
+don't know the ID. Run the privacy guard before editing — an in-place
+edit to a public gist is a publish.
+
+## Privacy guard (gist destinations only)
+
+Before running `gh gist create` or `gh gist edit` against a public gist,
+**read `/tmp/cost-impact.md` and judge whether the content would leak
+information the user wouldn't want public.** This is assistant judgment, not
+a mechanical check. Look for:
+
+- Repo names that identify private, client, or unreleased projects
+  (anything not already visible on the user's public GitHub profile)
+- PR URLs pointing at private repos
+- Session UUIDs that could correlate with private incidents if cross-referenced
+- Session titles or PR titles that reference secrets, credentials, internal
+  codenames, or people by name
+- Hostnames that reveal internal network naming conventions beyond the
+  user's already-public setup
+
+**If the report looks sensitive: STOP the gist upload.** Do NOT publish.
+Tell the user *what specifically* looked sensitive (cite the repo name,
+PR URL, or line), and offer the local-save path instead:
+
+> "Holding off on the gist — I see `<specific thing>` in the report which
+> looks like it'd expose a private project. Saving locally to
+> `~/tmp/cost-impact-YYYY-MM-DD.md` instead, or want to scrub and retry?"
+
+**Local save is always allowed regardless of sensitivity** — the user's own
+disk is not a publication surface.
+
+When in doubt, prefer refusing the gist. A false-positive refusal costs the
+user one prompt ("go ahead, it's fine") — a false-negative publish can't be
+unsent once the gist URL is indexed.
 
 ## What the report contains
 
 1. **Summary table** — total $, total duration, total turns (main/sub/total),
-   sessions in window, cost breakdown (input/output/cache writes/reads),
-   without-cache reference, cache savings %
+   sessions in window, host (from `socket.gethostname()` — load-bearing
+   provenance when the report is shared out of context), cost breakdown
+   (input/output/cache writes/reads), without-cache reference, cache savings %
 2. **Cost by model** — each model's share of the total
 3. **Per day** — actual $, sessions, main+sub turns, no-cache reference, plus
    a separate daily details table splitting input, output, 1h cache
@@ -129,14 +180,17 @@ Update the table if Anthropic changes published rates.
 ## Hard rules
 
 - **Do NOT** modify `_impl.py` to bake in a specific user's values
-  (repo list, gist ID, plan cost). Keep it generic.
-- **Do NOT** post the report to a gist without asking the user — the
-  report contains session names that may identify private repos.
+  (repo list, gist ID, plan cost, hostname). Keep it generic — the
+  hostname comes from `socket.gethostname()` at runtime, not a constant.
+- **Do NOT** post the report to a gist without running the privacy guard
+  (see "Privacy guard" above). The report contains session names, PR
+  URLs, and repo paths that may identify private projects.
 - **Do NOT** run this on a machine that isn't the user's — it reads
   `~/.claude/projects/` which contains conversation history.
 - **Ask before updating an existing gist in place** — the previous
   version of the report may have been shared with someone, and
   editing it in place will change what they see next time they load it.
+  In-place edits are subject to the same privacy guard as new publishes.
 
 ## Known caveats (surfaced in the report's footnotes)
 

--- a/skills/cost-impact/SKILL.md
+++ b/skills/cost-impact/SKILL.md
@@ -33,22 +33,29 @@ If the user names a specific day ("yesterday", "last Friday"), compute the
 integer offset from today and pass that — the underlying script is
 window-based, not date-based.
 
-## Ask destination FIRST
+## Default flow: save locally, then offer the gist
 
-**Before running `_impl.py`, ask the user where the report should go:**
+**Always save locally first.** Local save is the unconditional default — the
+user's own disk is not a publication surface and needs no approval gate.
+After the local save lands, **ask whether they also want to publish a public
+gist.** If yes, run the privacy guard (see below) and only publish if it
+passes.
 
-> "Where should this go — public gist, or local save to
-> `~/tmp/cost-impact-YYYY-MM-DD.md`?"
+Sequence:
 
-Ask this up front so (a) the user doesn't have to context-switch after
-waiting for the script, and (b) the privacy guard below can short-circuit
-the run if a gist is selected and the content is sensitive. The destination
-answer is the only thing that gates how the script's output is routed — it
-does NOT change what `_impl.py` computes.
+1. Run `_impl.py` (writes `/tmp/cost-impact.md`)
+2. Copy to `~/tmp/cost-impact-YYYY-MM-DD.md` and report the absolute path
+3. Ask: "Want me to also publish this as a public gist?"
+4. If yes → run the privacy guard, then `gh gist create` if it passes
+5. If no → done
 
-If the user already has a cost-impact gist they want updated in place, ask
-which gist ID (see "Updating an existing gist" below). Treat an in-place
-edit as a gist publish for the purposes of the privacy guard.
+**Do not ask about destination up front.** That order forces the user to
+context-switch before the script's output exists; asking *after* the local
+save lets them glance at the file (or its summary) before deciding to share.
+
+If the user has an existing cost-impact gist they want updated in place,
+treat the in-place edit as a publish for privacy-guard purposes — see
+"Updating an existing gist" below.
 
 ## How to run
 
@@ -83,22 +90,9 @@ If you see `Actual: $0.00` the window is probably wrong — check that
 
 ## Routing the output
 
-Destination was chosen up front (see "Ask destination FIRST"). After
-`_impl.py` writes `/tmp/cost-impact.md`:
+After `_impl.py` writes `/tmp/cost-impact.md`:
 
-**If the user chose gist: run the privacy guard first (see below). Only if
-the guard passes, publish:**
-
-```bash
-gh gist create --public \
-  -d "Claude cost impact YYYY-MM-DD (N-day window)" \
-  /tmp/cost-impact.md
-```
-
-Relay the gist URL back.
-
-**If the user chose local save** (always allowed — it's their own disk, no
-privacy check needed):
+**Step 1 — Save locally (always, no questions):**
 
 ```bash
 mkdir -p ~/tmp
@@ -106,6 +100,18 @@ cp /tmp/cost-impact.md ~/tmp/cost-impact-$(date +%Y-%m-%d).md
 ```
 
 Relay the absolute path back.
+
+**Step 2 — Ask if they want a public gist as well.** Only if yes, run the
+privacy guard (see below). If the guard passes, publish:
+
+```bash
+gh gist create --public \
+  -d "Claude cost impact YYYY-MM-DD (N-day window)" \
+  /tmp/cost-impact.md
+```
+
+Relay the gist URL back. If they decline the gist or the guard refuses,
+the local save from Step 1 is the final artifact — no further action.
 
 ### Updating an existing gist
 

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -10,6 +10,7 @@ import argparse
 import concurrent.futures
 import json
 import re
+import socket
 import subprocess
 import sys
 from collections import defaultdict
@@ -293,11 +294,12 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
       tot_actual, tot_naive, tot_comps, tot_by_model, tot_dur_min,
       tot_main_turns, tot_sub_turns, per_day, by_repo, repo_totals, unknown_models
     """
+    hostname = socket.gethostname()
     L = []
     L.append(f"# Claude Cost Impact — {start_date} → {today}")
     L.append("")
     L.append(
-        f"*Generated {datetime.now().strftime('%Y-%m-%d %H:%M')} · "
+        f"*Generated {datetime.now().strftime('%Y-%m-%d %H:%M')} on `{hostname}` · "
         f"{days_back}-day window · Includes main sessions + subagents · "
         f"Pricing from [platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing)*"
     )
@@ -322,6 +324,7 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
         L.append(
             f"- Window: {start_date} → {today} ({days_back} day{'s' if days_back != 1 else ''})"
         )
+        L.append(f"- Host: `{hostname}`")
         if unknown_models:
             L.append(
                 f"- ⚠ Saw {sum(unknown_models.values())} turn(s) with unpriced models: "
@@ -339,6 +342,7 @@ def build_report(entries, bucket_meta, days_back, start_date, today, titles):
         f"| **Total turns** (main / sub / total) | **{tot_main_turns:,} / {tot_sub_turns:,} / {tot_main_turns + tot_sub_turns:,}** |"
     )
     L.append(f"| Sessions in window | {len(entries)} |")
+    L.append(f"| Host | `{hostname}` |")
     L.append(f"| — Input | ${tot_comps['inp']:,.2f} |")
     L.append(f"| — Output | ${tot_comps['out']:,.2f} |")
     L.append(f"| — Cache writes (1h TTL) | ${tot_comps['c1h']:,.2f} |")


### PR DESCRIPTION
## Summary

Three related changes to the `cost-impact` skill, driven by a session where the cost report was shared as a public gist and the missing hostname / awkward post-run prompt / privacy concerns all surfaced at once.

- **Hostname in the report.** `socket.gethostname()` is now embedded in both the italic generation line and a new `Host` row in the Summary table (and in the empty-window bullet list). When the report is shared out of context — gist, Slack, email — hostname is load-bearing provenance. Kept generic in `_impl.py`: no hardcoded values, per the skill's existing "Hard rules".
- **Destination asked up front, not after.** The gist-vs-local prompt was previously after `_impl.py` finished writing `/tmp/cost-impact.md`, forcing the user to context-switch post-wait. Now it's the opening question, which also lets the privacy guard short-circuit the run before any gist publish.
- **Privacy guard on gist uploads.** Before `gh gist create` or `gh gist edit` against a public gist, the assistant reviews `/tmp/cost-impact.md` for content that would leak private repos, PR URLs pointing at private projects, sensitive session titles, or internal hostnames. Assistant judgment at runtime — not a mechanical check in `_impl.py` (per the task spec). If sensitive, refuse the gist, cite the specific concern, offer local save. Local save is always allowed — it's the user's own disk.

## Test plan

- [x] `python3 -m unittest skills.cost-impact.test_impl` — all 44 tests pass (`build_report` signature unchanged)
- [x] Smoke-rendered a synthetic report; verified hostname appears in italic line + Summary table
- [ ] Run `/cost-impact` on a real session and confirm the new opening prompt flow + privacy-guard language feels right in practice

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Report destination must now be selected before generation
  * Privacy guard checks for sensitive content before publishing to public gist
  * Cost-impact reports now include the originating hostname

* **Documentation**
  * Updated workflow guides and gist handling procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->