### PR TITLE
docs(claude-md): sign external-repo GH issues with "Claws" brand

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -62,19 +62,19 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **`git commit` can silently no-op when a pre-commit hook reformats staged files.** The commit aborts (hook exit != 0) but a chained `&& git push` still fires — pushing an empty branch or the unchanged tip. Detection: after `git commit`, scan output for the `[branch sha] commit-message` confirmation line. If missing, the commit didn't land — re-stage the reformatted file and retry. Don't trust the chained-push output alone.
 - **Non-interactive `git rebase -i` via scripted editors.** For programmatic squashes in sessions without a human editor, write todo to `/tmp/rebase-todo.txt` and message to `/tmp/rebase-msg.txt`, then `GIT_SEQUENCE_EDITOR="cp /tmp/rebase-todo.txt" GIT_EDITOR="cp /tmp/rebase-msg.txt" git rebase -i <base>`. Supports `pick`/`fixup`/`reword`/`squash` in one pass. Always `git tag backup HEAD` first — reflog expires.
 - **Session token / context usage** — when asked "how many tokens am I using" or "how much context is left," read `~/.claude/statusline_last_input.json` with `jq`. The statusline script dumps the harness JSON there every turn; grab `.context_window.used_percentage`, `.context_window.context_window_size`, `.cost.total_cost_usd`. Don't guess from transcript length.
-- **Signing GitHub issues and comments on external repos.** When filing issues, PRs, or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), end the body with this sign-off so Igor gets tagged and notified without relying on watch settings he doesn't have:
+- **Signing GitHub issues and comments on external repos.** When filing issues, PRs, or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), append this signature so Igor gets tagged and notified, the AI-agent origin is explicit, and readers can follow the deep link to Igor's writeup on the "Claws" concept:
 
   ```
-  — Keeping my human friend @idvorkin in the loop!
+  Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
   ```
 
-  **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — he already gets notifications there.
+  **Skip the signature on `idvorkin/*` and `idvorkin-ai-tools/*` repos** — he already gets notifications there and attribution is implied.
 
   **Example issue comment:**
 
   > Confirmed — `--dangerously-skip-permissions` has intentional carve-outs (sensitive-file writes, outside-cwd writes, shell metachars). Worth a docs update since the flag name implies full bypass. Happy to PR if useful.
   >
-  > — Keeping my human friend @idvorkin in the loop!
+  > Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
 - **Close PRs and issues you opened that become stale or superseded.** If Claude filed a PR or issue and it's no longer relevant (work redirected, approach pivoted, superseded by another PR, spec changed before review), close it yourself with a clear comment explaining why. Don't leave orphan PRs/issues for Igor to clean up — they accumulate and lose context. Always include a pointer to the replacement work (bead ID, superseding PR, or updated design doc).
 - **zsh reserved array vars**: `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to shell path resolution. Using them as local string vars fails with "inconsistent type for assignment". Use `wt_path`, `file_path`, `dir` etc. instead.
 


### PR DESCRIPTION
## Summary

Replaces the existing external-repo sign-off (landed via #128 earlier this week) with a Claws-branded one:

**Before:**
```
— Keeping my human friend @idvorkin in the loop!
```

**After:**
```
Created w/♥ by @idvorkin's [Claws](https://idvork.in/igors-claws)
```

Same notification purpose (tags `@idvorkin`, routes around watch-settings he doesn't have), but tighter and deep-links to your writeup on the Claws concept so external readers can follow the trail. Shifts framing from "friend" to "tooling," which reads better in issues and PRs on strangers' repos.

Single commit off `upstream/main` — the 3 iterative refinement commits (`7ff5273` → `f640a09` → `818f26b`) were squashed into one and resolved against the current `global.md` structure.

## Test plan

- [ ] Signature renders cleanly as markdown in a real GitHub comment (the `[text](url)` link + ♥ glyph + backtick-less deep link all play well with GitHub's parser)
- [ ] Confirm this is the direction you want — if you prefer to keep the "friend" framing, close this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)