### PR TITLE
feat(dev-setup): bd-close-gated wrapper (block close if children open)

### DIFF
--- a/dev-setup/bd-close-gated
+++ b/dev-setup/bd-close-gated
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# bd-close-gated: bd close wrapper that refuses to close a bead with open children.
+#
+# bd's parent-child dependency is organizational, not gating — `bd close <parent>`
+# succeeds even when children are still open. This wrapper adds a soft gate.
+#
+# Usage:
+#   bd-close-gated <bead-id> [--reason "..."]    # gated close
+#   bd-close-gated <bead-id> --force [...]       # skip gate, pass --force to bd close
+#   bd-close-gated -h | --help                   # show usage
+#
+# Exit codes:
+#   0  success (underlying `bd close` succeeded)
+#   1  gate blocked close (open children found)
+#   2  usage error
+#   *  whatever `bd close` returns on failure
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: bd-close-gated <bead-id> [--reason "..."] [--force]
+
+Closes a bd bead, but refuses if it has any open parent-child children.
+Passes --reason/--force through to `bd close`. Unknown flags are forwarded.
+
+Examples:
+  bd-close-gated igor2-1z7.16 --reason "All tax tasks done"
+  bd-close-gated igor2-1z7.16 --force --reason "Abandoning branch"
+EOF
+}
+
+die_usage() {
+  echo "bd-close-gated: $1" >&2
+  echo >&2
+  usage >&2
+  exit 2
+}
+
+# --- parse args -------------------------------------------------------------
+BEAD_ID=""
+FORCE=0
+PASSTHROUGH=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --force|-f)
+      FORCE=1
+      shift
+      ;;
+    --)
+      shift
+      PASSTHROUGH+=("$@")
+      break
+      ;;
+    -*)
+      PASSTHROUGH+=("$1")
+      shift
+      ;;
+    *)
+      if [[ -z "$BEAD_ID" ]]; then
+        BEAD_ID="$1"
+      else
+        PASSTHROUGH+=("$1")
+      fi
+      shift
+      ;;
+  esac
+done
+
+[[ -n "$BEAD_ID" ]] || die_usage "missing bead-id"
+
+# --- sanity: tools we need --------------------------------------------------
+command -v bd >/dev/null 2>&1 || die_usage "bd not found in PATH"
+command -v jq >/dev/null 2>&1 || die_usage "jq not found in PATH"
+
+# --- gate -------------------------------------------------------------------
+if [[ "$FORCE" -eq 0 ]]; then
+  # `bd show <id> --json` returns a JSON array with one issue whose
+  # `dependents` array lists children (plus other reverse-deps). A child
+  # is anything with dependency_type == "parent-child". We only block on
+  # children whose status is open/in_progress/blocked — closed ones are fine.
+  if ! show_json="$(bd show "$BEAD_ID" --json 2>&1)"; then
+    echo "bd-close-gated: \`bd show $BEAD_ID\` failed:" >&2
+    echo "$show_json" >&2
+    exit 2
+  fi
+
+  open_children="$(
+    printf '%s' "$show_json" | jq -r '
+      (if type == "array" then .[0] else . end)
+      | (.dependents // [])
+      | map(select(.dependency_type == "parent-child"))
+      | map(select(.status != "closed"))
+      | .[]
+      | "\(.id)\t\(.status)\t\(.title)"
+    '
+  )"
+
+  if [[ -n "$open_children" ]]; then
+    echo "bd-close-gated: refusing to close $BEAD_ID — open children:" >&2
+    # indent for readability
+    printf '%s\n' "$open_children" | while IFS=$'\t' read -r cid cstatus ctitle; do
+      printf '  %-20s [%s] %s\n' "$cid" "$cstatus" "$ctitle" >&2
+    done
+    echo >&2
+    echo "Resolve (close the children) or rerun with --force to override." >&2
+    exit 1
+  fi
+fi
+
+# --- exec bd close ----------------------------------------------------------
+cmd=(bd close "$BEAD_ID")
+if [[ "$FORCE" -eq 1 ]]; then
+  cmd+=(--force)
+fi
+if [[ ${#PASSTHROUGH[@]} -gt 0 ]]; then
+  cmd+=("${PASSTHROUGH[@]}")
+fi
+
+exec "${cmd[@]}"

--- a/dev-setup/beads.md
+++ b/dev-setup/beads.md
@@ -230,6 +230,42 @@ bd sync                     # Bidirectional git sync
 bd sync --status            # Check sync status
 ```
 
+## `bd-close-gated` wrapper (opt-in)
+
+`bd`'s `parent-child` dependency is organizational, not gating — `bd close
+<parent>` succeeds even when children are still open. That's by design (epics
+often close with trailing admin children), but for beads tracking real
+sequential work it's a foot-gun: you close the parent, forget the children,
+and work goes silent.
+
+[`bd-close-gated`](./bd-close-gated) is a small bash wrapper that refuses to
+close a bead with open parent-child children, printing their IDs so you can
+decide to close them first or rerun with `--force`.
+
+**Usage**
+
+```bash
+bd-close-gated <bead-id> [--reason "..."]    # gated close
+bd-close-gated <bead-id> --force [...]       # bypass gate, pass --force through
+bd-close-gated -h | --help
+```
+
+Exit codes: `0` success, `1` gate blocked, `2` usage error.
+
+**Install (opt-in alias)**
+
+```bash
+# In ~/.zshrc or ~/.bashrc
+alias bd-close="$HOME/gits/chop-conventions/dev-setup/bd-close-gated"
+```
+
+Leave `bd close` as-is for the unshadowed escape hatch. Use `bd-close` when
+you want the gate.
+
+**Tests** — run `bash dev-setup/test_bd_close_gated.sh`. Creates a temp
+beads DB, exercises happy / blocked / force / usage-error paths, tears down
+on exit.
+
 ## Troubleshooting
 
 **Worktree error: "branch is already checked out"**

--- a/dev-setup/test_bd_close_gated.sh
+++ b/dev-setup/test_bd_close_gated.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Manual verification harness for dev-setup/bd-close-gated.
+#
+# Creates a throwaway beads DB in a tempdir, exercises three scenarios,
+# and tears down on exit. Run with: bash dev-setup/test_bd_close_gated.sh
+#
+# Requires: bd, jq, git.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WRAPPER="$SCRIPT_DIR/bd-close-gated"
+
+[[ -x "$WRAPPER" ]] || { echo "FAIL: $WRAPPER not executable"; exit 2; }
+command -v bd >/dev/null || { echo "FAIL: bd not in PATH"; exit 2; }
+command -v jq >/dev/null || { echo "FAIL: jq not in PATH"; exit 2; }
+
+TMPDIR="$(mktemp -d -t bd-close-gated-test.XXXXXX)"
+cleanup() { rm -rf "$TMPDIR"; }
+trap cleanup EXIT
+
+cd "$TMPDIR"
+# bd init expects a git repo; the --non-interactive path will create one.
+export BD_NON_INTERACTIVE=1
+bd init --prefix=tst >/dev/null 2>&1
+
+pass=0
+fail=0
+
+check() {
+  # check <label> <expected-exit> <actual-exit>
+  if [[ "$2" -eq "$3" ]]; then
+    echo "  PASS: $1 (exit=$3)"
+    pass=$((pass + 1))
+  else
+    echo "  FAIL: $1 (expected exit=$2, got $3)"
+    fail=$((fail + 1))
+  fi
+}
+
+# ---------------------------------------------------------------------------
+echo "[1] Happy path — unblocked bead closes cleanly"
+solo_id="$(bd create "solo bead" -t task --json | jq -r '.id')"
+set +e
+"$WRAPPER" "$solo_id" --reason "test solo close" >/dev/null
+rc=$?
+set -e
+check "solo close returns 0" 0 "$rc"
+status="$(bd show "$solo_id" --json | jq -r '.[0].status')"
+[[ "$status" == "closed" ]] && echo "  PASS: solo bead marked closed" || { echo "  FAIL: solo bead status=$status"; fail=$((fail + 1)); }
+
+# ---------------------------------------------------------------------------
+echo "[2] Blocked path — parent with open child refuses to close"
+parent_id="$(bd create "parent" -t task --json | jq -r '.id')"
+child_id="$(bd create "child" -t task --parent "$parent_id" --json | jq -r '.id')"
+set +e
+out="$("$WRAPPER" "$parent_id" --reason "try close" 2>&1)"
+rc=$?
+set -e
+check "blocked close returns 1" 1 "$rc"
+if grep -q "$child_id" <<<"$out"; then
+  echo "  PASS: error names open child $child_id"
+  pass=$((pass + 1))
+else
+  echo "  FAIL: error did not mention $child_id"
+  echo "  --- output ---"; echo "$out"; echo "  --------------"
+  fail=$((fail + 1))
+fi
+status="$(bd show "$parent_id" --json | jq -r '.[0].status')"
+[[ "$status" == "open" ]] && echo "  PASS: parent still open after refused close" || { echo "  FAIL: parent status=$status"; fail=$((fail + 1)); }
+
+# ---------------------------------------------------------------------------
+echo "[3] Force path — --force bypasses the gate"
+set +e
+"$WRAPPER" "$parent_id" --force --reason "force close" >/dev/null
+rc=$?
+set -e
+check "force close returns 0" 0 "$rc"
+status="$(bd show "$parent_id" --json | jq -r '.[0].status')"
+[[ "$status" == "closed" ]] && echo "  PASS: parent closed via --force" || { echo "  FAIL: parent status=$status"; fail=$((fail + 1)); }
+
+# ---------------------------------------------------------------------------
+echo "[4] Usage error — missing bead-id returns 2"
+set +e
+"$WRAPPER" >/dev/null 2>&1
+rc=$?
+set -e
+check "missing-arg returns 2" 2 "$rc"
+
+# ---------------------------------------------------------------------------
+echo
+echo "Results: $pass passed, $fail failed"
+[[ "$fail" -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds a `bd-close-gated` wrapper script that refuses to close an issue if any of its children are still open. Paired with a test script.

**Why:** `bd close` has no child-state check by default. Closing a parent with open children orphans them — they accumulate, silently drop out of `bd ready`, and lose their context link to the parent.

**Files:**
- `dev-setup/bd-close-gated` — the wrapper script
- `dev-setup/test_bd_close_gated.sh` — test coverage
- `dev-setup/beads.md` — one-liner note documenting the wrapper

## Test plan

- [ ] `bash dev-setup/test_bd_close_gated.sh` passes
- [ ] Confirm the wrapper path is what you want (`dev-setup/` vs a skill vs `justfile` target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)