### PR TITLE
fix(telegram_bot): defer notify_clients until attachment UPDATE completes

### DIFF
--- a/skills/harden-telegram/server/telegram_bot.py
+++ b/skills/harden-telegram/server/telegram_bot.py
@@ -1012,9 +1012,18 @@ async def handle_any_message(
 
     # Wake up any connected server.ts clients — DB is the source of truth,
     # the socket is just a latency shortcut so they don't have to poll.
+    # Determine if this message has an attachment — if so, DEFER
+    # notify_clients() until after the attachment UPDATE below. Otherwise
+    # server.ts wakes on the initial NULL-attachments row, marks it
+    # delivered, and never re-reads once the UPDATE populates fields.
+    # Race-condition fix: 2026-04-15.
+    has_attachment = gate_res["action"] == "allow" and _extract_attachment(msg) is not None
+
     # Fired AFTER the inner reaction so the race with server.ts's outer
-    # reaction is deterministic (see comment above).
-    await notify_clients()
+    # reaction is deterministic (see comment above). For attachment-bearing
+    # messages, the attachment block below handles the wakeup after UPDATE.
+    if not has_attachment:
+        await notify_clients()
     log(
         f"inbound [{gate_res['action']}/{message_type}]: "
         f"{evt['username'] or evt['from_id']}: "
@@ -1043,6 +1052,7 @@ async def handle_any_message(
             local_path, err = await _download_attachment(
                 ctx, attachment, evt["chat_id"], base_dir
             )
+            update_ok = False
             try:
                 await db.execute("BEGIN IMMEDIATE")
                 await db.execute(
@@ -1067,9 +1077,16 @@ async def handle_any_message(
                     ),
                 )
                 await db.commit()
-                await notify_clients()
+                update_ok = True
             except Exception as e:
                 log(f"attachment UPDATE failed: {e}")
+            # Always notify — attachment UPDATE success populates the fields,
+            # failure still means server.ts should deliver the row (with NULL
+            # attachments) rather than silently drop. has_attachment branch
+            # above deferred the initial notify; this is the gated wakeup.
+            await notify_clients()
+            if not update_ok:
+                log(f"attachment UPDATE failed for row {row_id} — delivering with NULL attachments")
 
 
 async def handle_callback_query(


### PR DESCRIPTION
## Summary

Fixes a race condition where voice/photo/document messages arrived in Claude's `<channel>` block with NO attachment metadata (empty content + no `attachment_kind`/`attachment_file_id` attributes), making it impossible for Claude to know an attachment existed or call `download_attachment`.

## Root cause

`handle_any_message` in `telegram_bot.py` inserted the row **without** attachment columns, called `notify_clients()` to wake `server.ts`, **then** downloaded the attachment and UPDATEd the row with the attachment fields. server.ts's catchup loop would read the row during the window between INSERT and UPDATE, see NULL attachments, deliver an empty `<channel>` to Claude, mark `delivered=1`, and never re-read.

## Fix

1. Detect attachment before the initial `notify_clients()` via `_extract_attachment(msg)`.
2. Skip the initial notify when an attachment is present — server.ts doesn't wake until the UPDATE is done.
3. After the UPDATE block (success OR failure), always call `notify_clients()`. On failure, server.ts still delivers the row (with NULL attachments) rather than silently dropping it — better signal than no signal.

Text-only messages are unaffected (initial notify still fires immediately).

## Verified

Live test during session 2026-04-15: voice messages before the fix arrived as empty `<channel chat_id="..." user="..." ts="..." message_id="...">` blocks. After the fix (msg 1824 in Igor's channel):

```
<channel source="plugin:telegram:telegram" chat_id="8589434664"
  user="idvorkin" user_id="8589434664"
  ts="2026-04-16T04:45:55+00:00" message_id="1824"
  attachment_kind="voice"
  attachment_file_id="AwACAgEAAxkB..."
  attachment_size="10678"
  attachment_mime="audio/ogg">
```

`download_attachment` now works end-to-end.

## Test plan

- [x] Send a voice message, confirm `<channel>` tag includes `attachment_kind="voice"` + `attachment_file_id`
- [x] Confirm `download_attachment` can fetch the file
- [ ] Send a photo, confirm `image_path` is populated (same code path)
- [ ] Simulate UPDATE failure (disk full / permissions) and confirm server.ts still delivers the row with NULL attachments

— Keeping my human friend @idvorkin in the loop!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of messages with attachments to ensure reliable delivery
  * Server now guarantees client notifications even when attachment updates encounter issues
  * Enhanced logging to track attachment update failure scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->