### PR TITLE
docs(claude-md): consolidate external-repo sign-off to human-friend phrasing

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -48,10 +48,6 @@ Just do it - including obvious follow-up actions. Only pause when:
 - YAGNI. The best code is no code. Don't add features we don't need.
 - When it doesn't conflict with YAGNI, architect for extensibility.
 
-### GitHub Workflow
-
-- **When filing a GitHub issue or PR in a repo outside `idvorkin/*` or `idvorkin-ai-tools/*`** (upstream library, third-party tool), end the body with a friendly sign-off that tags Igor — e.g. `— Keeping my human friend @idvorkin in the loop!` — so he gets notified without relying on watch settings he doesn't have. Skip this for Igor's own repos, where he already gets notifications.
-
 ## Important Rules
 
 - **Don't use `claude-agent-sdk` for batch/pipeline extraction.** Measured 17× cost + ~50% reliability vs direct `anthropic.AsyncAnthropic` on an 80-entry structured-JSON test. Claude Code auto-loads ~20k tokens of framework context per call and has no stateless-cache path. If `ANTHROPIC_API_KEY` credits exhaust, switch to the Anthropic **batches endpoint** (50% cheaper), not Claude Code SDK.
@@ -64,19 +60,19 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **`/reload-plugins` does NOT restart running MCP server processes.** It re-reads plugin config but leaves live MCP servers alone. To deploy new MCP code: `pkill -f '<server>'` first, THEN `/reload-plugins` (the next MCP tool call respawns the server from the plugin cache). Confirmed against Claude Code's telegram plugin 2026-04-12.
 - **Non-interactive `git rebase -i` via scripted editors.** For programmatic squashes in sessions without a human editor, write todo to `/tmp/rebase-todo.txt` and message to `/tmp/rebase-msg.txt`, then `GIT_SEQUENCE_EDITOR="cp /tmp/rebase-todo.txt" GIT_EDITOR="cp /tmp/rebase-msg.txt" git rebase -i <base>`. Supports `pick`/`fixup`/`reword`/`squash` in one pass. Always `git tag backup HEAD` first — reflog expires.
 - **Session token / context usage** — when asked "how many tokens am I using" or "how much context is left," read `~/.claude/statusline_last_input.json` with `jq`. The statusline script dumps the harness JSON there every turn; grab `.context_window.used_percentage`, `.context_window.context_window_size`, `.cost.total_cost_usd`. Don't guess from transcript length.
-- **Signing GitHub issues and comments on external repos.** When filing issues or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), append this signature:
+- **Signing GitHub issues and comments on external repos.** When filing issues, PRs, or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), end the body with this sign-off so Igor gets tagged and notified without relying on watch settings he doesn't have:
 
   ```
-  Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
+  — Keeping my human friend @idvorkin in the loop!
   ```
 
-  This tags Igor for notification, makes the AI-agent origin explicit, and deep-links to the page about his claws. **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — they're self-authored and attribution is implied.
+  **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — he already gets notifications there.
 
   **Example issue comment:**
 
   > Confirmed — `--dangerously-skip-permissions` has intentional carve-outs (sensitive-file writes, outside-cwd writes, shell metachars). Worth a docs update since the flag name implies full bypass. Happy to PR if useful.
   >
-  > Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
+  > — Keeping my human friend @idvorkin in the loop!
 - **zsh reserved array vars**: `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to shell path resolution. Using them as local string vars fails with "inconsistent type for assignment". Use `wt_path`, `file_path`, `dir` etc. instead.
 
 ## Side-Edit: Preview Files in a Side Pane


### PR DESCRIPTION
## Summary

- Resolves conflicting sign-off rules in `claude-md/global.md`: the OLD "Keeping my human friend @idvorkin in the loop!" bullet (under GitHub Workflow) coexisted with a NEWER Claws-signature rule (added in 63a4ebc under Important Rules).
- Consolidates to ONE rule under "Important Rules", preserving the newer rule's structure (skip-on-own-repos guidance + example block) but swapping the signature text back to the human-friend phrasing.
- Rewrites the prose to match the simpler "tag Igor so he gets notified" rationale — drops the Claws-specific "makes AI-agent origin explicit / deep-links to igors-claws" justifications that no longer apply.
- Net: one rule, one signature, no Claws references remain in `claude-md/global.md`.

## Test plan

- [x] `grep -i claws claude-md/global.md` returns no hits
- [x] Only one "human friend" bullet remains (plus its example reuse)
- [x] Rule still positioned under Important Rules with skip-on-own-repos guidance and example block intact