### PR TITLE
feat(gen-image): use edge-connected flood fill for --transparent (protects interior)

### DIFF
--- a/skills/gen-image/SKILL.md
+++ b/skills/gen-image/SKILL.md
@@ -19,7 +19,7 @@ Parse the user's input for:
 - **`--api-url 'url'`**: Override the Gemini API endpoint (default below)
 - **`--count N`**: Max number of images to generate (default: 3)
 - **`--aspect 'W:H'`**: Aspect ratio via `imageConfig` (default: 3:4, portrait). Valid values: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`
-- **`--transparent`**: Generate on magenta chroma-key background (`#FF00FF`), then strip it with ImageMagick's `-fuzz 30% -transparent` to produce a PNG/webp with real alpha transparency. Fast (sub-second) and pixel-accurate — no ML needed. Requires `magick` (ImageMagick).
+- **`--transparent`**: Generate on magenta chroma-key background (`#FF00FF`), then strip it via ImageMagick **edge-connected flood fill** from all 4 corners. Only magenta pixels reachable from the image edges are made transparent — interior magenta-tinted pixels (pink fur highlights, glass reflections, lobster-claw reds) are preserved automatically. Fast (sub-second) and pixel-accurate — no ML needed. Requires `magick` (ImageMagick).
 
 ## Configuration
 

--- a/skills/image-explore/generate.py
+++ b/skills/image-explore/generate.py
@@ -121,19 +121,37 @@ def read_default_style(chop_root):
 
 
 def remove_background(image_path):
-    """Strip the magenta chroma-key background using ImageMagick.
+    """Strip the magenta chroma-key background using edge-connected flood fill.
 
-    Since images are generated on a KNOWN solid #FF00FF background, exact
-    color-based transparency with ImageMagick's -fuzz is pixel-accurate,
-    fast, and dependency-free. This beat rembg in testing: rembg left
-    purple halos around character edges and required a heavy ML install.
+    Images are generated on a KNOWN solid #FF00FF background, so chroma-key
+    stripping is pixel-accurate without ML. The earlier approach used
+    `-fuzz 30% -transparent #FF00FF`, which kills ALL magenta-ish pixels
+    globally — including magenta-tinted highlights *inside* the character
+    (pink fur, specular glass reflections, lobster-claw reds). That leaves
+    swiss-cheese holes in the alpha mask.
 
-    Fuzz of 30% handles edge antialiasing (where magenta blends into the
-    subject outline) without bleeding into red/pink character colors.
+    Flood-fill from all 4 corners only reaches the contiguous background
+    region; interior pixels are protected by the character's own silhouette
+    and preserved automatically. Fuzz of 30% still handles edge antialiasing
+    where magenta blends into the subject outline.
     """
     magick = shutil.which("magick") or shutil.which("convert")
     if not magick:
         return False, "magick not found — install ImageMagick"
+
+    # Pre-query image dimensions so we can flood-fill from each corner.
+    probe = subprocess.run(
+        [magick, "identify", "-format", "%w %h", image_path],
+        capture_output=True,
+        text=True,
+    )
+    if probe.returncode != 0:
+        return False, f"magick identify failed: {probe.stderr.strip()}"
+    try:
+        w, h = (int(x) for x in probe.stdout.split())
+    except ValueError:
+        return False, f"could not parse image dimensions: {probe.stdout!r}"
+    w1, h1 = w - 1, h - 1
 
     with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
         tmp_path = tmp.name
@@ -143,10 +161,20 @@ def remove_background(image_path):
             [
                 magick,
                 image_path,
+                "-alpha",
+                "set",
                 "-fuzz",
                 "30%",
-                "-transparent",
-                "#FF00FF",
+                "-fill",
+                "none",
+                "-draw",
+                "color 0,0 floodfill",
+                "-draw",
+                f"color {w1},0 floodfill",
+                "-draw",
+                f"color 0,{h1} floodfill",
+                "-draw",
+                f"color {w1},{h1} floodfill",
                 "-quality",
                 "90",
                 tmp_path,
@@ -155,7 +183,7 @@ def remove_background(image_path):
             text=True,
         )
         if result.returncode != 0:
-            return False, f"magick -transparent failed: {result.stderr.strip()}"
+            return False, f"magick flood-fill failed: {result.stderr.strip()}"
 
         ext = Path(image_path).suffix.lower()
         if ext == ".webp":
@@ -275,7 +303,7 @@ def main():
         "--transparent",
         action="store_true",
         default=False,
-        help="Generate on magenta chroma-key background, then strip it via ImageMagick -fuzz -transparent",
+        help="Generate on magenta chroma-key background, then strip it via ImageMagick edge-connected flood fill from the 4 corners (preserves interior magenta-tinted pixels)",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Summary

Rework `gen-image`'s `--transparent` post-process so interior magenta-tinted pixels survive chroma-key stripping.

The previous path in `skills/image-explore/generate.py::remove_background` ran:

```python
magick <img> -fuzz 30% -transparent "#FF00FF" <out>
```

That kills **every** magenta-ish pixel globally, including magenta-tinted highlights *inside* the character — pink fur rim-lighting, specular glass reflections, lobster-claw reds. The alpha mask ends up swiss-cheesed: character outlines stay clean, but interior pixels (eyes, glasses, claws) punch through to whatever renders behind the image.

Parent session observed this concretely during a raccoon-larry illustration generation in blog4 — the generated alpha mask showed eye/glasses/claw holes after `-fuzz -transparent`. A side-by-side test with four flood-fills from the corners showed solid interior coverage, identical background strip quality, and the same sub-second runtime.

## What changed

- `skills/image-explore/generate.py::remove_background` — pre-queries image dimensions via `magick identify`, then flood-fills from all 4 corners (`-alpha set -fuzz 30% -fill none -draw "color X,Y floodfill"` × 4). Docstring rewritten with the "why".
- `skills/image-explore/generate.py` — argparse `--help` for `--transparent` updated.
- `skills/gen-image/SKILL.md` — `--transparent` description rewritten to document the new flood-fill behavior and list the classes of interior pixels it protects.

**Unchanged:** generation prompt (`raccoon-style.txt`, `GREENSCREEN_PROMPT`). The model still renders on magenta; only the post-process changes.

## Why flood-fill, not global `-transparent`

Flood-fill from the 4 corners only reaches the contiguous background region. Interior magenta-tinted pixels are unreachable without crossing through character pixels, so they're preserved automatically by the character's own silhouette. Same fuzz tolerance (30%) still handles edge antialiasing where magenta blends into the subject outline. No ML, no heavy install, still pixel-accurate and sub-second.

## Test plan

- [x] `python3 -m py_compile skills/image-explore/generate.py` — syntax check
- [x] Pre-commit: ruff lint/format, prettier on markdown all pass (`SKIP=test` for the known-flaky telegram test hook tracked in chop-conventions#109)
- [ ] Manual verification with `--transparent` on a raccoon generation: confirm interior pixels survive, edges clean — parent already verified empirically in blog4's raccoon-larry session.