### PR TITLE
fix(delegate-to-other-repo): prefer upstream/<default> over origin/<default> as worktree base

### DIFF
--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -46,8 +46,11 @@ Parent (you)                             Subagent (fresh context)
 ──────────────────                       ─────────────────────────
 1. Resolve target repo
 2. git -C <T> fetch origin
+   (plus upstream if present)
 3. Create worktree off
-   origin/<default-branch>
+   upstream/<default> if
+   upstream exists, else
+   origin/<default>
 4. Build brief (template +
    substitutions)
 5. Agent tool dispatch  ─────────────►   1. cd <worktree>
@@ -140,9 +143,10 @@ All validation runs via `git -C <path>` — never `cd` into the target:
 3. Has an `origin` remote that resolves:
    `git -C "$T" remote get-url origin`
 4. Default branch is resolvable (see Phase 2 recipe)
-5. `origin/<default>` is reachable after `git fetch`
+5. `$base_ref` (upstream/<default> if upstream exists, else
+   origin/<default>) is reachable after `git fetch`
 
-**Not required to be clean.** Worktrees off `origin/<default>` are safe
+**Not required to be clean.** Worktrees off the remote base ref are safe
 even when the target's working tree is dirty.
 
 ## Phase 2: Create the worktree
@@ -150,7 +154,7 @@ even when the target's working tree is dirty.
 **DO NOT delegate to `superpowers:using-git-worktrees`.** That skill
 branches off current HEAD, auto-runs `npm install` / `cargo build`, and
 runs baseline tests — none of which are correct for delegating a change
-off a fresh `origin/<default>` that may be a doc-only edit.
+off a fresh canonical base ref that may be a doc-only edit.
 
 Full shell recipe lives at [`worktree-recipe.md`](worktree-recipe.md).
 Read that file and follow it verbatim. Key points:
@@ -171,7 +175,11 @@ Read that file and follow it verbatim. Key points:
   mutating any branch's history, works regardless of target's
   current branch, and survives branch-protected defaults
 - Creates the worktree at `.worktrees/delegated-<slug>` on branch
-  `delegated/<slug>` rooted at `origin/<default>`
+  `delegated/<slug>` rooted at `$base_ref` — prefers
+  `upstream/<default>` when an `upstream` remote is present (the
+  normal fork-workflow case), else falls back to `origin/<default>`.
+  Basing off upstream avoids starting the subagent on a stale fork
+  ref when `origin` lags canonical.
 
 ### V1 limitation
 
@@ -473,8 +481,11 @@ Only the subagent `cd`s.
 
 ### Hardcoding `origin/main`
 
-Breaks on repos with `master` or `trunk` as the default branch. Fix:
-resolve the default branch with the fallback chain in `worktree-recipe.md`.
+Breaks on repos with `master` or `trunk` as the default branch, and on
+two-remote fork workflows where `origin` is the fork and can lag
+`upstream`. Fix: resolve both the default branch name AND the base
+remote via the chain in `worktree-recipe.md` — upstream preferred when
+it exists, origin as fallback.
 
 ### Skipping `remote set-head --auto` after fetch
 

--- a/skills/delegate-to-other-repo/worktree-recipe.md
+++ b/skills/delegate-to-other-repo/worktree-recipe.md
@@ -2,8 +2,9 @@
 
 > Phase 2 shell recipe for `delegate-to-other-repo`. Read the parent
 > `SKILL.md` first. Follow this recipe verbatim — the ordering of
-> `set-head`, the step-by-step default-branch resolution, and the
-> gitignore-commit branch guard are all load-bearing.
+> `set-head`, the step-by-step default-branch resolution, the
+> upstream-over-origin base selection, and the gitignore-commit
+> branch guard are all load-bearing.
 
 ## Inputs
 
@@ -27,6 +28,15 @@ task_description=<user's task description, raw>
 # stale value below. `--auto` is a no-op if origin/HEAD already matches.
 git -C "$T" fetch origin
 git -C "$T" remote set-head origin --auto >/dev/null 2>&1 || true
+
+# If the target has a two-remote fork workflow, refresh upstream too —
+# we'll prefer upstream/<default> as the base below. `origin` in a
+# fork workflow points at the user's fork, which can lag the canonical
+# `upstream` by several commits; basing the worktree on stale origin
+# forces the subagent to detect and rebase at runtime.
+if git -C "$T" remote | grep -qx upstream; then
+  git -C "$T" fetch upstream
+fi
 
 # -----------------------------------------------------------------------------
 # 2. Determine default branch.
@@ -53,10 +63,30 @@ fi
 default_branch="${default_branch:-main}"
 
 # -----------------------------------------------------------------------------
-# 3. Verify origin/<default> is reachable.
+# 2.5. Select base ref — prefer upstream over origin when both exist.
 # -----------------------------------------------------------------------------
-if ! git -C "$T" rev-parse --verify "origin/$default_branch" >/dev/null 2>&1; then
-  echo "STOP: origin/$default_branch is not reachable in $T after fetch."
+# When both `upstream` and `origin` exist (fork workflow), the canonical
+# main lives on upstream and `origin/<default>` can lag. Base the
+# delegated worktree on upstream/<default> so the subagent starts
+# from canonical state. Fall back to origin/<default> otherwise.
+#
+# Incident that surfaced this: a delegation on 2026-04-16 was branched
+# from `origin/main` 4 commits behind `upstream/main`; the target file
+# the task referenced didn't exist yet on that base and the subagent
+# had to detect and rebase at runtime.
+base_remote=origin
+if git -C "$T" remote | grep -qx upstream; then
+  if git -C "$T" rev-parse --verify "upstream/$default_branch" >/dev/null 2>&1; then
+    base_remote=upstream
+  fi
+fi
+base_ref="$base_remote/$default_branch"
+
+# -----------------------------------------------------------------------------
+# 3. Verify $base_ref is reachable.
+# -----------------------------------------------------------------------------
+if ! git -C "$T" rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+  echo "STOP: $base_ref is not reachable in $T after fetch."
   exit 1
 fi
 
