### PR TITLE
docs: add lessons on chroma-key verification and merge-UI race

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -62,7 +62,7 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **`git commit` can silently no-op when a pre-commit hook reformats staged files.** The commit aborts (hook exit != 0) but a chained `&& git push` still fires — pushing an empty branch or the unchanged tip. Detection: after `git commit`, scan output for the `[branch sha] commit-message` confirmation line. If missing, the commit didn't land — re-stage the reformatted file and retry. Don't trust the chained-push output alone.
 - **Non-interactive `git rebase -i` via scripted editors.** For programmatic squashes in sessions without a human editor, write todo to `/tmp/rebase-todo.txt` and message to `/tmp/rebase-msg.txt`, then `GIT_SEQUENCE_EDITOR="cp /tmp/rebase-todo.txt" GIT_EDITOR="cp /tmp/rebase-msg.txt" git rebase -i <base>`. Supports `pick`/`fixup`/`reword`/`squash` in one pass. Always `git tag backup HEAD` first — reflog expires.
 - **Session token / context usage** — when asked "how many tokens am I using" or "how much context is left," read `~/.claude/statusline_last_input.json` with `jq`. The statusline script dumps the harness JSON there every turn; grab `.context_window.used_percentage`, `.context_window.context_window_size`, `.cost.total_cost_usd`. Don't guess from transcript length.
-- **Signing GitHub issues and comments on external repos.** When filing issues, PRs, or comments on repos *outside* `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), end the body with this sign-off so Igor gets tagged and notified without relying on watch settings he doesn't have:
+- **Signing GitHub issues and comments on external repos.** When filing issues, PRs, or comments on repos _outside_ `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), end the body with this sign-off so Igor gets tagged and notified without relying on watch settings he doesn't have:
 
   ```
   — Keeping my human friend @idvorkin in the loop!
@@ -75,8 +75,10 @@ Just do it - including obvious follow-up actions. Only pause when:
   > Confirmed — `--dangerously-skip-permissions` has intentional carve-outs (sensitive-file writes, outside-cwd writes, shell metachars). Worth a docs update since the flag name implies full bypass. Happy to PR if useful.
   >
   > — Keeping my human friend @idvorkin in the loop!
+
 - **Close PRs and issues you opened that become stale or superseded.** If Claude filed a PR or issue and it's no longer relevant (work redirected, approach pivoted, superseded by another PR, spec changed before review), close it yourself with a clear comment explaining why. Don't leave orphan PRs/issues for Igor to clean up — they accumulate and lose context. Always include a pointer to the replacement work (bead ID, superseding PR, or updated design doc).
 - **zsh reserved array vars**: `path`, `PATH`, `manpath`, `cdpath`, `fpath` are tied to shell path resolution. Using them as local string vars fails with "inconsistent type for assignment". Use `wt_path`, `file_path`, `dir` etc. instead.
+- **GitHub merge UI races with in-flight pushes.** If you push a new commit to a PR and the user clicks Merge before GitHub's cache refreshes, the merge commit's second parent will be the stale PR tip, not your latest push. Detection: `git show <merge-sha> --format='%P'` and verify the second parent SHA matches your intended tip. On mismatch, open a follow-up PR to replay the missing commit.
 
 ## Side-Edit: Preview Files in a Side Pane
 

--- a/skills/gen-image/SKILL.md
+++ b/skills/gen-image/SKILL.md
@@ -115,6 +115,10 @@ Use `generate.py` from the `image-explore` skill. It handles env loading (`~/.en
 
 5. If generation fails, report the error and ask if the user wants to retry with a modified prompt or skip.
 
+**Verifying transparent output.** Don't judge chroma-key quality by compositing on a solid background — interior holes read as the background color. Extract the alpha channel as a mask: `magick out.webp -alpha extract mask.png`. A clean mask is a solid silhouette; swiss-cheese holes mean the chroma ate interior color data.
+
+**Never chain chroma passes on different magenta tones** (e.g. a second pass on `#E040E0` to catch pink shadow remnants). It eats magenta-tinted highlights inside fluffy characters. If the first pass has fringe, regenerate the source with a stricter prompt (`no shadow on ground, no gradient, no environment`) rather than filtering harder.
+
 ### Phase 5: Insert References (Optional)
 
 Ask the user if they want the images inserted into the post. If yes:


### PR DESCRIPTION
## Summary

Two durable lessons from a `blog4` session that shipped a swiss-cheesed transparent image and required an emergency recovery PR (blob #14).

- **`skills/gen-image/SKILL.md`** — Phase 4 now includes a verification callout: judge chroma-key quality by extracting the alpha mask (`magick out.webp -alpha extract mask.png`), not by eyeballing the image on a solid background where interior holes read as the background color. Also forbids chaining chroma passes on different magenta tones (e.g. a second pass on `#E040E0`) — eats magenta-tinted highlights inside fluffy characters. If a first pass has fringe, regenerate from a stricter prompt instead of filtering harder.

- **`claude-md/global.md`** — new Important Rules bullet flagging the GitHub merge UI race: if a commit lands on a PR within ~seconds of the user clicking Merge, the merge commit's second parent can be the stale pre-push SHA, not the intended tip. Detection recipe via `git show <merge-sha> --format='%P'`; on mismatch, follow-up PR to replay.

## Why these are durable

Chroma-key verification: any future `--transparent` run hits the same visual-verification trap unless the skill explicitly routes the reviewer to the alpha mask. The parent session reviewed on black/white backgrounds and shipped holes that read as shading.

Merge UI race: environmental behavior of GitHub's merge pipeline, not session-specific. Reproducibly triggered any time a push lands within a few seconds of a UI-initiated merge.

## Notes

- Delegated from a `blog4` session (`6efd662e-e906-4bfa-867b-db6510307c02`) via the `delegate-to-other-repo` skill to isolate skill/CLAUDE.md edits from blog content work.
- Commits used `SKIP=test` because the repo's `harden-telegram` test suite is currently broken (unrelated to these docs-only changes) — consistent with the workaround blessed in `CLAUDE.md` bullet #37. Prettier, biome, ruff, dasel, and all other hooks ran and passed.

## Test plan

- [ ] Skim `skills/gen-image/SKILL.md` Phase 4 — the verification callout reads as a natural final step before Phase 5.
- [ ] Skim `claude-md/global.md` Important Rules tail — new bullet matches the bold-leading-phrase + concrete-detection-recipe style of surrounding bullets.
- [ ] Confirm the collateral prettier normalization in `global.md` (`*outside*` → `_outside_`, blank line before a later bullet) is acceptable — it's automatic, not semantic.