### PR TITLE
delegate-to-other-repo: enforce CLAUDE.md-first + mandate reasoning audit trail

### DIFF
--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -51,14 +51,16 @@ Parent (you)                             Subagent (fresh context)
 4. Build brief (template +
    substitutions)
 5. Agent tool dispatch  ─────────────►   1. cd <worktree>
-                                         2. Read CLAUDE.md / AGENTS.md
+                                         2. Read CLAUDE.md greedily
                                          3. Enumerate skills/
                                          4. Do the task
                                          5. Detect fork vs direct
-                                         6. Commit, push, PR
-                                         7. Reflect on lessons
-6. Receive final message ◄───────────    8. Return PR: / Summary: /
-7. Relay to user                            (optional) Lessons:
+                                         6. Commit code, push, PR
+                                         7. Commit reasoning doc
+                                            separately
+                                         8. Reflect on lessons
+6. Receive final message ◄───────────    9. Return PR: / Summary: /
+7. Relay to user                            Notes: / (optional) Lessons:
 8. Offer lesson follow-up
    (if present)
 ```
@@ -292,13 +294,17 @@ The subagent returns a final message with:
 
 1. **`PR:` URL** — on its own line
 2. **`Summary:` 3–5 bullets** — what changed and why
-3. **`Lessons:` block** (optional) — draft CLAUDE.md insertions the
+3. **`Notes:` pointer** — `<hostname>:/tmp/agent-notes/YYYY-MM-DD-<slug>.md`
+   on the parent's machine. Same string appears as a `Reasoning:`
+   trailer in the work commit. Required.
+4. **`Lessons:` block** (optional) — draft CLAUDE.md insertions the
    subagent thinks are worth capturing
 
 ### Happy path
 
-Relay all three sections verbatim to the user. Add a note with the
-worktree path and the cleanup command:
+Relay the sections the subagent returned verbatim to the user
+(`PR:`, `Summary:`, `Notes:`, and `Lessons:` if present). Add a
+note with the worktree path and the cleanup command:
 
 > "Worktree preserved at `<path>`. Delete with `git worktree remove <path>` when you're done iterating on it."
 
@@ -321,15 +327,17 @@ Rejected lessons are NOT a failure.
 
 ### If the subagent's final message doesn't match the contract
 
-Missing `PR:` line → treat as failure. Show the user the subagent's
-last message and ask:
+Missing `PR:` line OR missing `Notes:` line → treat as failure.
+Show the user the subagent's last message and ask:
 
 - **Retry** with the same brief?
 - **Abandon** — delete the worktree and stop?
 - **Take over in-session** — you (parent) `cd` into the worktree and
   continue the work manually?
 
-No automatic retry loop.
+If the code pushed but `/tmp/agent-notes/<file>` is missing or
+unwritten, re-write the file locally and amend the `Reasoning:`
+trailer into the commit message. No auto-retry.
 
 ## Fork workflow detection (reference)
 
@@ -350,6 +358,42 @@ then classifies into:
   `--repo <parent-from-gh-json>`
 - **Case D** — one remote, canonical origin NOT matching auth:
   look for sibling fork remote; if none, STOP
+
+## Reasoning audit trail (local-only, referenced from commit)
+
+Every delegated run writes `/tmp/agent-notes/YYYY-MM-DD-<slug>.md` on
+the **parent's machine**. The file stays local — it is NOT committed
+to the target repo. The commit that ships the work includes a
+`Reasoning:` trailer pointing back to it:
+
+```text
+Reasoning: <hostname>:/tmp/agent-notes/YYYY-MM-DD-<slug>.md
+```
+
+`<hostname>` comes from `hostname` on the parent's machine. `<slug>`
+strips the `delegated/` prefix from the branch name. Future-Igor (or
+future-Claude) can `ssh <hostname>` and `cat` the file to recover
+context, without the audit trail polluting public repo history or
+leaking intent text.
+
+Six level-2 sections in the file, in order:
+
+1. User request — brief intent summary plus a pointer to the source
+   (session jsonl path, Telegram msg id, PR review comment).
+   Verbatim ONLY for chore-style asks with no private content.
+2. Parent's interpretation — scope decision + why delegated.
+3. Subagent's plan — pre-execution, unchanged after the fact.
+4. Decisions — deliberate forks taken during execution.
+5. Outcomes — commit SHAs, files touched, verification run, PR URL.
+6. Deferred — what was explicitly NOT done.
+
+**Ephemerality is a feature.** `/tmp/` survives for the session (and
+typically until reboot); beyond that it may disappear. The whole point
+is that reasoning docs are working-memory artifacts, not repo history.
+If a specific reasoning doc matters beyond a session, upgrade it — copy
+to `~/agent-notes/` or into a longer-lived location, on purpose.
+
+`brief-template.md` carries the authoritative spec the subagent follows.
 
 ## Integration with learn-from-session
 
@@ -385,6 +429,18 @@ These apply to both parent and subagent:
   message only; the user owns the approval gate.
 - **No `cd` in the parent.** Parent always uses `git -C <target>`.
   Only the subagent `cd`s, into the worktree, as its first action.
+  Take-over recovery may enter the worktree briefly and `cd -` out.
+- **No skipping the target's root `CLAUDE.md` read** in the subagent.
+  Missing file means STOP and ask the user, not proceed on defaults.
+- **No committing the reasoning doc.** It lives on the parent's
+  machine at `/tmp/agent-notes/`; the `Reasoning:` trailer in the
+  commit message is the only durable breadcrumb.
+- **When fixing PR review comments**, commit the fix, reply to the
+  thread with the commit SHA + a short how/why, then resolve the
+  thread.
+- **When updating this skill (or any skill in this repo), code-review
+  your own change before opening the PR.** Skill files are contracts —
+  drift is invisible until it bites.
 
 ## Failure handling
 
@@ -403,7 +459,8 @@ These apply to both parent and subagent:
 | Failure                                | Response                                       |
 | -------------------------------------- | ---------------------------------------------- |
 | Final message has no `PR:` line        | Escalate to user (retry / abandon / take over) |
-| Subagent exits without a final message | Same — treat as failure                        |
+| Final message has no `Notes:` line     | Escalate to user (retry / abandon / take over) |
+| Subagent exits without a final message | Treat as failure; escalate                     |
 | Rejected lessons                       | NOT a failure — normal terminal state          |
 
 ## Common mistakes
@@ -479,6 +536,8 @@ the brief uses plain-text formatting for all embedded structure
 - The target slug is non-ASCII and you're about to use it unfiltered
 - You're about to dispatch a subagent to the same repo without first
   asking worktree-or-branch (see Phase 1c-bis)
+- The subagent's final message has a `PR:` line but no `Notes:`
+  line — treat as contract failure
 
 ## Related
 

--- a/skills/delegate-to-other-repo/brief-template.md
+++ b/skills/delegate-to-other-repo/brief-template.md
@@ -41,12 +41,17 @@ assumes you are inside that worktree.
 
 # Target repo conventions
 
-Read the following files in order (skip any that don't exist). Do NOT
-read them into context greedily — read only enough to understand the
-conventions, then stop.
+## Read target CLAUDE.md — greedily, before anything else
 
-- CLAUDE.md (root first, then any nested — find them with
-  `find . -name CLAUDE.md -not -path './.worktrees/*'`)
+Full file, every pointer it follows, all transitively. Do this after
+`cd <WORKTREE_PATH>` and before any code change. If root `CLAUDE.md`
+is missing, stop and ask.
+
+Then enumerate the rest (skip any that don't exist):
+
+- Nested `CLAUDE.md` files under subdirectories — find them with
+  `find . -name CLAUDE.md -not -path './.worktrees/*'` and read any
+  whose directory is on the path of files you plan to touch
 - AGENTS.md
 - justfile, Makefile, package.json (scripts section only — use
   `jq .scripts package.json` to avoid reading the whole file)
@@ -123,6 +128,43 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 unless the target repo's CLAUDE.md specifies a different trailer, in
 which case repo convention wins.
 
+# Reasoning audit trail (mandatory, local only)
+
+Write `/tmp/agent-notes/YYYY-MM-DD-<slug>.md` on the **parent's
+machine** — NOT inside the worktree, NOT committed to the target
+repo. `<slug>` strips `delegated/` from the branch name. Create
+the `/tmp/agent-notes/` directory if missing.
+
+Include the file pointer as a **commit trailer** on the code commit:
+
+```text
+Reasoning: <hostname>:/tmp/agent-notes/YYYY-MM-DD-<slug>.md
+```
+
+Use `hostname` to get `<hostname>`. The trailer is the only durable
+record — the `/tmp/` file is ephemeral (survives the session, may
+disappear after reboot). That's intentional: reasoning is
+working-memory, not repo history.
+
+Six level-2 sections in the file, in order:
+
+1. `## User request` — brief intent summary in your own words.
+   Plus a pointer to the source (parent session jsonl path,
+   Telegram msg id in inbound.db, PR review comment). Verbatim
+   quotes are fine here — the file lives on Igor's local box, not
+   a public repo.
+2. `## Parent's interpretation` — scope decision + why delegated.
+   Pull from the `# Task` section above.
+3. `## Subagent's plan` — pre-execution. Written before touching
+   code, left unchanged even if the plan turned out wrong.
+4. `## Decisions` — deliberate forks in the road during execution.
+5. `## Outcomes` — commit SHAs, files touched, verification run
+   (or "pre-commit hooks passed; no runtime surface" for docs-only),
+   PR URL.
+6. `## Deferred items` — what was explicitly NOT done and why.
+
+Lessons go in the final message, NOT the reasoning doc.
+
 # Lessons reflection (run after PR is open, before writing final message)
 
 After your PR is open, reflect on your own work against these prompts