@@ -110,7 +140,7 @@ path="$T/.worktrees/delegated-$slug"
 # ignore entry — but we deliberately avoid committing to `.gitignore`.
 #
 # Why not commit .gitignore on the default branch?
-#   - The delegated branch is created from `origin/$default_branch`
+#   - The delegated branch is created from `$base_ref`
 #     (a clean remote ref) so a local-only commit on the default
 #     branch wouldn't be in the delegated branch's base anyway.
 #   - Committing on the target's *current* branch would pollute
@@ -150,11 +180,11 @@ fi
 # -----------------------------------------------------------------------------
 # `worktree add` is the only step that mutates the working set. If it
 # fails (path collision, ref missing), STOP and report.
-git -C "$T" worktree add "$path" -b "$branch" "origin/$default_branch"
+git -C "$T" worktree add "$path" -b "$branch" "$base_ref"
 
 echo "Worktree ready: $path"
 echo "Branch:         $branch"
-echo "Base:           origin/$default_branch"
+echo "Base:           $base_ref"
 ```
 
 ## Why this skill does NOT call `superpowers:using-git-worktrees`
@@ -162,14 +192,14 @@ echo "Base:           origin/$default_branch"
 That skill:
 
 - Branches off current HEAD — no way to pass a base ref like
-  `origin/<default>`
+  `upstream/<default>` (or `origin/<default>` as fallback)
 - Auto-runs `npm install` / `cargo build` / `pip install` — noisy
   and wrong for doc-only or tiny changes
 - Runs the target's test suite as a baseline — slow, and unnecessary
   before the subagent has done anything
 
 Those are good defaults for same-repo feature work but wrong defaults
-for cross-repo delegation off a fresh `origin/<default>`. This recipe
+for cross-repo delegation off a fresh canonical base ref. This recipe
 is the explicit alternative.
 
 ## Output
@@ -177,7 +207,9 @@ is the explicit alternative.
 On success:
 
 - Worktree at `$T/.worktrees/delegated-<slug>` checked out to
-  `delegated/<slug>` branch, based on `origin/<default-branch>`
+  `delegated/<slug>` branch, based on `$base_ref` —
+  `upstream/<default-branch>` when an `upstream` remote exists (the
+  normal fork-workflow case), else `origin/<default-branch>`
 - Possibly one new line appended to `.git/info/exclude` ensuring
   `.worktrees/` is ignored. This is local-only, untracked, and
   shared across all worktrees via the common git dir — no branch


### PR DESCRIPTION
## Summary

In fork workflows (`origin` = user's fork, `upstream` = canonical), `origin/<default>` can lag `upstream/<default>` by several commits. The current `delegate-to-other-repo/worktree-recipe.md` bases the delegated worktree on `origin/<default>`, so the subagent starts on stale state — it either detects the skew and rebases at runtime, or silently fails if its target file didn't exist yet on the stale ref.

The incident that surfaced this: a delegation on 2026-04-16 was branched from `origin/main` 4 commits behind `upstream/main`; the target file (`skills/explainers/methodology.md`) didn't exist yet on that base, and the subagent had to detect-and-rebase mid-task. The rebase worked, but it was a foot-gun that shouldn't have been necessary. See upstream commit `de5b42d` (`docs: session learnings from dolt-explainer`) — the PR that shipped right after this happened.

## Fix

**`skills/delegate-to-other-repo/worktree-recipe.md`:**

- **Section 1** — if an `upstream` remote exists, fetch it too. No-op when there's no upstream.
- **New section 2.5** — select `$base_ref`: prefer `upstream/<default>` when `upstream` exists and is reachable, fall back to `origin/<default>` otherwise.
- **Section 3** — verify `$base_ref` instead of `origin/<default>`. STOP message references `$base_ref`.
- **Section 6** — `git worktree add` uses `"$base_ref"`; `echo "Base: ..."` prints `$base_ref`.
- Preamble and Output sections updated to reflect the dynamic base.

**`skills/delegate-to-other-repo/SKILL.md`:**

- Phase 2 bullet, Flow-at-a-glance diagram, and Phase 1d validation step updated to describe the new base selection.
- "Hardcoding `origin/main`" common-mistake entry broadened — the recipe now resolves the right *remote* in addition to the right branch name.

**No new "Common mistakes" entry** — this is a behavior improvement inside the recipe, not a user-facing gotcha. The existing "Hardcoding origin/main" entry already covers the spirit.

## Verification

- Recipe block bash-syntax-checks clean (`awk` extracted the Recipe fenced block, piped to `bash -n`)
- Pre-commit hooks passed (prettier; `test` hook skipped per the known corruption risk documented in root CLAUDE.md for docs-only edits that don't exercise `up-to-date`)
- Repos with no `upstream` remote hit the fallback path unchanged — `base_remote=origin` stays as-is

## Test plan

- [ ] Delegate a task into a fork-workflow target (e.g. chop-conventions itself with `origin`=fork + `upstream`=canonical) and confirm the worktree is based on `upstream/main`
- [ ] Delegate into a single-remote target (canonical `origin` only) and confirm the worktree is based on `origin/main`
- [ ] Delegate into a target whose default branch is `master` or `trunk` and confirm the default-branch resolution still works