### PR TITLE
feat(harden-telegram): telegram_debug.py --send-reply and --react

### DIFF
--- a/skills/harden-telegram/tools/telegram_debug.py
+++ b/skills/harden-telegram/tools/telegram_debug.py
@@ -1493,6 +1493,7 @@ REACTION_WHITELIST: frozenset[str] = frozenset(
         "\U0001f64a",  # 🙊
         "\U0001f60e",  # 😎
         "\U0001f47e",  # 👾
+        "\U0001f5d1",  # 🗑  (used by larry-bead cancel)
     }
 )
 

--- a/skills/harden-telegram/tools/telegram_debug.py
+++ b/skills/harden-telegram/tools/telegram_debug.py
@@ -8,6 +8,8 @@ Usage:
     python3 telegram_debug.py --tail 50      # More log lines (default 20)
     python3 telegram_debug.py --json --tail 100 | jq '.server_log[-5:]'
     python3 telegram_debug.py --doctor       # Validate two-process chain end-to-end
+    python3 telegram_debug.py --send-reply "hi" --reply-to 42 --chat-id 123  # Threaded reply (prints new message_id)
+    python3 telegram_debug.py --react "\U0001f44d" --message-id 42 --chat-id 123  # Set reaction
 """
 
 import argparse
@@ -842,8 +844,7 @@ def _doctor_check_server_ts(report: DoctorReport) -> None:
         if orphans:
             pids_str = ", ".join(str(b["pid"]) for b in orphans)
             report.warn(
-                f"{len(orphans)} orphaned bridge(s): {pids_str} — "
-                "owning Claude is gone"
+                f"{len(orphans)} orphaned bridge(s): {pids_str} — owning Claude is gone"
             )
         return
 
@@ -864,9 +865,7 @@ def _doctor_check_server_ts(report: DoctorReport) -> None:
         )
 
     if others:
-        summary = ", ".join(
-            f"{b['pid']}→claude:{b['owning_claude']}" for b in others
-        )
+        summary = ", ".join(f"{b['pid']}→claude:{b['owning_claude']}" for b in others)
         report.note(
             f"{len(others)} bridge(s) in other Claude sessions: {summary} — ignored"
         )
@@ -893,15 +892,13 @@ def _doctor_check_session_subscription(report: DoctorReport) -> None:
     our_claude = _find_owning_claude(os.getpid())
     if our_claude is None:
         report.note(
-            "doctor not running inside a Claude session — "
-            "subscription check skipped"
+            "doctor not running inside a Claude session — subscription check skipped"
         )
         return
     argv = _read_proc_cmdline(our_claude)
     if argv is None:
         report.warn(
-            f"could not read /proc/{our_claude}/cmdline — "
-            "subscription check skipped"
+            f"could not read /proc/{our_claude}/cmdline — subscription check skipped"
         )
         return
     if session_subscribed_to_telegram(argv):
@@ -1422,6 +1419,245 @@ def send_direct(text: str, chat_id: str | None = None) -> int:
     return 0
 
 
+# Telegram's fixed reaction whitelist (Bot API setMessageReaction).
+# Source: https://core.telegram.org/bots/api#reactiontypeemoji — free-tier bots
+# may only set reactions drawn from this set. Non-whitelisted emoji return
+# HTTP 400 "REACTION_INVALID". Mirrors server.ts's `react` tool, which today
+# delegates validation to Telegram; we validate client-side so the CLI can
+# fail loudly without a network round-trip.
+REACTION_WHITELIST: frozenset[str] = frozenset(
+    {
+        "\U0001f44d",  # 👍
+        "\U0001f44e",  # 👎
+        "\u2764",  # ❤
+        "\U0001f525",  # 🔥
+        "\U0001f970",  # 🥰
+        "\U0001f44f",  # 👏
+        "\U0001f60a",  # 😊
+        "\U0001f914",  # 🤔
+        "\U0001f92f",  # 🤯
+        "\U0001f631",  # 😱
+        "\U0001f92c",  # 🤬
+        "\U0001f622",  # 😢
+        "\U0001f389",  # 🎉
+        "\U0001f929",  # 🤩
+        "\U0001f92e",  # 🤮
+        "\U0001f4a9",  # 💩
+        "\U0001f64f",  # 🙏
+        "\U0001f44c",  # 👌
+        "\U0001f54a",  # 🕊
+        "\U0001f921",  # 🤡
+        "\U0001f971",  # 🥱
+        "\U0001f974",  # 🥴
+        "\U0001f60d",  # 😍
+        "\U0001f433",  # 🐳
+        "\u2764\u200d\U0001f525",  # ❤‍🔥
+        "\U0001f31a",  # 🌚
+        "\U0001f32d",  # 🌭
+        "\U0001f4af",  # 💯
+        "\U0001f923",  # 🤣
+        "\u26a1",  # ⚡
+        "\U0001f34c",  # 🍌
+        "\U0001f3c6",  # 🏆
+        "\U0001f494",  # 💔
+        "\U0001f928",  # 🤨
+        "\U0001f610",  # 😐
+        "\U0001f353",  # 🍓
+        "\U0001f37e",  # 🍾
+        "\U0001f48b",  # 💋
+        "\U0001f595",  # 🖕
+        "\U0001f608",  # 😈
+        "\U0001f634",  # 😴
+        "\U0001f62d",  # 😭
+        "\U0001f913",  # 🤓
+        "\U0001f47b",  # 👻
+        "\U0001f468\u200d\U0001f4bb",  # 👨‍💻
+        "\U0001f440",  # 👀
+        "\U0001f383",  # 🎃
+        "\U0001f648",  # 🙈
+        "\U0001f607",  # 😇
+        "\U0001f628",  # 😨
+        "\U0001f91d",  # 🤝
+        "\u270d",  # ✍
+        "\U0001f917",  # 🤗
+        "\U0001fae1",  # 🫡
+        "\U0001f385",  # 🎅
+        "\U0001f384",  # 🎄
+        "\u2603",  # ☃
+        "\U0001f485",  # 💅
+        "\U0001f92a",  # 🤪
+        "\U0001f5ff",  # 🗿
+        "\U0001f36f",  # 🍯
+        "\U0001f483",  # 💃
+        "\U0001f62e\u200d\U0001f4a8",  # 😮‍💨
+        "\U0001f64a",  # 🙊
+        "\U0001f60e",  # 😎
+        "\U0001f47e",  # 👾
+    }
+)
+
+
+def build_reply_request(
+    token: str,
+    chat_id: str,
+    text: str,
+    reply_to_message_id: int,
+) -> tuple[str, bytes]:
+    """Build (url, body) for a threaded sendMessage via Bot API.
+
+    Pure — no network, no token leak. Unlike build_direct_request(), this
+    does NOT auto-tag with [direct-send]: replies route through the normal
+    conversation and should read as ordinary bot messages.
+    """
+    import urllib.parse
+
+    url = f"{TELEGRAM_API_BASE}/bot{token}/sendMessage"
+    body = urllib.parse.urlencode(
+        {
+            "chat_id": str(chat_id),
+            "text": text,
+            "reply_to_message_id": str(int(reply_to_message_id)),
+        }
+    ).encode()
+    return url, body
+
+
+def build_react_request(
+    token: str,
+    chat_id: str,
+    message_id: int,
+    emoji: str,
+) -> tuple[str, bytes]:
+    """Build (url, body) for a setMessageReaction call.
+
+    Telegram's setMessageReaction takes `reaction` as a JSON array — we
+    urlencode the single-element JSON array inline.
+    """
+    import urllib.parse
+
+    url = f"{TELEGRAM_API_BASE}/bot{token}/setMessageReaction"
+    reaction_json = json.dumps([{"type": "emoji", "emoji": emoji}])
+    body = urllib.parse.urlencode(
+        {
+            "chat_id": str(chat_id),
+            "message_id": str(int(message_id)),
+            "reaction": reaction_json,
+        }
+    ).encode()
+    return url, body
+
+
+def parse_sent_message_id(response_body: str) -> int | None:
+    """Extract `result.message_id` from a Telegram sendMessage JSON response.
+
+    Returns None on malformed input — caller decides whether that's fatal.
+    """
+    try:
+        payload = json.loads(response_body)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    result = payload.get("result")
+    if not isinstance(result, dict):
+        return None
+    mid = result.get("message_id")
+    try:
+        return int(mid)
+    except (TypeError, ValueError):
+        return None
+
+
+def send_reply(text: str, chat_id: str, reply_to: int) -> int:
+    """Post a threaded reply via Bot API. Prints new message_id on success.
+
+    Unlike send_direct(), both chat_id and reply_to are REQUIRED — this is
+    an explicit-threading operation, not an emergency broadcast.
+    """
+    import urllib.request
+
+    try:
+        token = _read_bot_token()
+    except RuntimeError as e:
+        print(f"send-reply failed: {e}", file=sys.stderr)
+        return 1
+
+    if not chat_id:
+        print("send-reply failed: --chat-id is required", file=sys.stderr)
+        return 1
+
+    url, data = build_reply_request(token, chat_id, text, reply_to)
+    try:
+        with urllib.request.urlopen(url, data=data, timeout=10) as resp:
+            body = resp.read().decode()
+            if resp.status != 200:
+                print(
+                    f"send-reply HTTP {resp.status}: {_redact(body, token)}",
+                    file=sys.stderr,
+                )
+                return 1
+    except Exception as e:
+        print(f"send-reply failed: {_redact(str(e), token)}", file=sys.stderr)
+        return 1
+
+    new_mid = parse_sent_message_id(body)
+    if new_mid is None:
+        # Telegram returned 200 but we couldn't parse the id. The message
+        # likely landed; still, callers who pipe stdout into a pipeline
+        # need to know the contract wasn't fully met.
+        print(
+            f"send-reply succeeded but could not parse message_id from response: {body[:200]}",
+            file=sys.stderr,
+        )
+        return 1
+    print(new_mid)
+    return 0
+
+
+def set_reaction(emoji: str, chat_id: str, message_id: int) -> int:
+    """Set a single-emoji reaction on a message via Bot API.
+
+    Validates `emoji` against REACTION_WHITELIST before any network call so
+    the operator gets a fast, obvious error on typos / non-whitelist picks
+    instead of an opaque HTTP 400 from Telegram.
+    """
+    import urllib.request
+
+    if emoji not in REACTION_WHITELIST:
+        print(
+            f"react failed: emoji {emoji!r} is not in Telegram's reaction whitelist",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        token = _read_bot_token()
+    except RuntimeError as e:
+        print(f"react failed: {e}", file=sys.stderr)
+        return 1
+
+    if not chat_id:
+        print("react failed: --chat-id is required", file=sys.stderr)
+        return 1
+
+    url, data = build_react_request(token, chat_id, message_id, emoji)
+    try:
+        with urllib.request.urlopen(url, data=data, timeout=10) as resp:
+            body = resp.read().decode()
+            if resp.status != 200:
+                print(
+                    f"react HTTP {resp.status}: {_redact(body, token)}",
+                    file=sys.stderr,
+                )
+                return 1
+    except Exception as e:
+        print(f"react failed: {_redact(str(e), token)}", file=sys.stderr)
+        return 1
+
+    print(f"reacted {emoji} on chat_id={chat_id} message_id={message_id}")
+    return 0
+
+
 def main():
     parser = argparse.ArgumentParser(description="Telegram MCP diagnostic tool")
     parser.add_argument("--json", action="store_true", help="JSON output (pipe to jq)")
@@ -1449,13 +1685,69 @@ def main():
         help="EMERGENCY DIRECT-SEND via Telegram Bot API — bypasses MCP entirely. Use when server.ts is down and you still need to reach Igor. Message is auto-tagged with [direct-send] so it's visually distinct in Telegram. Runs alone; ignores --doctor/--paths if combined.",
     )
     parser.add_argument(
+        "--send-reply",
+        dest="send_reply",
+        metavar="TEXT",
+        help="Post a threaded reply via Bot API. Partners with --reply-to and --chat-id (both required). Prints the new message_id on success. Unlike --direct-send, output is NOT tagged — threads as a normal bot reply.",
+    )
+    parser.add_argument(
+        "--reply-to",
+        dest="reply_to",
+        type=int,
+        help="Message_id to thread under when using --send-reply (required).",
+    )
+    parser.add_argument(
+        "--react",
+        dest="react",
+        metavar="EMOJI",
+        help="Set an emoji reaction on a Telegram message via Bot API setMessageReaction. Partners with --message-id and --chat-id (both required). Emoji must be in Telegram's reaction whitelist.",
+    )
+    parser.add_argument(
+        "--message-id",
+        dest="message_id",
+        type=int,
+        help="Message_id to react to when using --react (required).",
+    )
+    parser.add_argument(
         "--chat-id",
-        help="Target chat_id for --direct-send (defaults to last inbound chat_id from inbound.db)",
+        help="Target chat_id for --direct-send / --send-reply / --react. Defaults to the last inbound chat_id from inbound.db for --direct-send; required explicitly for --send-reply and --react.",
     )
     args = parser.parse_args()
 
+    # Enforce top-level action exclusivity. We do this manually (rather than
+    # via argparse's add_mutually_exclusive_group) so the error message names
+    # every action in one place and keeps each flag a simple value flag.
+    actions = {
+        "--doctor": args.doctor,
+        "--paths": args.paths,
+        "--direct-send": args.direct_send is not None,
+        "--send-reply": args.send_reply is not None,
+        "--react": args.react is not None,
+    }
+    active = [name for name, on in actions.items() if on]
+    if len(active) > 1:
+        parser.error(f"only one top-level action allowed; got {', '.join(active)}")
+
     if args.direct_send is not None:
         sys.exit(send_direct(args.direct_send, chat_id=args.chat_id))
+
+    if args.send_reply is not None:
+        if args.reply_to is None:
+            parser.error("--send-reply requires --reply-to <message-id>")
+        if not args.chat_id:
+            parser.error("--send-reply requires --chat-id <chat-id>")
+        sys.exit(
+            send_reply(args.send_reply, chat_id=args.chat_id, reply_to=args.reply_to)
+        )
+
+    if args.react is not None:
+        if args.message_id is None:
+            parser.error("--react requires --message-id <message-id>")
+        if not args.chat_id:
+            parser.error("--react requires --chat-id <chat-id>")
+        sys.exit(
+            set_reaction(args.react, chat_id=args.chat_id, message_id=args.message_id)
+        )
 
     if args.doctor:
         sys.exit(run_doctor())

--- a/skills/harden-telegram/tools/test_telegram_debug.py
+++ b/skills/harden-telegram/tools/test_telegram_debug.py
@@ -543,6 +543,13 @@ class TestReactionWhitelist(unittest.TestCase):
         for emoji in ("👍", "🎉", "👀", "🫡", "🔥", "❤"):
             self.assertIn(emoji, REACTION_WHITELIST)
 
+    def test_contains_larry_bead_consumer_reactions(self):
+        # These three are used by larry-bead (igor2) — capture (✍), close (🏆),
+        # cancel (🗑). Regressing any of them is a silent consumer break since
+        # the client-side rejection fires before any Bot API round-trip.
+        for emoji in ("\u270d", "\U0001f3c6", "\U0001f5d1"):  # ✍ 🏆 🗑
+            self.assertIn(emoji, REACTION_WHITELIST)
+
 
 class TestParseSentMessageId(unittest.TestCase):
     def test_happy_path(self):

--- a/skills/harden-telegram/tools/test_telegram_debug.py
+++ b/skills/harden-telegram/tools/test_telegram_debug.py
@@ -14,28 +14,35 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from telegram_debug import (  # noqa: E402
+    REACTION_WHITELIST,
     _default_chat_id,
     _find_owning_claude,
     _read_bot_token,
     _redact,
     build_direct_request,
+    build_react_request,
+    build_reply_request,
     classify_bridges,
     parse_env_token,
     parse_proc_stat,
+    parse_sent_message_id,
     session_subscribed_to_telegram,
 )
 
 
 def make_stat_reader(table: dict[int, tuple[str, int]]):
     """Build a fake stat reader from a {pid: (comm, ppid)} table."""
+
     def reader(pid: int):
         return table.get(pid)
+
     return reader
 
 
 def make_alive(alive_pids: set[int]):
     def is_alive(pid: int) -> bool:
         return pid in alive_pids
+
     return is_alive
 
 
@@ -85,7 +92,9 @@ class TestFindOwningClaude(unittest.TestCase):
             100: ("bun", 99),
             99: ("claude", 1),
         }
-        self.assertEqual(_find_owning_claude(100, stat_reader=make_stat_reader(table)), 99)
+        self.assertEqual(
+            _find_owning_claude(100, stat_reader=make_stat_reader(table)), 99
+        )
 
     def test_grandchild_through_shell(self):
         table = {
@@ -93,7 +102,9 @@ class TestFindOwningClaude(unittest.TestCase):
             150: ("bash", 99),
             99: ("claude", 1),
         }
-        self.assertEqual(_find_owning_claude(200, stat_reader=make_stat_reader(table)), 99)
+        self.assertEqual(
+            _find_owning_claude(200, stat_reader=make_stat_reader(table)), 99
+        )
 
     def test_no_claude_ancestor(self):
         table = {
@@ -118,7 +129,9 @@ class TestFindOwningClaude(unittest.TestCase):
             200: ("bash", 100),
             100: ("claude", 1),
         }
-        self.assertEqual(_find_owning_claude(300, stat_reader=make_stat_reader(table)), 250)
+        self.assertEqual(
+            _find_owning_claude(300, stat_reader=make_stat_reader(table)), 250
+        )
 
     def test_matches_claude_code_shim(self):
         # Linux truncates comm to 15 chars; launchers like `claude-code` or
@@ -127,7 +140,9 @@ class TestFindOwningClaude(unittest.TestCase):
             100: ("bun", 99),
             99: ("claude-code", 1),
         }
-        self.assertEqual(_find_owning_claude(100, stat_reader=make_stat_reader(table)), 99)
+        self.assertEqual(
+            _find_owning_claude(100, stat_reader=make_stat_reader(table)), 99
+        )
 
     def test_loop_guard(self):
         # Impossible in practice, but a pid-reuse race could in theory produce
@@ -254,9 +269,7 @@ class TestClassifyBridges(unittest.TestCase):
 class TestSessionSubscribedToTelegram(unittest.TestCase):
     def test_plain_claude_is_not_subscribed(self):
         self.assertFalse(
-            session_subscribed_to_telegram(
-                ["claude", "--dangerously-skip-permissions"]
-            )
+            session_subscribed_to_telegram(["claude", "--dangerously-skip-permissions"])
         )
 
     def test_channels_flag_with_telegram_plugin(self):
@@ -305,9 +318,7 @@ class TestSessionSubscribedToTelegram(unittest.TestCase):
 
     def test_channels_flag_with_no_value_is_ignored(self):
         # Trailing --channels with nothing after it shouldn't crash or match.
-        self.assertFalse(
-            session_subscribed_to_telegram(["claude", "--channels"])
-        )
+        self.assertFalse(session_subscribed_to_telegram(["claude", "--channels"]))
 
     def test_empty_argv(self):
         self.assertFalse(session_subscribed_to_telegram([]))
@@ -318,14 +329,10 @@ class TestParseEnvToken(unittest.TestCase):
         self.assertEqual(parse_env_token("TELEGRAM_BOT_TOKEN=123:abc\n"), "123:abc")
 
     def test_double_quoted(self):
-        self.assertEqual(
-            parse_env_token('TELEGRAM_BOT_TOKEN="123:abc"\n'), "123:abc"
-        )
+        self.assertEqual(parse_env_token('TELEGRAM_BOT_TOKEN="123:abc"\n'), "123:abc")
 
     def test_single_quoted(self):
-        self.assertEqual(
-            parse_env_token("TELEGRAM_BOT_TOKEN='123:abc'\n"), "123:abc"
-        )
+        self.assertEqual(parse_env_token("TELEGRAM_BOT_TOKEN='123:abc'\n"), "123:abc")
 
     def test_export_prefix(self):
         # `.env` files copied from shell profiles often carry `export`.
@@ -334,9 +341,7 @@ class TestParseEnvToken(unittest.TestCase):
         )
 
     def test_trailing_whitespace(self):
-        self.assertEqual(
-            parse_env_token("TELEGRAM_BOT_TOKEN=123:abc   \n"), "123:abc"
-        )
+        self.assertEqual(parse_env_token("TELEGRAM_BOT_TOKEN=123:abc   \n"), "123:abc")
 
     def test_inline_comment_unquoted(self):
         # Unquoted values take a `#` as an inline comment boundary.
@@ -347,9 +352,7 @@ class TestParseEnvToken(unittest.TestCase):
 
     def test_hash_inside_quoted_value_kept(self):
         # Quoted values are literal — no comment stripping.
-        self.assertEqual(
-            parse_env_token('TELEGRAM_BOT_TOKEN="abc#def"\n'), "abc#def"
-        )
+        self.assertEqual(parse_env_token('TELEGRAM_BOT_TOKEN="abc#def"\n'), "abc#def")
 
     def test_ignores_comment_lines_before_match(self):
         text = "# leading comment\nOTHER_VAR=foo\nTELEGRAM_BOT_TOKEN=123:abc\n"
@@ -357,9 +360,7 @@ class TestParseEnvToken(unittest.TestCase):
 
     def test_substring_collision_rejected(self):
         # A different var whose name *contains* TELEGRAM_BOT_TOKEN must not match.
-        self.assertIsNone(
-            parse_env_token("OLD_TELEGRAM_BOT_TOKEN=stale\n")
-        )
+        self.assertIsNone(parse_env_token("OLD_TELEGRAM_BOT_TOKEN=stale\n"))
 
     def test_missing_returns_none(self):
         self.assertIsNone(parse_env_token("OTHER=x\n"))
@@ -397,9 +398,7 @@ class TestDefaultChatId(unittest.TestCase):
         tmp = tempfile.TemporaryDirectory()
         db = Path(tmp.name) / "inbound.db"
         con = sqlite3.connect(db)
-        con.execute(
-            "CREATE TABLE inbound (id INTEGER PRIMARY KEY, chat_id INTEGER)"
-        )
+        con.execute("CREATE TABLE inbound (id INTEGER PRIMARY KEY, chat_id INTEGER)")
         con.executemany("INSERT INTO inbound (chat_id) VALUES (?)", rows)
         con.commit()
         con.close()
@@ -464,6 +463,7 @@ class TestBuildDirectRequest(unittest.TestCase):
         _, body = build_direct_request("T", "1", "héllo 🚨")
         # Body must decode back to the same string after urldecode.
         import urllib.parse
+
         decoded = dict(urllib.parse.parse_qsl(body.decode()))
         self.assertEqual(decoded["text"], "[direct-send] héllo 🚨")
 
@@ -487,6 +487,243 @@ class TestRedact(unittest.TestCase):
 
     def test_empty_token_is_noop(self):
         self.assertEqual(_redact("anything", ""), "anything")
+
+
+class TestBuildReplyRequest(unittest.TestCase):
+    def test_url_shape(self):
+        url, _ = build_reply_request("T0KEN", "123", "hi", 42)
+        self.assertEqual(url, "https://api.telegram.org/botT0KEN/sendMessage")
+
+    def test_no_direct_send_tag(self):
+        # Unlike build_direct_request, --send-reply must NOT auto-tag. This
+        # is a contract: replies route through the normal conversation.
+        _, body = build_reply_request("T", "123", "hello", 42)
+        self.assertNotIn(b"direct-send", body)
+        self.assertIn(b"text=hello", body)
+
+    def test_reply_to_message_id_present(self):
+        _, body = build_reply_request("T", "123", "hi", 42)
+        self.assertIn(b"reply_to_message_id=42", body)
+
+    def test_reply_to_coerced_to_int(self):
+        # Guards against accidentally allowing arbitrary strings through
+        # as reply_to_message_id — int() will raise on bad input.
+        with self.assertRaises((TypeError, ValueError)):
+            build_reply_request("T", "1", "hi", "not-an-int")  # type: ignore[arg-type]
+
+    def test_unicode_roundtrips(self):
+        import urllib.parse
+
+        _, body = build_reply_request("T", "1", "héllo 🎉", 7)
+        decoded = dict(urllib.parse.parse_qsl(body.decode()))
+        self.assertEqual(decoded["text"], "héllo 🎉")
+
+
+class TestBuildReactRequest(unittest.TestCase):
+    def test_url_shape(self):
+        url, _ = build_react_request("T0KEN", "123", 42, "👍")
+        self.assertEqual(url, "https://api.telegram.org/botT0KEN/setMessageReaction")
+
+    def test_reaction_json_shape(self):
+        import urllib.parse
+
+        _, body = build_react_request("T", "123", 42, "🔥")
+        decoded = dict(urllib.parse.parse_qsl(body.decode()))
+        self.assertEqual(decoded["chat_id"], "123")
+        self.assertEqual(decoded["message_id"], "42")
+        # `reaction` is a JSON-encoded list per Bot API.
+        import json as _json
+
+        reaction = _json.loads(decoded["reaction"])
+        self.assertEqual(reaction, [{"type": "emoji", "emoji": "🔥"}])
+
+
+class TestReactionWhitelist(unittest.TestCase):
+    def test_contains_common_reactions(self):
+        for emoji in ("👍", "🎉", "👀", "🫡", "🔥", "❤"):
+            self.assertIn(emoji, REACTION_WHITELIST)
+
+
+class TestParseSentMessageId(unittest.TestCase):
+    def test_happy_path(self):
+        body = '{"ok":true,"result":{"message_id":555,"date":1}}'
+        self.assertEqual(parse_sent_message_id(body), 555)
+
+    def test_missing_result(self):
+        self.assertIsNone(parse_sent_message_id('{"ok":false}'))
+
+    def test_missing_message_id(self):
+        self.assertIsNone(parse_sent_message_id('{"ok":true,"result":{}}'))
+
+    def test_malformed_json(self):
+        self.assertIsNone(parse_sent_message_id("not-json"))
+
+    def test_empty_string(self):
+        self.assertIsNone(parse_sent_message_id(""))
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object urllib.request.urlopen yields."""
+
+    def __init__(self, *, status: int = 200, body: str = "{}"):
+        self.status = status
+        self._body = body.encode()
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _patch_token(monkey_env: dict, token: str = "T0KEN"):
+    """Write a .env file and point HOME at it for _read_bot_token to find."""
+    tmp = tempfile.TemporaryDirectory()
+    home = Path(tmp.name)
+    env_dir = home / ".claude" / "channels" / "telegram"
+    env_dir.mkdir(parents=True)
+    (env_dir / ".env").write_text(f"TELEGRAM_BOT_TOKEN={token}\n")
+    monkey_env["HOME"] = str(home)
+    return tmp
+
+
+class TestSendReply(unittest.TestCase):
+    def setUp(self):
+        self._old_home = os.environ.get("HOME")
+        self._tmp = _patch_token(os.environ)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        if self._old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._old_home
+
+    def test_success_prints_new_message_id(self):
+        import io
+        import telegram_debug as td
+
+        captured = {}
+
+        def fake_urlopen(url, data=None, timeout=0):
+            captured["url"] = url
+            captured["data"] = data
+            return _FakeResponse(
+                status=200,
+                body='{"ok":true,"result":{"message_id":777,"date":1}}',
+            )
+
+        old_urlopen = __import__("urllib.request").request.urlopen
+        __import__("urllib.request").request.urlopen = fake_urlopen
+        try:
+            buf = io.StringIO()
+            old_stdout = sys.stdout
+            sys.stdout = buf
+            try:
+                rc = td.send_reply("hi there", chat_id="999", reply_to=42)
+            finally:
+                sys.stdout = old_stdout
+        finally:
+            __import__("urllib.request").request.urlopen = old_urlopen
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf.getvalue().strip(), "777")
+        # Sanity: the token was read and the URL includes sendMessage.
+        self.assertIn("/sendMessage", captured["url"])
+        self.assertIn(b"reply_to_message_id=42", captured["data"])
+
+    def test_missing_token_fails(self):
+        import telegram_debug as td
+
+        # Point HOME at an empty dir so _read_bot_token raises.
+        empty = tempfile.TemporaryDirectory()
+        old_home = os.environ["HOME"]
+        os.environ["HOME"] = empty.name
+        try:
+            rc = td.send_reply("hi", chat_id="999", reply_to=1)
+        finally:
+            os.environ["HOME"] = old_home
+            empty.cleanup()
+        self.assertEqual(rc, 1)
+
+    def test_missing_chat_id_fails(self):
+        import telegram_debug as td
+
+        rc = td.send_reply("hi", chat_id="", reply_to=1)
+        self.assertEqual(rc, 1)
+
+
+class TestSetReaction(unittest.TestCase):
+    def setUp(self):
+        self._old_home = os.environ.get("HOME")
+        self._tmp = _patch_token(os.environ)
+
+    def tearDown(self):
+        self._tmp.cleanup()
+        if self._old_home is None:
+            os.environ.pop("HOME", None)
+        else:
+            os.environ["HOME"] = self._old_home
+
+    def test_success_path(self):
+        import telegram_debug as td
+
+        captured = {}
+
+        def fake_urlopen(url, data=None, timeout=0):
+            captured["url"] = url
+            captured["data"] = data
+            return _FakeResponse(status=200, body='{"ok":true,"result":true}')
+
+        old_urlopen = __import__("urllib.request").request.urlopen
+        __import__("urllib.request").request.urlopen = fake_urlopen
+        try:
+            rc = td.set_reaction("👍", chat_id="999", message_id=42)
+        finally:
+            __import__("urllib.request").request.urlopen = old_urlopen
+
+        self.assertEqual(rc, 0)
+        self.assertIn("/setMessageReaction", captured["url"])
+
+    def test_emoji_not_in_whitelist_fails_before_network(self):
+        import telegram_debug as td
+
+        # If this ever reaches the network, it means whitelist validation
+        # was skipped — guard that by making urlopen explode.
+        def poison(*a, **k):
+            raise AssertionError("urlopen must not be called for whitelist rejection")
+
+        old_urlopen = __import__("urllib.request").request.urlopen
+        __import__("urllib.request").request.urlopen = poison
+        try:
+            # Picked a plausible but non-whitelisted emoji.
+            rc = td.set_reaction("🧇", chat_id="999", message_id=42)
+        finally:
+            __import__("urllib.request").request.urlopen = old_urlopen
+
+        self.assertEqual(rc, 1)
+
+    def test_missing_token_fails(self):
+        import telegram_debug as td
+
+        empty = tempfile.TemporaryDirectory()
+        old_home = os.environ["HOME"]
+        os.environ["HOME"] = empty.name
+        try:
+            rc = td.set_reaction("👍", chat_id="999", message_id=42)
+        finally:
+            os.environ["HOME"] = old_home
+            empty.cleanup()
+        self.assertEqual(rc, 1)
+
+    def test_missing_chat_id_fails(self):
+        import telegram_debug as td
+
+        rc = td.set_reaction("👍", chat_id="", message_id=42)
+        self.assertEqual(rc, 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Extends `skills/harden-telegram/tools/telegram_debug.py` with two new mutually-exclusive top-level actions that reuse the existing token-discovery + Bot API path from `--direct-send`:

- **`--send-reply <text> --reply-to <msg-id> --chat-id <id>`** — posts a threaded `sendMessage` reply. Prints the new `message_id` to stdout on success. Unlike `--direct-send`, output is NOT auto-tagged with `[direct-send]`; threads as an ordinary bot reply.
- **`--react <emoji> --message-id <id> --chat-id <id>`** — calls `setMessageReaction` with a single-emoji reaction. Validates the emoji client-side against Telegram's fixed reaction whitelist so typos fail fast instead of returning an opaque HTTP 400.

Both flags reuse `_read_bot_token`, `_redact`, and the `urllib.request` call shape from `send_direct`, with pure `build_*_request` functions mirroring `build_direct_request` for testability.

## Motivation

Unblocks the larry-bead consolidation work tracked in igor2 (epic `igor2-88g`, leaf `igor2-88g.10`; design doc `docs/plans/2026-04-15-larry-protocol-v2.md`). That refactor needs a stateless, MCP-independent way to reply/react from outside a Claude Code session — the existing `--direct-send` already proved the pattern, these flags round it out.

## Changes

- `skills/harden-telegram/tools/telegram_debug.py` — new `REACTION_WHITELIST`, `build_reply_request`, `build_react_request`, `parse_sent_message_id`, `send_reply`, `set_reaction`; new CLI flags with manual action-exclusivity enforcement so existing `--doctor` / `--paths` / `--direct-send` behavior is unchanged.
- `skills/harden-telegram/tools/test_telegram_debug.py` — 20 new unit tests covering URL/body shape, whitelist membership, response parsing, and the three failure paths (missing token, missing chat-id, non-whitelisted emoji). `urllib.request.urlopen` is stubbed at the module boundary.

## Test plan

- [x] `python3 -m unittest test_telegram_debug` — 75 tests pass (was 55; 20 new)
- [x] `ruff check` + `ruff format --check` clean
- [x] `--help` lists new flags
- [x] Mutual exclusivity: `--doctor --paths` rejected with listing of all active actions
- [x] Partner-arg validation: `--send-reply` without `--reply-to` / without `--chat-id` both reject; `--react` without `--message-id` / without `--chat-id` both reject
- [ ] Live smoke test against real bot token (deferred to caller — tool is mockable end-to-end)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added CLI action to send threaded replies via Telegram Bot API with message ID tracking
  * Added CLI action to set emoji reactions on Telegram messages with client-side emoji whitelist validation
  * Enhanced argument validation to enforce mutually exclusive top-level actions and required argument combinations

* **Tests**
  * Extended test coverage for new Telegram messaging and reaction functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->