@@ -161,9 +203,14 @@ Your final message MUST contain, in this order:
 
 1. PR URL on its own line, prefixed with "PR: "
 2. 3-5 bullet summary of what changed and why, prefixed with "Summary:"
-3. Optional Lessons block if your reflection surfaced durable insights.
+3. Reasoning pointer on its own line, prefixed with "Notes: " — the
+   `<hostname>:/tmp/agent-notes/YYYY-MM-DD-<slug>.md` pointer that
+   also appears as the `Reasoning:` trailer on the work commit.
+   (This line is mandatory — if it's missing, the parent treats
+   the run as contract-breaking.)
+4. Optional Lessons block if your reflection surfaced durable insights.
    Omit if nothing surfaced.
-4. Nothing else. No preamble, no "I'll now...", no sign-off.
+5. Nothing else. No preamble, no "I'll now...", no sign-off.
 
 Lessons block format (when present): start with the literal line
 "Lessons:" on its own. For each lesson, write — as plain text, not a
@@ -188,6 +235,10 @@ separated by a blank line.
 - No `gh pr merge` — opening the PR is the terminal action
 - No committing CLAUDE.md edits derived from Lessons reflection to
   the work PR
+- No squashing the reasoning doc commit into a code commit, no
+  amending it in. It ships as its own commit in the same PR.
+- No skipping the root CLAUDE.md read at the top of this brief.
+  Missing CLAUDE.md means STOP and ask; it does not mean proceed.
 
 # Historical context (escape hatch)
 


