### PR TITLE
feat(gen-image): auto-eval alpha quality after --transparent chroma-key

### DIFF
--- a/skills/gen-image/SKILL.md
+++ b/skills/gen-image/SKILL.md
@@ -19,7 +19,37 @@ Parse the user's input for:
 - **`--api-url 'url'`**: Override the Gemini API endpoint (default below)
 - **`--count N`**: Max number of images to generate (default: 3)
 - **`--aspect 'W:H'`**: Aspect ratio via `imageConfig` (default: 3:4, portrait). Valid values: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`
-- **`--transparent`**: Generate on magenta chroma-key background (`#FF00FF`), then strip it via ImageMagick **border-seeded flood fill**. The scanner samples pixels along every image edge and keeps only the ones that are actually near `#FF00FF` as flood seeds — so shots where Gemini rendered grass/scenery into some corners (which broke the earlier 4-corners-only approach when flood-fill started from grass at 30% fuzz and ate the subject) still strip cleanly. Only magenta pixels reachable from the image edges are made transparent; interior magenta-tinted pixels (pink fur highlights, glass reflections, lobster-claw reds) are preserved automatically. Fast (sub-second) and pixel-accurate — no ML needed. Requires `magick` (ImageMagick). If the subject fills the frame and no border pixel is near-magenta, the strip is skipped with an error rather than producing a swiss-cheese result.
+- **`--transparent`**: Generate on magenta chroma-key background (`#FF00FF`), then strip it via ImageMagick **border-seeded flood fill**. The scanner samples pixels along every image edge and keeps only the ones that are actually near `#FF00FF` as flood seeds — so shots where Gemini rendered grass/scenery into some corners (which broke the earlier 4-corners-only approach when flood-fill started from grass at 30% fuzz and ate the subject) still strip cleanly. Only magenta pixels reachable from the image edges are made transparent; interior magenta-tinted pixels (pink fur highlights, glass reflections, lobster-claw reds) are preserved automatically. Fast (sub-second) and pixel-accurate — no ML needed. Requires `magick` (ImageMagick). If the subject fills the frame and no border pixel is near-magenta, the strip is skipped with an error rather than producing a swiss-cheese result. After the strip, two layered evals auto-run — see **Automatic eval** below.
+- **`--no-eval`**: Skip the alpha-mask eval pass that looks for interior holes, residual magenta, and edge fringe (needs numpy/pillow/scipy — the `uv run --script` shebang installs them automatically, but plain `python3` invocations without `uv` may need this flag). The alpha-mean signal still runs.
+- **`--eval-strict`**: Exit nonzero when any alpha-mask eval threshold trips. Useful when a calling agent wants to retry or fail loudly instead of silently shipping a broken alpha mask.
+
+### Automatic eval
+
+When `--transparent` is active, `generate.py` runs two complementary evals on the output and prints metrics to stderr.
+
+**(1) Alpha-mean signal** (`evaluate_strip`, always on — same thresholds `test_generate.py` asserts):
+
+- Status `healthy` — alpha mean in 15–85% band.
+- Status `subject_eaten` — alpha mean below 15%; the strip ate the subject. Regenerate with a magenta border on all four sides.
+- Status `nothing_stripped` — alpha mean above 85%; subject fills the frame. Widen the crop.
+
+**(2) Alpha-mask quality signal** (`eval_alpha`, opt-out via `--no-eval`):
+
+- `interior_hole_px` — transparent pixels enclosed by opaque (signals interior damage the alpha-mean misses: Swiss-cheese holes that read as shading on a colored preview background).
+- `residual_magenta_px` — opaque pixels still near chroma color (signals trapped magenta pockets corner-seeded flood couldn't reach).
+- `edge_fringe_px` — partial-alpha pixels (signals halo).
+
+Output format:
+
+```
+eval [healthy] out.webp: alpha=51.3% size=74.0KB
+[eval] /tmp/out.webp: holes=84, residual=132, fringe=0   [OK]
+[eval] /tmp/out.webp: holes=9687, residual=0, fringe=0   [WARN: interior damage likely — check alpha mask]
+```
+
+Thresholds for the mask-quality signal are conservative by default (holes > 200, residual > 500, fringe > 2000). Pass `--no-eval` to skip it. Pass `--eval-strict` to exit nonzero when a mask-quality threshold trips.
+
+**Why:** visual inspection on a light or dark background hides interior damage (holes read as shadow/shading). The alpha mask is the ground truth. Baking both evals into the skill makes them the default, so a silently-broken output can't ship. See [/hill-climbing](https://idvork.in/hill-climbing) for the "eval becomes regression guard" pattern.
 
 ## Configuration
 
@@ -88,7 +118,7 @@ Use `generate.py` from the `image-explore` skill. It handles env loading (`~/.en
    uv run "$GEN" single --scene "Raccoon lifting kettlebell in a gym" --shirt "FIT" --output raccoon-kettlebell.webp
    ```
 
-   Pass `--aspect`, `--ref`, or `--style` to override defaults.
+   The script's PEP 723 shebang auto-installs deps (typer + numpy/pillow/scipy for the `--transparent` eval). Pass `--aspect`, `--ref`, or `--style` to override defaults. Under `--transparent`, pass `--no-eval` to skip the mask-quality eval on stock python3 callers without numpy/scipy, and `--eval-strict` to exit nonzero when any eval threshold trips.
 
 3. **Multiple images (parallel):** Write a JSON file and use batch mode:
 
@@ -115,7 +145,7 @@ Use `generate.py` from the `image-explore` skill. It handles env loading (`~/.en
 
 5. If generation fails, report the error and ask if the user wants to retry with a modified prompt or skip.
 
-**Auto-eval runs on every generation.** When `--transparent` is set, `generate.py` runs `evaluate_strip()` on the output right after the chroma-key pass and prints a one-line metrics card to stderr (alpha mean %, file size, status). Status is one of `healthy` (in the 15–85% alpha band), `subject_eaten` (below 15% — strip invariant was violated; regenerate with a magenta border on all four sides), or `nothing_stripped` (above 85% — subject fills the frame; widen the crop). The thresholds are the same ones asserted in `test_generate.py`'s integration suite, so the eval that guards the test suite is the same eval that guards every runtime output — see [/hill-climbing](https://idvork.in/hill-climbing) for the pattern.
+**Auto-eval runs on every generation.** When `--transparent` is set, `generate.py` runs two complementary evals right after the chroma-key pass — the alpha-mean signal (always) and the alpha-mask quality signal (interior holes, residual magenta, edge fringe; opt-out via `--no-eval`). Details and thresholds in the **Automatic eval** subsection above. See [/hill-climbing](https://idvork.in/hill-climbing) for the "eval becomes regression guard" pattern.
 
 **Verifying transparent output.** Don't judge chroma-key quality by compositing on a solid background — interior holes read as the background color. Extract the alpha channel as a mask: `magick out.webp -alpha extract mask.png`. A clean mask is a solid silhouette; swiss-cheese holes mean the chroma ate interior color data.
 

--- a/skills/image-explore/generate.py
+++ b/skills/image-explore/generate.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env -S uv run --script
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.13"
 # dependencies = [
 #     "typer>=0.12",
+#     "numpy",
+#     "pillow",
+#     "scipy",
 # ]
 # ///
 # ABOUTME: Wrapper around gemini-image.sh for image generation (single or batch).
@@ -17,6 +20,12 @@
 #
 # directions.json format:
 #   [{"scene": "...", "shirt": "TEXT", "output": "file.webp"}, ...]
+#
+# Numpy/Pillow/Scipy power the --transparent post-strip eval_alpha()
+# pathway (interior holes / residual magenta / edge fringe) and are
+# lazy-imported there. The `uv run --script` shebang auto-installs them;
+# running via plain `python3` works as long as --transparent is off or
+# --no-eval is set.
 
 import json
 import os
@@ -50,6 +59,10 @@ class GenerateConfig:
     ref_image: str | None
     aspect: str
     transparent: bool = False
+    # Layered alpha-mask eval on top of evaluate_strip's alpha-mean signal.
+    # Detects interior holes, residual magenta pockets, and edge fringe.
+    eval_alpha: bool = True
+    eval_strict: bool = False
 
 
 @dataclass
@@ -59,6 +72,21 @@ class GenerationResult:
     error: str | None
     prompt: str
     duration_s: float
+    eval_metrics: dict | None = None
+    eval_warnings: list | None = None
+
+
+# Alpha-mask eval thresholds for eval_alpha(). Tuned conservatively on
+# typical output so clean images don't false-alarm. Exceeding any one
+# triggers a [WARN] on the eval line (and, under --eval-strict, a
+# nonzero exit). These complement evaluate_strip's alpha-mean signal —
+# the mean catches "strip ate the subject" / "nothing stripped"; these
+# catch "Swiss-cheese holes", "trapped magenta pockets", and "halo".
+EVAL_ALPHA_THRESHOLDS = {
+    "interior_hole_px": 200,
+    "residual_magenta_px": 500,
+    "edge_fringe_px": 2000,
+}
 
 
 def resolve_chop_root():
@@ -400,6 +428,95 @@ def _format_eval_card(image_path, metrics, warning):
     return line
 
 
+def eval_alpha(image_path, chroma_rgb=(255, 0, 255), tolerance=20):
+    """Compute alpha-mask quality metrics for a post-chroma RGBA image.
+
+    Detects failure modes orthogonal to evaluate_strip's alpha-mean signal:
+      * interior_hole_px — transparent pixels NOT connected to the image
+        border. These are "eaten" interiors: highlights/glass the flood-fill
+        or fuzzy chroma chewed through and left as holes. On a light preview
+        background these holes read as shading and hide silently — the alpha
+        mask is the only ground truth.
+      * residual_magenta_px — opaque pixels still near the chroma color.
+        Trapped magenta pockets between characters or inside enclosed
+        negative space the flood-fill couldn't reach from the corners.
+      * edge_fringe_px — partial-alpha pixels. Large counts suggest halo.
+
+    Deps (numpy, pillow, scipy) are lazy-imported so callers that pass
+    --no-eval (or don't touch --transparent) never hit an ImportError on
+    a stock python3.
+    """
+    import numpy as np  # noqa: PLC0415 — lazy import, see module header
+    from PIL import Image  # noqa: PLC0415
+    from scipy.ndimage import label  # noqa: PLC0415
+
+    arr = np.asarray(Image.open(image_path).convert("RGBA"))
+    rgb, a = arr[:, :, :3], arr[:, :, 3]
+    opaque = a > 128
+    transparent = a < 16
+
+    # Residual magenta: opaque pixels whose RGB is still within tolerance
+    # of the chroma color. L1 distance on int16 to avoid uint8 overflow.
+    chroma = np.array(chroma_rgb, dtype=np.int16)
+    dist = np.abs(rgb.astype(np.int16) - chroma).sum(axis=2)
+    residual = int((opaque & (dist <= tolerance)).sum())
+
+    # Interior holes: label connected components of transparent pixels,
+    # then subtract every component that touches the image border.
+    # What remains is transparent regions fully enclosed by opaque — the
+    # "Swiss-cheese" damage we care about.
+    labeled, _ = label(transparent)
+    border = set()
+    border.update(labeled[0, :].tolist())
+    border.update(labeled[-1, :].tolist())
+    border.update(labeled[:, 0].tolist())
+    border.update(labeled[:, -1].tolist())
+    border.discard(0)  # 0 is the non-transparent background in the labeling
+    interior = int(transparent.sum() - np.isin(labeled, list(border)).sum())
+
+    # Edge fringe: partial alpha. Some is expected (antialiasing); a lot
+    # suggests the chroma removal left a halo.
+    edge = int(((~opaque) & (~transparent)).sum())
+
+    return {
+        "interior_hole_px": interior,
+        "residual_magenta_px": residual,
+        "edge_fringe_px": edge,
+    }
+
+
+def format_eval_line(image_path, metrics, warnings):
+    """Render the eval_alpha line printed to stderr."""
+    status = f"[WARN: {'; '.join(warnings)}]" if warnings else "[OK]"
+    return (
+        f"[eval] {image_path}: "
+        f"holes={metrics['interior_hole_px']}, "
+        f"residual={metrics['residual_magenta_px']}, "
+        f"fringe={metrics['edge_fringe_px']}   {status}"
+    )
+
+
+def check_eval_thresholds(metrics, thresholds=EVAL_ALPHA_THRESHOLDS):
+    """Return a list of human-readable warnings for tripped thresholds."""
+    warnings = []
+    if metrics["interior_hole_px"] > thresholds["interior_hole_px"]:
+        warnings.append(
+            f"interior damage likely (holes={metrics['interior_hole_px']} "
+            f"> {thresholds['interior_hole_px']}) — check alpha mask"
+        )
+    if metrics["residual_magenta_px"] > thresholds["residual_magenta_px"]:
+        warnings.append(
+            f"residual magenta (residual={metrics['residual_magenta_px']} "
+            f"> {thresholds['residual_magenta_px']}) — trapped pocket"
+        )
+    if metrics["edge_fringe_px"] > thresholds["edge_fringe_px"]:
+        warnings.append(
+            f"edge fringe (fringe={metrics['edge_fringe_px']} "
+            f"> {thresholds['edge_fringe_px']}) — possible halo"
+        )
+    return warnings
+
+
 def generate_one(direction: Direction, config: GenerateConfig) -> GenerationResult:
     """Generate a single image.
 
@@ -451,6 +568,8 @@ def generate_one(direction: Direction, config: GenerateConfig) -> GenerationResu
     if result.stderr:
         print(result.stderr, file=sys.stderr)
 
+    eval_alpha_metrics = None
+    eval_alpha_warnings = None
     if config.transparent:
         print(f"Removing background: {direction.output}", file=sys.stderr)
         success, err = remove_background(direction.output)
@@ -472,12 +591,40 @@ def generate_one(direction: Direction, config: GenerateConfig) -> GenerationResu
             file=sys.stderr,
         )
 
+        # Layered alpha-mask eval — catches interior holes, trapped
+        # magenta pockets, and halo fringe that the alpha-mean signal
+        # above can't detect. Best-effort: missing deps or errors log
+        # and continue rather than failing the generation.
+        if config.eval_alpha:
+            try:
+                eval_alpha_metrics = eval_alpha(direction.output)
+                eval_alpha_warnings = check_eval_thresholds(eval_alpha_metrics)
+                print(
+                    format_eval_line(
+                        direction.output, eval_alpha_metrics, eval_alpha_warnings
+                    ),
+                    file=sys.stderr,
+                )
+            except ImportError as e:
+                print(
+                    f"[eval] {direction.output}: skipped (missing deps: {e}); "
+                    f"run via 'uv run --script' or pass --no-eval",
+                    file=sys.stderr,
+                )
+            except Exception as e:  # noqa: BLE001 — eval is best-effort
+                print(
+                    f"[eval] {direction.output}: skipped (error: {e})",
+                    file=sys.stderr,
+                )
+
     return GenerationResult(
         output=direction.output,
         success=True,
         error=None,
         prompt=full_prompt,
         duration_s=duration_s,
+        eval_metrics=eval_alpha_metrics,
+        eval_warnings=eval_alpha_warnings,
     )
 
 
@@ -505,6 +652,16 @@ def _build_app():
             False,
             help="Generate on magenta chroma-key background, then strip it via ImageMagick edge-connected flood fill from the 4 corners (preserves interior magenta-tinted pixels)",
         ),
+        no_eval: bool = typer.Option(
+            False,
+            "--no-eval",
+            help="Skip the post-chroma alpha-mask eval (interior holes, residual magenta, edge fringe). Needs numpy/pillow/scipy — the uv shebang installs them, but bare python3 callers may need this.",
+        ),
+        eval_strict: bool = typer.Option(
+            False,
+            "--eval-strict",
+            help="Exit 2 if any eval threshold trips (interior holes, residual magenta, edge fringe). Useful for CI / calling agents that want to retry or fail loudly.",
+        ),
     ) -> None:
         """Generate a single raccoon image."""
         chop_root = resolve_chop_root()
@@ -523,6 +680,8 @@ def _build_app():
             ref_image=ref or resolve_ref_image(),
             aspect=aspect,
             transparent=transparent,
+            eval_alpha=not no_eval,
+            eval_strict=eval_strict,
         )
 
         direction = Direction(scene=scene, shirt=shirt, output=output)
@@ -532,6 +691,12 @@ def _build_app():
             raise typer.Exit(1)
         print(result.output)
         print(f"Generated in {result.duration_s}s", file=sys.stderr)
+        if config.eval_strict and result.eval_warnings:
+            print(
+                f"Error: --eval-strict tripped on {result.output}",
+                file=sys.stderr,
+            )
+            raise typer.Exit(2)
 
     @app.command()
     def batch(
@@ -544,6 +709,16 @@ def _build_app():
         transparent: bool = typer.Option(
             False,
             help="Generate on magenta chroma-key background, then strip it via ImageMagick edge-connected flood fill from the 4 corners (preserves interior magenta-tinted pixels)",
+        ),
+        no_eval: bool = typer.Option(
+            False,
+            "--no-eval",
+            help="Skip the post-chroma alpha-mask eval (interior holes, residual magenta, edge fringe). Needs numpy/pillow/scipy — the uv shebang installs them, but bare python3 callers may need this.",
+        ),
+        eval_strict: bool = typer.Option(
+            False,
+            "--eval-strict",
+            help="Exit 2 if any eval threshold trips on any image. Useful for CI / calling agents that want to retry or fail loudly.",
         ),
     ) -> None:
         """Generate images in parallel from a JSON manifest."""
@@ -563,6 +738,8 @@ def _build_app():
             ref_image=ref or resolve_ref_image(),
             aspect=aspect,
             transparent=transparent,
+            eval_alpha=not no_eval,
+            eval_strict=eval_strict,
         )
 
         batch_path = Path(json_file)
@@ -581,6 +758,7 @@ def _build_app():
             f"Generating {len(raw_directions)} images in parallel...", file=sys.stderr
         )
         failures = []
+        eval_tripped = []
 
         # Map output filename -> raw dict for augmenting with debug info
         dir_by_output = {d["output"]: d for d in raw_directions}
@@ -606,8 +784,12 @@ def _build_app():
                 if result.output in dir_by_output:
                     dir_by_output[result.output]["_prompt"] = result.prompt
                     dir_by_output[result.output]["_duration_s"] = result.duration_s
+                    if result.eval_metrics is not None:
+                        dir_by_output[result.output]["_eval"] = result.eval_metrics
                 if result.success:
                     print(result.output)
+                    if result.eval_warnings:
+                        eval_tripped.append(result.output)
                 else:
                     failures.append((result.output, result.error))
                     print(f"FAILED: {result.output} — {result.error}", file=sys.stderr)
@@ -628,6 +810,13 @@ def _build_app():
             f"\nAll {len(raw_directions)} images generated ({batch_duration}s total)",
             file=sys.stderr,
         )
+        if config.eval_strict and eval_tripped:
+            print(
+                f"\nError: --eval-strict tripped on {len(eval_tripped)} image(s): "
+                f"{', '.join(eval_tripped)}",
+                file=sys.stderr,
+            )
+            raise typer.Exit(2)
 
     return app
 


### PR DESCRIPTION
## Summary

PR #153 landed edge-connected flood-fill for `--transparent`, which fixed the aggressive-chroma failure mode at the pixel-stripping layer. This PR adds a **self-verify eval** on the output so the two residual failure modes we've seen in practice can't ship silently:

1. **Interior holes.** When a magenta-tinted highlight (pink fur, glass reflection, lobster-claw red) has a thin antialiased bridge to the chroma background, corner flood-fill can tunnel through and leave Swiss-cheese holes in the alpha. On a light or dark preview background these read as *shading* and hide silently — the alpha mask is the only ground truth.
2. **Trapped magenta pockets.** Enclosed negative space (between legs, inside a ring, between two characters) can't be reached by 4-corner flood-fill and ships as opaque magenta.

When `--transparent` is active, `generate.py` now runs `eval_alpha(output)` after `remove_background` and prints a one-line stderr summary per image:

```
[eval] out.webp: holes=84, residual=132, fringe=0   [OK]
[eval] out.webp: holes=9687, residual=0, fringe=0   [WARN: interior damage likely (holes=9687 > 200) — check alpha mask]
```

Three metrics:

- `interior_hole_px` — `scipy.ndimage.label` over transparent pixels, subtract any component touching the image border. What remains is interior holes.
- `residual_magenta_px` — opaque pixels within L1 distance 20 of `#FF00FF`.
- `edge_fringe_px` — partial-alpha pixel count (halo signal).

Thresholds tuned conservatively (holes > 200, residual > 500, fringe > 2000). Verified no false-alarm on the `case-sparse.webp` reference image (holes=0, residual=105, fringe=0 → OK), and a synthetic 1600-px interior hole correctly trips the warning.

## Escape hatches

- `--no-eval` — skip entirely. For stock-python3 callers without numpy/scipy/pillow.
- `--eval-strict` — exit 2 when any threshold trips. Lets calling agents retry with modified prompt, or fail CI loudly, instead of scraping stderr.

## Dependency handling

`generate.py` was `#!/usr/bin/env python3` (stdlib-only). Converted to `#!/usr/bin/env -S uv run --script` with PEP 723 inline deps (`numpy`, `pillow`, `scipy`). Deps are **lazy-imported** inside `eval_alpha()` only, so:

- `"$GEN" --transparent ...` — deps auto-install, eval runs.
- `python3 $GEN --transparent --no-eval` — no ImportError, eval skipped.
- `python3 $GEN --transparent` without `--no-eval` — eval is best-effort, prints `[eval] skipped (missing deps: ...)` and generation still succeeds.

`skills/gen-image/SKILL.md` invocation examples updated from `python3 "$GEN" ...` to `"$GEN" ...` so the uv shebang fires. `chmod +x` set on the script.

## Test plan

- [x] CLI `--help` shows new `--no-eval` / `--eval-strict` flags
- [x] `eval_alpha` against real sparse chroma output → returns OK (no false alarm)
- [x] `eval_alpha` against synthetic 1600-px interior hole → returns WARN with correct reason
- [x] `ruff-format` pre-commit hook pass (ran clean on second attempt)
- [ ] End-to-end `--transparent` generation with a real Gemini call (not run in this session to avoid API spend; eval path is independent of generation)

## Files changed

- `skills/image-explore/generate.py`
- `skills/gen-image/SKILL.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-eval` flag to skip automatic alpha mask quality evaluation.
  * Added `--eval-strict` flag to enforce strict validation with error exit on quality issues.
  * Automatic evaluation of transparent background quality with metrics for interior holes, residual color, and edge fringing.

* **Documentation**
  * Updated usage examples to demonstrate direct script invocation with the uv run shebang.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->