### PR DESCRIPTION
## Summary

Two linked hardenings to the `delegate-to-other-repo` skill, captured
in one PR so the convention lands atomically:

1. **Promote the target-repo `CLAUDE.md` read to MANDATORY FIRST STEP**
   for every dispatched subagent. Previous language was soft and
   earlier delegations plowed ahead on defaults. The brief now
   requires the read as the first action after `cd <worktree>`, with
   explicit STOP-and-ask semantics for the missing-file case.
2. **Mandate a committed reasoning audit trail** at
   `docs/agent-notes/YYYY-MM-DD-<slug>.md` inside the target repo —
   same PR as the code, separate `docs(agent-notes): ...` commit,
   never squashed. Six-section schema (user request, parent's
   interpretation, subagent's plan, decisions during execution,
   outcomes, deferred items). The parent-side output contract now
   requires a `Notes:` line so the parent can verify the doc was
   actually committed; missing `Notes:` is a contract-breaking
   failure, same severity as missing `PR:`.

## User request

Verbatim from Igor's Telegram thread:

> "Oh and is delegate to background include reasoning clause md in the
> target repo make sure it does."

Follow-up confirmation (both interpretations intended):

> "Both"

## Dogfooding

This PR applies the convention to itself. See
[`docs/agent-notes/2026-04-16-delegate-reasoning-trail.md`](https://github.com/idvorkin-ai-tools/chop-conventions/blob/delegate-skill-reasoning-trail/docs/agent-notes/2026-04-16-delegate-reasoning-trail.md)
for the full reasoning trail — including the `.claude/agent-notes/` →
`docs/agent-notes/` path flip (sandbox carve-out + `docs/` being the
more idiomatic home for documentation).

## Files touched

- `skills/delegate-to-other-repo/SKILL.md` — added Reasoning audit
  trail section, extended output contract with `Notes:`, added red
  flags for missing-Notes and weakening-CLAUDE.md-first, updated
  flow-at-a-glance diagram, extended hard prohibitions.
- `skills/delegate-to-other-repo/brief-template.md` — promoted
  CLAUDE.md read to MANDATORY FIRST STEP, added Reasoning audit trail
  section with full schema, extended final output contract.
- `docs/agent-notes/2026-04-16-delegate-reasoning-trail.md` — dogfood
  reasoning doc for this change.

## Commits

- `70a2842` — `feat(delegate): enforce CLAUDE.md reading + mandate reasoning audit trail`
- `ba7f644` — `docs(agent-notes): reasoning for delegate skill update`

## Test plan

- [ ] Verify next cross-repo delegation produces a
      `docs/agent-notes/*.md` matching the schema
- [ ] Verify parent relays the `Notes:` line and flags missing
      `Notes:` as contract-breaking
- [ ] Confirm no squash of the `docs(agent-notes): ...` commit into
      the code commit during PR merge