### PR TITLE
refactor: argparse → Typer subcommands for 4 CLI scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,15 @@ Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) M
 - Working example: [`skills/up-to-date/diagnose.py`](skills/up-to-date/diagnose.py) — stdlib-only, `uv run` shebang, parallelized subprocess calls, unit-tested pure functions.
 - **Lazy-import PEP 723 deps that tests don't need.** Scripts with `uv run --script` shebangs self-bootstrap their deps at runtime, but tests and pre-commit hooks import the module in system Python (no `uv`). Put the dep-specific import inside a builder function (e.g. `_build_app()`) called only from `if __name__ == "__main__":`. Tests import the pure-function layer without `ModuleNotFoundError`. Reference: `skills/harden-telegram/tools/telegram_debug.py`.
 
+## Python CLI Apps
+
+**User-facing CLIs use Typer + Rich; programmatic JSON-emitting helpers stay stdlib-only.** The dividing line: if a human will type `--help`, use Typer. If only Claude or a pipeline calls it, argparse (or nothing) is fine.
+
+- **Typer subcommands replace manual mutual exclusion.** Batch-vs-single mode, action flags that can't combine — these are subcommands, not `parser.error()` calls. Typer enforces "exactly one subcommand" for free; argparse requires hand-written validation that rots.
+- **`_build_app()` lazy-import pattern.** `import typer` goes inside a `_build_app()` function called only from `if __name__ == "__main__":`. Tests and pre-commit hooks import the pure-function layer in system Python without `ModuleNotFoundError`. See "Scripting Language Defaults → Lazy-import PEP 723 deps" above.
+- **PEP 723 shebang with `typer>=0.12` dependency.** Scripts self-bootstrap via `#!/usr/bin/env -S uv run --script` — no venv, no pip, no setup. Typer is the only runtime dep; Rich comes transitively.
+- **Reference implementation:** [`skills/harden-telegram/tools/telegram_debug.py`](skills/harden-telegram/tools/telegram_debug.py) — 6 subcommands, `_build_app()` pattern, `app.callback(invoke_without_command=True)` for a default mode.
+
 ## Parsing Claude Session Data
 
 - **Subagents live at `~/.claude/projects/<proj>/<session-uuid>/subagents/agent-*.jsonl`**, NOT inside the main session JSONL. Scripts scanning session data must glob `**/subagents/*.jsonl` or undercount tokens by ~18% (measured against ~40k assistant messages).

--- a/python/python-cli.md
+++ b/python/python-cli.md
@@ -62,6 +62,60 @@ if **name** == "**main**":
 app()
 </example>
 
+<example>
+# Lazy-import pattern for testability (tests run in system Python without uv)
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "typer>=0.12",
+# ]
+# ///
+"""My CLI tool — single or batch mode."""
+
+import json
+import sys
+from pathlib import Path
+
+# Pure logic — importable by tests without typer
+def process_one(item: dict) -> dict:
+    return {"result": item["name"].upper()}
+
+def _build_app():
+    """Wire Typer app. Called only from __main__ so tests skip the typer import."""
+    import typer
+
+    app = typer.Typer(
+        help="My CLI tool — process items.",
+        add_completion=False,
+        no_args_is_help=True,
+    )
+
+    @app.command()
+    def single(
+        name: str = typer.Argument(..., help="Item name to process"),
+        output: str = typer.Option(..., "--output", help="Output file path"),
+    ) -> None:
+        """Process a single item."""
+        result = process_one({"name": name})
+        Path(output).write_text(json.dumps(result))
+        print(output)
+
+    @app.command()
+    def batch(
+        json_file: str = typer.Argument(..., help="JSON file with items array"),
+    ) -> None:
+        """Process items in parallel from a JSON file."""
+        items = json.loads(Path(json_file).read_text())
+        for item in items:
+            result = process_one(item)
+            print(json.dumps(result))
+
+    return app
+
+if __name__ == "__main__":
+    _build_app()()
+</example>
+
 <example type="invalid">
 import typer  # Missing UV script configuration
 

--- a/skills/gen-image/SKILL.md
+++ b/skills/gen-image/SKILL.md
@@ -85,7 +85,7 @@ Use `generate.py` from the `image-explore` skill. It handles env loading (`~/.en
 2. **Single image:**
 
    ```bash
-   python3 "$GEN" --scene "Raccoon lifting kettlebell in a gym" --shirt "FIT" --output raccoon-kettlebell.webp
+   uv run "$GEN" single --scene "Raccoon lifting kettlebell in a gym" --shirt "FIT" --output raccoon-kettlebell.webp
    ```
 
    Pass `--aspect`, `--ref`, or `--style` to override defaults.
@@ -108,7 +108,7 @@ Use `generate.py` from the `image-explore` skill. It handles env loading (`~/.en
    ```
 
    ```bash
-   python3 "$GEN" --batch illustrations.json --aspect 3:4
+   uv run "$GEN" batch illustrations.json --aspect 3:4
    ```
 
 4. After generation, show each image to the user by reading the file with the Read tool (which renders images inline).

--- a/skills/gen-stt/SKILL.md
+++ b/skills/gen-stt/SKILL.md
@@ -140,7 +140,7 @@ a tight end-to-end test:
 GEN_TTS=~/gits/chop-conventions/skills/gen-tts/generate-tts.py
 GEN_STT=~/gits/chop-conventions/skills/gen-stt/parakeet-stt.py
 
-"$GEN_TTS" --text "Hello from Larry. This is the voice pipeline test." --output /tmp/roundtrip.wav
+"$GEN_TTS" single --text "Hello from Larry. This is the voice pipeline test." --output /tmp/roundtrip.wav
 "$GEN_STT" single /tmp/roundtrip.wav --output /tmp/roundtrip.txt
 cat /tmp/roundtrip.txt
 # → "Hello from Larry. This is the voice pipeline test."

--- a/skills/gen-stt/SKILL.md
+++ b/skills/gen-stt/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gen-stt
 description: "Transcribe audio to text locally via NVIDIA Parakeet TDT 0.6B ONNX — single clip or batch parallel, no API key"
-argument-hint: "<audio-file-or-dir> [--output path.txt] [--json] [--batch-dir dir]"
+argument-hint: "single <file> | batch-dir <dir> | batch-files <file...> [--json] [--output path]"
 allowed-tools: Bash, Read, Write, Glob, Grep
 ---
 
@@ -21,8 +21,9 @@ voice-in / voice-out pipeline.
 
 Parse the user's input for:
 
-- **Input**: Audio file path (`--input`), directory of audio files
-  (`--batch-dir`), or space-separated list (`--batch-files`). Accepted
+- **Input**: Audio file path (`single` subcommand), directory of audio
+  files (`batch-dir` subcommand), or space-separated list (`batch-files`
+  subcommand). Accepted
   formats: WAV, OGG, OGA, MP3, M4A, FLAC, AAC, OPUS — anything ffmpeg
   can read. Non-WAV (or non-16kHz-mono) inputs are auto-transcoded to
   16 kHz mono 16-bit PCM WAV (Parakeet's training sample rate) in a
@@ -52,8 +53,8 @@ Parse the user's input for:
 - **Canonical script**: `parakeet-stt.py` — single Python entry point
   handling transcode detection, ffmpeg invocation, onnx-asr dispatch,
   and parallel batch via `ThreadPoolExecutor`. Uses PEP-723 inline
-  metadata with stdlib only (`subprocess`, `pathlib`, `wave`, `json`,
-  `argparse`, `concurrent.futures`), launched via `uv run --script`.
+  metadata with stdlib (`subprocess`, `pathlib`, `wave`, `json`,
+  `concurrent.futures`) plus `typer>=0.12`, launched via `uv run --script`.
 
 ## Model & Pipeline
 
@@ -93,13 +94,13 @@ level) and `ionice -p <pid>` (IO class `idle`).
 
 ```bash
 GEN_STT="$(git -C ~/gits/chop-conventions rev-parse --show-toplevel)/skills/gen-stt/parakeet-stt.py"
-"$GEN_STT" --input /tmp/clip.ogg --output /tmp/transcript.txt
+"$GEN_STT" single /tmp/clip.ogg --output /tmp/transcript.txt
 ```
 
 ### Single file — JSON output
 
 ```bash
-"$GEN_STT" --input /tmp/clip.wav --json --output /tmp/transcript.json
+"$GEN_STT" single /tmp/clip.wav --json --output /tmp/transcript.json
 ```
 
 Produces:
@@ -116,7 +117,7 @@ Produces:
 ### Batch (parallel) — directory
 
 ```bash
-"$GEN_STT" --batch-dir /tmp/voice-memos --output-dir /tmp/transcripts
+"$GEN_STT" batch-dir /tmp/voice-memos --output-dir /tmp/transcripts
 ```
 
 Every audio file under `/tmp/voice-memos` gets a `<stem>.txt` in
@@ -127,7 +128,7 @@ writes `<stem>.json` and emits a summary JSON on stdout. Without
 ### Batch — explicit file list
 
 ```bash
-"$GEN_STT" --batch-files /tmp/a.ogg /tmp/b.m4a /tmp/c.wav --json
+"$GEN_STT" batch-files /tmp/a.ogg /tmp/b.m4a /tmp/c.wav --json
 ```
 
 ## Round-Trip Integration Test
@@ -140,7 +141,7 @@ GEN_TTS=~/gits/chop-conventions/skills/gen-tts/generate-tts.py
 GEN_STT=~/gits/chop-conventions/skills/gen-stt/parakeet-stt.py
 
 "$GEN_TTS" --text "Hello from Larry. This is the voice pipeline test." --output /tmp/roundtrip.wav
-"$GEN_STT" --input /tmp/roundtrip.wav --output /tmp/roundtrip.txt
+"$GEN_STT" single /tmp/roundtrip.wav --output /tmp/roundtrip.txt
 cat /tmp/roundtrip.txt
 # → "Hello from Larry. This is the voice pipeline test."
 ```

--- a/skills/gen-stt/parakeet-stt.py
+++ b/skills/gen-stt/parakeet-stt.py
@@ -1,21 +1,21 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.10"
-# dependencies = []
+# dependencies = [
+#     "typer>=0.12",
+# ]
 # ///
 # ABOUTME: Local speech-to-text via NVIDIA Parakeet TDT 0.6B ONNX — single file or batch.
 # ABOUTME: Auto-transcodes non-16kHz/non-mono audio via ffmpeg; wraps every subprocess
 # ABOUTME: with `nice -n 19 ionice -c 3 env OMP_NUM_THREADS=2 ORT_NUM_THREADS=2 MKL_NUM_THREADS=2`.
 # ABOUTME: No API key — uses the local nemo-parakeet-tdt-0.6b-v2 ONNX model via onnx-asr.
 #
-# Single mode:
-#   parakeet-stt.py --input clip.wav --output transcript.txt
-#   parakeet-stt.py --input clip.ogg --json --output transcript.json
-#
-# Batch mode (parallel):
-#   parakeet-stt.py --batch-dir /path/to/audio/dir
-#   parakeet-stt.py --batch-dir /path/to/audio/dir --json --max-workers 2
-#   parakeet-stt.py --batch-files a.wav b.m4a c.ogg
+# Subcommands:
+#   parakeet-stt.py single clip.wav --output transcript.txt
+#   parakeet-stt.py single clip.ogg --json --output transcript.json
+#   parakeet-stt.py batch-dir /path/to/audio/dir
+#   parakeet-stt.py batch-dir /path/to/audio/dir --json --max-workers 2
+#   parakeet-stt.py batch-files a.wav b.m4a c.ogg
 #
 # Mandatory nice-wrap (BAKED IN — there is no code path that skips it):
 #   nice -n 19 ionice -c 3 env OMP_NUM_THREADS=2 ORT_NUM_THREADS=2 MKL_NUM_THREADS=2 <cmd>
@@ -23,9 +23,6 @@
 # Empirically 2 threads is FASTER than onnxruntime's default on consumer CPUs
 # because the default thrashes.
 
-from __future__ import annotations
-
-import argparse
 import json
 import subprocess
 import sys
@@ -304,174 +301,49 @@ def default_output_path(
     return target_dir / f"{input_path.stem}{suffix}"
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Transcribe audio via local Parakeet TDT 0.6B ONNX "
-            "(single or batch). No API key required."
-        ),
-    )
+def _run_batch(
+    inputs: list[Path],
+    *,
+    json_mode: bool,
+    keep_wav: bool,
+    model: str,
+    max_workers: int,
+    output_dir: Path | None,
+) -> None:
+    """Shared batch execution logic for batch-dir and batch-files subcommands."""
+    import typer
 
-    # Single mode
-    parser.add_argument(
-        "--input",
-        default=None,
-        help="Single audio file to transcribe",
-    )
-    parser.add_argument(
-        "--output",
-        default=None,
-        help="Output transcript path (single mode). Defaults to <input>.txt / .json.",
-    )
+    if max_workers < 1:
+        print(
+            f"Error: --max-workers must be >= 1 (got {max_workers})",
+            file=sys.stderr,
+        )
+        raise typer.Exit(2)
 
-    # Batch mode
-    parser.add_argument(
-        "--batch-dir",
-        default=None,
-        metavar="DIR",
-        help="Directory of audio files to transcribe in parallel",
-    )
-    parser.add_argument(
-        "--batch-files",
-        nargs="+",
-        default=None,
-        metavar="PATH",
-        help="Space-separated list of audio files to transcribe in parallel",
-    )
-    parser.add_argument(
-        "--output-dir",
-        default=None,
-        metavar="DIR",
-        help="Batch mode: write transcripts to this dir instead of alongside inputs",
-    )
-
-    # Shared
-    parser.add_argument(
-        "--json",
-        action="store_true",
-        help="Emit {text, duration_s, model, elapsed_s} JSON instead of plain text",
-    )
-    parser.add_argument(
-        "--keep-wav",
-        action="store_true",
-        help="Retain the intermediate transcoded WAV file (debugging)",
-    )
-    parser.add_argument(
-        "--model",
-        default=DEFAULT_MODEL,
-        help=f"onnx-asr model name (default: {DEFAULT_MODEL})",
-    )
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=1,
-        help=(
-            "Parallel batch worker count (default: 1 — empirically faster than 2 "
-            "on consumer CPUs because OMP_NUM_THREADS=2 × N_workers still thrashes)."
-        ),
-    )
-
-    args = parser.parse_args()
-
-    modes = sum(bool(x) for x in (args.input, args.batch_dir, args.batch_files))
-    if modes == 0:
-        parser.error("Provide --input, --batch-dir, or --batch-files")
-    if modes > 1:
-        parser.error("Use exactly one of --input / --batch-dir / --batch-files")
-
-    output_dir = Path(args.output_dir).expanduser() if args.output_dir else None
-
-    # Shared work-root for intermediate transcoded WAVs.
     work_root = Path("/tmp") / f"parakeet-stt-{int(time.time() * 1000)}"
     work_root.mkdir(parents=True, exist_ok=True)
 
     try:
-        # --- Single mode ---------------------------------------------------
-        if args.input:
-            input_path = Path(args.input).expanduser()
-            if not input_path.exists():
-                print(f"Error: input file not found: {input_path}", file=sys.stderr)
-                sys.exit(1)
-            output_path = (
-                Path(args.output).expanduser()
-                if args.output
-                else default_output_path(input_path, args.json, output_dir)
-            )
-            job = STTJob(
-                input_path=input_path,
-                output_path=output_path,
-                json_mode=args.json,
-                keep_wav=args.keep_wav,
-                model=args.model,
-            )
-            result = transcribe_one(job, work_root)
-            if not result.success:
-                print(f"Error: {result.error}", file=sys.stderr)
-                sys.exit(1)
-            # Stdout contract: transcript text (or JSON) → stdout, so the tool
-            # composes in pipelines, e.g. `TEXT=$(parakeet-stt.py --input x.wav)`.
-            # The saved path is echoed to stderr instead.
-            print(result.text or "")
-            print(f"Saved: {result.output_path}", file=sys.stderr)
-            print(f"Transcribed in {result.elapsed_s}s", file=sys.stderr)
-            return
-
-        # --- Batch mode ----------------------------------------------------
-        inputs: list[Path] = []
-        if args.batch_dir:
-            batch_dir = Path(args.batch_dir).expanduser()
-            inputs = discover_audio_files(batch_dir)
-            if not inputs:
-                print(
-                    f"Error: no audio files found under {batch_dir} "
-                    f"(accepted: {sorted(AUDIO_EXTS)})",
-                    file=sys.stderr,
-                )
-                sys.exit(1)
-        else:
-            for raw in args.batch_files:
-                raw = raw.strip()
-                if not raw:
-                    continue
-                p = Path(raw).expanduser()
-                if not p.exists():
-                    print(f"Error: batch file not found: {p}", file=sys.stderr)
-                    sys.exit(1)
-                inputs.append(p)
-            if not inputs:
-                print(
-                    "Error: --batch-files was empty",
-                    file=sys.stderr,
-                )
-                sys.exit(2)
-
-        if args.max_workers < 1:
-            print(
-                f"Error: --max-workers must be >= 1 (got {args.max_workers})",
-                file=sys.stderr,
-            )
-            sys.exit(2)
-
         jobs: list[STTJob] = [
             STTJob(
                 input_path=p,
-                output_path=default_output_path(p, args.json, output_dir),
-                json_mode=args.json,
-                keep_wav=args.keep_wav,
-                model=args.model,
+                output_path=default_output_path(p, json_mode, output_dir),
+                json_mode=json_mode,
+                keep_wav=keep_wav,
+                model=model,
             )
             for p in inputs
         ]
 
         print(
             f"Transcribing {len(jobs)} files in parallel "
-            f"(max_workers={args.max_workers})...",
+            f"(max_workers={max_workers})...",
             file=sys.stderr,
         )
 
         failures: list[tuple[Path, str | None]] = []
         batch_t0 = time.monotonic()
-        workers = min(args.max_workers, len(jobs))
+        workers = min(max_workers, len(jobs))
         with ThreadPoolExecutor(max_workers=workers) as pool:
             futures = {
                 pool.submit(transcribe_one, j, work_root): j for j in jobs
@@ -494,9 +366,9 @@ def main() -> None:
                 f"\n{len(failures)}/{len(jobs)} failed ({batch_duration}s total)",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            raise typer.Exit(1)
 
-        if args.json:
+        if json_mode:
             summary = {
                 "total": len(jobs),
                 "succeeded": len(jobs) - len(failures),
@@ -510,8 +382,6 @@ def main() -> None:
             file=sys.stderr,
         )
     finally:
-        # Best-effort cleanup of shared work root (individual jobs clean
-        # their own files unless --keep-wav was set).
         try:
             if work_root.exists() and not any(work_root.iterdir()):
                 work_root.rmdir()
@@ -519,5 +389,194 @@ def main() -> None:
             pass
 
 
+def _build_app():
+    """Wire Typer app. Called only from __main__ so tests skip the typer import."""
+    import typer
+
+    app = typer.Typer(
+        help=(
+            "Transcribe audio via local Parakeet TDT 0.6B ONNX "
+            "(single or batch). No API key required."
+        ),
+        add_completion=False,
+        no_args_is_help=True,
+    )
+
+    @app.command()
+    def single(
+        input_file: Path,
+        output: str | None = typer.Option(
+            None,
+            help="Output transcript path. Defaults to <input>.txt / .json.",
+        ),
+        json: bool = typer.Option(
+            False,
+            "--json",
+            help="Emit {text, duration_s, model, elapsed_s} JSON instead of plain text",
+        ),
+        keep_wav: bool = typer.Option(
+            False,
+            "--keep-wav",
+            help="Retain the intermediate transcoded WAV file (debugging)",
+        ),
+        model: str = typer.Option(
+            DEFAULT_MODEL,
+            help=f"onnx-asr model name (default: {DEFAULT_MODEL})",
+        ),
+    ) -> None:
+        """Transcribe one audio file."""
+        input_path = input_file.expanduser()
+        if not input_path.exists():
+            print(f"Error: input file not found: {input_path}", file=sys.stderr)
+            raise typer.Exit(1)
+
+        output_path = (
+            Path(output).expanduser()
+            if output
+            else default_output_path(input_path, json, None)
+        )
+
+        work_root = Path("/tmp") / f"parakeet-stt-{int(time.time() * 1000)}"
+        work_root.mkdir(parents=True, exist_ok=True)
+
+        try:
+            job = STTJob(
+                input_path=input_path,
+                output_path=output_path,
+                json_mode=json,
+                keep_wav=keep_wav,
+                model=model,
+            )
+            result = transcribe_one(job, work_root)
+            if not result.success:
+                print(f"Error: {result.error}", file=sys.stderr)
+                raise typer.Exit(1)
+            # Stdout contract: transcript text (or JSON) → stdout, so the tool
+            # composes in pipelines, e.g. `TEXT=$(parakeet-stt.py single x.wav)`.
+            # The saved path is echoed to stderr instead.
+            print(result.text or "")
+            print(f"Saved: {result.output_path}", file=sys.stderr)
+            print(f"Transcribed in {result.elapsed_s}s", file=sys.stderr)
+        finally:
+            try:
+                if work_root.exists() and not any(work_root.iterdir()):
+                    work_root.rmdir()
+            except OSError:
+                pass
+
+    @app.command("batch-dir")
+    def batch_dir(
+        directory: Path,
+        output_dir: str | None = typer.Option(
+            None,
+            "--output-dir",
+            help="Write transcripts to this dir instead of alongside inputs",
+        ),
+        json: bool = typer.Option(
+            False,
+            "--json",
+            help="Emit {text, duration_s, model, elapsed_s} JSON instead of plain text",
+        ),
+        keep_wav: bool = typer.Option(
+            False,
+            "--keep-wav",
+            help="Retain the intermediate transcoded WAV file (debugging)",
+        ),
+        model: str = typer.Option(
+            DEFAULT_MODEL,
+            help=f"onnx-asr model name (default: {DEFAULT_MODEL})",
+        ),
+        max_workers: int = typer.Option(
+            1,
+            "--max-workers",
+            help=(
+                "Parallel batch worker count (default: 1 — empirically faster "
+                "than 2 on consumer CPUs because OMP_NUM_THREADS=2 × N_workers "
+                "still thrashes)."
+            ),
+        ),
+    ) -> None:
+        """Transcribe all audio files in a directory."""
+        dir_path = directory.expanduser()
+        inputs = discover_audio_files(dir_path)
+        if not inputs:
+            print(
+                f"Error: no audio files found under {dir_path} "
+                f"(accepted: {sorted(AUDIO_EXTS)})",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1)
+
+        out_dir = Path(output_dir).expanduser() if output_dir else None
+        _run_batch(
+            inputs,
+            json_mode=json,
+            keep_wav=keep_wav,
+            model=model,
+            max_workers=max_workers,
+            output_dir=out_dir,
+        )
+
+    @app.command("batch-files")
+    def batch_files(
+        files: list[Path] = typer.Argument(
+            ...,
+            help="Audio files to transcribe in parallel",
+        ),
+        output_dir: str | None = typer.Option(
+            None,
+            "--output-dir",
+            help="Write transcripts to this dir instead of alongside inputs",
+        ),
+        json: bool = typer.Option(
+            False,
+            "--json",
+            help="Emit {text, duration_s, model, elapsed_s} JSON instead of plain text",
+        ),
+        keep_wav: bool = typer.Option(
+            False,
+            "--keep-wav",
+            help="Retain the intermediate transcoded WAV file (debugging)",
+        ),
+        model: str = typer.Option(
+            DEFAULT_MODEL,
+            help=f"onnx-asr model name (default: {DEFAULT_MODEL})",
+        ),
+        max_workers: int = typer.Option(
+            1,
+            "--max-workers",
+            help=(
+                "Parallel batch worker count (default: 1 — empirically faster "
+                "than 2 on consumer CPUs because OMP_NUM_THREADS=2 × N_workers "
+                "still thrashes)."
+            ),
+        ),
+    ) -> None:
+        """Transcribe a list of files."""
+        inputs: list[Path] = []
+        for f in files:
+            p = f.expanduser()
+            if not p.exists():
+                print(f"Error: batch file not found: {p}", file=sys.stderr)
+                raise typer.Exit(1)
+            inputs.append(p)
+
+        if not inputs:
+            print("Error: no files provided", file=sys.stderr)
+            raise typer.Exit(2)
+
+        out_dir = Path(output_dir).expanduser() if output_dir else None
+        _run_batch(
+            inputs,
+            json_mode=json,
+            keep_wav=keep_wav,
+            model=model,
+            max_workers=max_workers,
+            output_dir=out_dir,
+        )
+
+    return app
+
+
 if __name__ == "__main__":
-    main()
+    _build_app()()

--- a/skills/gen-tts/SKILL.md
+++ b/skills/gen-tts/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gen-tts
 description: "Synthesize speech audio via Gemini 3.1 Flash TTS — single clip, batch parallel, voice + style presets"
-argument-hint: "<text-or-file> [--voice NAME] [--style-preset NAME] [--output path.wav] [--batch file.json]"
+argument-hint: "single --text <text> --output path.wav | batch file.json [--voice NAME] [--style-preset NAME]"
 allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion
 ---
 
@@ -25,7 +25,7 @@ Parse the user's input for:
 - **`--style-preset NAME`**: Load a multi-line style directive from `voices/<NAME>.txt` (e.g. `freud`, `soprano`). Comment lines stripped, body collapsed to one paragraph, prepended as a director's note. Mutually exclusive with `--style-prompt` / `--style-file`.
 - **`--style-file PATH`**: Like `--style-preset` but takes an explicit file path (for styles kept outside the skill dir).
 - **`--output path.wav`**: Where to save the WAV file
-- **`--batch file.json`**: Parallel batch mode (see shape below)
+- **`batch file.json`**: Parallel batch mode subcommand (see shape below)
 - **`--api-url URL`**: Override the Gemini endpoint (rarely needed; useful for testing against a proxy)
 
 `--voice` (Gemini voice ID) and `--style-*` (director's notes prepended to
@@ -36,7 +36,7 @@ freud` pairs the Charon baritone with Freud's Viennese pacing.
 
 - **Auth**: `GOOGLE_API_KEY` — auto-loaded from `~/.env` by `generate-tts.py` (same var as `gen-image`). Passed as an `x-goog-api-key` header so the key never leaks into URL access logs, shell traces, or proxy logs.
 - **Default voice**: Read from `tts-voice.txt` in this skill's directory
-- **Single entry point**: `generate-tts.py` — handles the HTTP call, WAV assembly, env loading, voice resolution, and parallel batch execution. Stdlib-only (no `requests` / `httpx` / `jq` / `curl` deps); the PEP-723 shebang (`#!/usr/bin/env -S uv run --script`) means it runs without a local venv.
+- **Single entry point**: `generate-tts.py` — handles the HTTP call, WAV assembly, env loading, voice resolution, and parallel batch execution. Stdlib core with Typer for CLI (no `requests` / `httpx` / `jq` / `curl` deps); the PEP-723 shebang (`#!/usr/bin/env -S uv run --script`) means it runs without a local venv. Two subcommands: `single` (one clip) and `batch` (parallel from JSON manifest).
 
 ## Model & Endpoint
 
@@ -106,25 +106,25 @@ GEN_TTS="$(git -C ~/gits/chop-conventions rev-parse --show-toplevel)/skills/gen-
 ### Single clip — text arg
 
 ```bash
-"$GEN_TTS" --text "Hello from Larry. [short pause] This is a voice pipeline test." --output /tmp/larry.wav
+"$GEN_TTS" single --text "Hello from Larry. [short pause] This is a voice pipeline test." --output /tmp/larry.wav
 ```
 
 ### Single clip — text file or stdin
 
 ```bash
-"$GEN_TTS" --text-file /tmp/script.txt --output /tmp/read.wav --voice Charon
-echo "piped text" | "$GEN_TTS" --output /tmp/piped.wav
+"$GEN_TTS" single --text-file /tmp/script.txt --output /tmp/read.wav --voice Charon
+echo "piped text" | "$GEN_TTS" single --output /tmp/piped.wav
 ```
 
 ### Single clip — character style preset
 
 ```bash
 # Freud's Viennese analyst voice, baritone
-"$GEN_TTS" --text "Tell me about your mother." --voice Charon \
+"$GEN_TTS" single --text "Tell me about your mother." --voice Charon \
   --style-preset freud --output /tmp/freud.wav
 
 # Inline director's notes (no preset)
-"$GEN_TTS" --text "Welcome aboard." --voice Puck \
+"$GEN_TTS" single --text "Welcome aboard." --voice Puck \
   --style-prompt "Speak with the warmth of a flight attendant greeting family." \
   --output /tmp/welcome.wav
 ```
@@ -162,7 +162,7 @@ CLI provides a default that per-job entries can override.
 Then:
 
 ```bash
-"$GEN_TTS" --batch /tmp/lines.json --max-workers 4
+"$GEN_TTS" batch /tmp/lines.json --max-workers 4
 ```
 
 `_duration_s` is written back into each job object for debug visibility. The batch file is rewritten atomically (tempfile + `os.replace`) so a crash mid-write never corrupts the input.

--- a/skills/gen-tts/generate-tts.py
+++ b/skills/gen-tts/generate-tts.py
@@ -1,26 +1,23 @@
 #!/usr/bin/env -S uv run --script
 # /// script
 # requires-python = ">=3.11"
-# dependencies = []
+# dependencies = ["typer>=0.12"]
 # ///
 # ABOUTME: Python-only Gemini 3.1 Flash TTS generator — single clip or parallel batch.
-# ABOUTME: Stdlib-only (urllib, wave, struct); no requests/httpx/jq/curl deps.
+# ABOUTME: Stdlib-only core (urllib, wave, struct); Typer for CLI. No requests/httpx/jq/curl deps.
 # ABOUTME: In batch mode, augments the input JSON with _duration_s debug fields.
 #
 # Single mode:
-#   generate-tts.py --text "Hello [short pause] world." --output greeting.wav
-#   generate-tts.py --text-file script.txt --output read.wav --voice Kore
-#   echo "piped text" | generate-tts.py --output out.wav
+#   generate-tts.py single --text "Hello [short pause] world." --output greeting.wav
+#   generate-tts.py single --text-file script.txt --output read.wav --voice Kore
+#   echo "piped text" | generate-tts.py single --output out.wav
 #
 # Batch mode (parallel):
-#   generate-tts.py --batch lines.json
+#   generate-tts.py batch lines.json
 #
 # lines.json format:
 #   [{"text": "...", "output": "file.wav", "voice": "Kore"}, ...]
 
-from __future__ import annotations
-
-import argparse
 import base64
 import json
 import os
@@ -451,250 +448,295 @@ def generate_one(job: TTSJob, api_url: str, api_key: str) -> TTSResult:
 # ----- CLI ---------------------------------------------------------------
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser(
-        description="Generate speech audio via Gemini 3.1 Flash TTS (single or batch)",
+def _build_app():
+    """Wire Typer app. Called only from __main__ so tests skip the typer import."""
+    import typer
+    from typing import Optional
+
+    app = typer.Typer(
+        help="Generate speech audio via Gemini 3.1 Flash TTS (single or batch).",
+        add_completion=False,
+        no_args_is_help=True,
     )
 
-    # Batch mode
-    parser.add_argument(
-        "--batch",
-        metavar="JSON",
-        default=None,
-        help="JSON file with jobs to generate in parallel",
-    )
-
-    # Single mode
-    parser.add_argument("--text", default=None, help="Text to synthesize")
-    parser.add_argument(
-        "--text-file",
-        default=None,
-        help="Read text from file (alternative to --text)",
-    )
-    parser.add_argument(
-        "--output", default=None, help="Output WAV filename (e.g., greeting.wav)"
-    )
-
-    # Shared options
-    parser.add_argument(
-        "--voice",
-        default=None,
-        help=(
-            "Voice preset name (resolves voices/<name>.txt single-line) or "
-            "literal Gemini voice (e.g. Kore, Puck, Charon). Default: read "
-            "tts-voice.txt"
+    @app.command()
+    def single(
+        text: Optional[str] = typer.Option(None, help="Text to synthesize"),
+        text_file: Optional[str] = typer.Option(
+            None, "--text-file", help="Read text from file (alternative to --text)"
         ),
-    )
-    parser.add_argument(
-        "--style-prompt",
-        default=None,
-        help=(
-            "Director's-notes style prefix prepended to the text (e.g. "
-            "'Speak in a warm Newcastle accent.')"
+        output: str = typer.Option(
+            ..., help="Output WAV filename (e.g., greeting.wav)"
         ),
-    )
-    parser.add_argument(
-        "--style-preset",
-        default=None,
-        help=(
-            "Name of a multi-line style file under voices/<name>.txt (e.g. "
-            "freud, soprano). Mutually exclusive with --style-prompt / --style-file"
+        voice: Optional[str] = typer.Option(
+            None,
+            help=(
+                "Voice preset name (resolves voices/<name>.txt single-line) or "
+                "literal Gemini voice (e.g. Kore, Puck, Charon). Default: read "
+                "tts-voice.txt"
+            ),
         ),
-    )
-    parser.add_argument(
-        "--style-file",
-        default=None,
-        help=(
-            "Path to a multi-line style-directive file (comment lines stripped). "
-            "Mutually exclusive with --style-prompt / --style-preset"
+        style_prompt: Optional[str] = typer.Option(
+            None,
+            "--style-prompt",
+            help=(
+                "Director's-notes style prefix prepended to the text (e.g. "
+                "'Speak in a warm Newcastle accent.')"
+            ),
         ),
-    )
-    parser.add_argument(
-        "--api-url",
-        default=DEFAULT_API_URL,
-        help="Override Gemini endpoint URL",
-    )
-    parser.add_argument(
-        "--max-workers",
-        type=int,
-        default=4,
-        help="Parallel batch worker count (default: 4)",
-    )
+        style_preset: Optional[str] = typer.Option(
+            None,
+            "--style-preset",
+            help=(
+                "Name of a multi-line style file under voices/<name>.txt (e.g. "
+                "freud, soprano). Mutually exclusive with --style-prompt / --style-file"
+            ),
+        ),
+        style_file: Optional[str] = typer.Option(
+            None,
+            "--style-file",
+            help=(
+                "Path to a multi-line style-directive file (comment lines stripped). "
+                "Mutually exclusive with --style-prompt / --style-preset"
+            ),
+        ),
+        api_url: str = typer.Option(
+            DEFAULT_API_URL,
+            "--api-url",
+            help="Override Gemini endpoint URL",
+        ),
+    ) -> None:
+        """Synthesize one clip from --text, --text-file, or stdin."""
+        if text and text_file:
+            print("Error: Use either --text or --text-file, not both", file=sys.stderr)
+            raise typer.Exit(1)
 
-    args = parser.parse_args()
-
-    is_batch = args.batch is not None
-    is_single = (
-        args.text is not None or args.text_file is not None or not sys.stdin.isatty()
-    )
-    if is_batch and (args.text is not None or args.text_file is not None):
-        parser.error("Cannot combine --batch with --text/--text-file")
-    if args.text and args.text_file:
-        parser.error("Use either --text or --text-file, not both")
-
-    style_flags = [args.style_prompt, args.style_preset, args.style_file]
-    if sum(1 for s in style_flags if s) > 1:
-        parser.error(
-            "Pass at most one of --style-prompt / --style-preset / --style-file"
-        )
-
-    skill_dir = resolve_skill_dir()
-    load_env()
-
-    api_key = os.environ.get("GOOGLE_API_KEY")
-    if not api_key:
-        print(
-            "Error: GOOGLE_API_KEY not found in environment or ~/.env",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
-    # ----- Single mode (includes stdin-piped input) -----
-    if not is_batch:
-        # Resolve text: --text > --text-file > stdin
-        if args.text is not None:
-            text = args.text
-        elif args.text_file is not None:
-            text = Path(args.text_file).read_text().strip()
-        elif not sys.stdin.isatty():
-            text = sys.stdin.read().strip()
-        else:
-            parser.error(
-                "Provide --batch JSON, --text/--text-file, or pipe text on stdin"
+        style_flags = [style_prompt, style_preset, style_file]
+        if sum(1 for s in style_flags if s) > 1:
+            print(
+                "Error: Pass at most one of --style-prompt / --style-preset / --style-file",
+                file=sys.stderr,
             )
-            return  # unreachable — parser.error calls sys.exit
+            raise typer.Exit(1)
 
-        if not text:
+        skill_dir = resolve_skill_dir()
+        load_env()
+
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            print(
+                "Error: GOOGLE_API_KEY not found in environment or ~/.env",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1)
+
+        # Resolve text: --text > --text-file > stdin
+        if text is not None:
+            resolved_text = text
+        elif text_file is not None:
+            resolved_text = Path(text_file).read_text().strip()
+        elif not sys.stdin.isatty():
+            resolved_text = sys.stdin.read().strip()
+        else:
+            print(
+                "Error: Provide --text, --text-file, or pipe text on stdin",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1)
+
+        if not resolved_text:
             print("Error: no text provided (pass as arg or via stdin)", file=sys.stderr)
-            sys.exit(2)
-        if not args.output:
-            parser.error("Single mode requires --output")
+            raise typer.Exit(2)
 
-        voice = resolve_voice_preset(skill_dir, args.voice)
+        resolved_voice = resolve_voice_preset(skill_dir, voice)
         try:
-            style_prompt = resolve_style(
-                skill_dir, args.style_prompt, args.style_preset, args.style_file
+            resolved_style = resolve_style(
+                skill_dir, style_prompt, style_preset, style_file
             )
         except FileNotFoundError as e:
             print(f"Error: {e}", file=sys.stderr)
-            sys.exit(2)
+            raise typer.Exit(2)
 
         job = TTSJob(
-            text=text,
-            output=args.output,
-            voice=voice,
-            style_prompt=style_prompt,
+            text=resolved_text,
+            output=output,
+            voice=resolved_voice,
+            style_prompt=resolved_style,
         )
-        result = generate_one(job, args.api_url, api_key)
+        result = generate_one(job, api_url, api_key)
         if not result.success:
             print(f"Error: {result.error}", file=sys.stderr)
-            sys.exit(1)
+            raise typer.Exit(1)
         print(result.output)
         print(f"Generated in {result.duration_s}s", file=sys.stderr)
-        return
 
-    # ----- Batch mode -----
-    batch_path = Path(args.batch)
-    if not batch_path.exists():
-        print(f"Error: Batch file not found: {batch_path}", file=sys.stderr)
-        sys.exit(1)
+    @app.command()
+    def batch(
+        json_file: str = typer.Argument(help="JSON file with jobs to generate in parallel"),
+        voice: Optional[str] = typer.Option(
+            None,
+            help=(
+                "Voice preset name (resolves voices/<name>.txt single-line) or "
+                "literal Gemini voice (e.g. Kore, Puck, Charon). Default: read "
+                "tts-voice.txt"
+            ),
+        ),
+        style_prompt: Optional[str] = typer.Option(
+            None,
+            "--style-prompt",
+            help=(
+                "Director's-notes style prefix prepended to the text (e.g. "
+                "'Speak in a warm Newcastle accent.')"
+            ),
+        ),
+        style_preset: Optional[str] = typer.Option(
+            None,
+            "--style-preset",
+            help=(
+                "Name of a multi-line style file under voices/<name>.txt (e.g. "
+                "freud, soprano). Mutually exclusive with --style-prompt / --style-file"
+            ),
+        ),
+        style_file: Optional[str] = typer.Option(
+            None,
+            "--style-file",
+            help=(
+                "Path to a multi-line style-directive file (comment lines stripped). "
+                "Mutually exclusive with --style-prompt / --style-preset"
+            ),
+        ),
+        api_url: str = typer.Option(
+            DEFAULT_API_URL,
+            "--api-url",
+            help="Override Gemini endpoint URL",
+        ),
+        max_workers: int = typer.Option(
+            4, "--max-workers", help="Parallel batch worker count"
+        ),
+    ) -> None:
+        """Generate clips in parallel from a JSON manifest."""
+        style_flags = [style_prompt, style_preset, style_file]
+        if sum(1 for s in style_flags if s) > 1:
+            print(
+                "Error: Pass at most one of --style-prompt / --style-preset / --style-file",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1)
 
-    with open(batch_path) as f:
-        raw_jobs = json.load(f)
+        skill_dir = resolve_skill_dir()
+        load_env()
 
-    if not raw_jobs:
-        print("Error: No jobs in batch file", file=sys.stderr)
-        sys.exit(1)
+        api_key = os.environ.get("GOOGLE_API_KEY")
+        if not api_key:
+            print(
+                "Error: GOOGLE_API_KEY not found in environment or ~/.env",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1)
 
-    # Map output filename -> raw dict for augmenting with debug info
-    job_by_output = {d["output"]: d for d in raw_jobs}
-    jobs: list[TTSJob] = []
-    try:
-        cli_style = resolve_style(
-            skill_dir, args.style_prompt, args.style_preset, args.style_file
-        )
-    except FileNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        sys.exit(2)
-    for d in raw_jobs:
-        voice = resolve_voice_preset(skill_dir, d.get("voice"))
+        batch_path = Path(json_file)
+        if not batch_path.exists():
+            print(f"Error: Batch file not found: {batch_path}", file=sys.stderr)
+            raise typer.Exit(1)
+
+        with open(batch_path) as f:
+            raw_jobs = json.load(f)
+
+        if not raw_jobs:
+            print("Error: No jobs in batch file", file=sys.stderr)
+            raise typer.Exit(1)
+
+        # Map output filename -> raw dict for augmenting with debug info
+        job_by_output = {d["output"]: d for d in raw_jobs}
+        jobs: list[TTSJob] = []
         try:
-            job_style = resolve_style(
-                skill_dir,
-                d.get("style_prompt"),
-                d.get("style_preset"),
-                d.get("style_file"),
+            cli_style = resolve_style(
+                skill_dir, style_prompt, style_preset, style_file
             )
         except FileNotFoundError as e:
-            print(f"Error: {e} (job output={d.get('output')})", file=sys.stderr)
-            sys.exit(2)
-        style_prompt = job_style if job_style is not None else cli_style
-        jobs.append(
-            TTSJob(
-                text=d["text"],
-                output=d["output"],
-                voice=voice,
-                style_prompt=style_prompt,
+            print(f"Error: {e}", file=sys.stderr)
+            raise typer.Exit(2)
+        for d in raw_jobs:
+            resolved_voice = resolve_voice_preset(skill_dir, d.get("voice"))
+            try:
+                job_style = resolve_style(
+                    skill_dir,
+                    d.get("style_prompt"),
+                    d.get("style_preset"),
+                    d.get("style_file"),
+                )
+            except FileNotFoundError as e:
+                print(f"Error: {e} (job output={d.get('output')})", file=sys.stderr)
+                raise typer.Exit(2)
+            resolved_style = job_style if job_style is not None else cli_style
+            jobs.append(
+                TTSJob(
+                    text=d["text"],
+                    output=d["output"],
+                    voice=resolved_voice,
+                    style_prompt=resolved_style,
+                )
             )
-        )
 
-    print(
-        f"Generating {len(jobs)} audio clips in parallel (max_workers={args.max_workers})...",
-        file=sys.stderr,
-    )
-    failures: list[tuple[str, str | None]] = []
-
-    batch_t0 = time.monotonic()
-    workers = min(args.max_workers, len(jobs))
-    with ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = {
-            pool.submit(generate_one, j, args.api_url, api_key): j for j in jobs
-        }
-        for future in as_completed(futures):
-            result = future.result()
-            if result.output in job_by_output:
-                job_by_output[result.output]["_duration_s"] = result.duration_s
-            if result.success:
-                print(result.output)
-            else:
-                failures.append((result.output, result.error))
-                print(f"FAILED: {result.output} — {result.error}", file=sys.stderr)
-
-    batch_duration = round(time.monotonic() - batch_t0, 1)
-
-    # Atomic write: tempfile in same dir + os.replace, so a crash mid-write
-    # leaves the original batch file intact rather than a half-written one.
-    tmp_fd, tmp_path = None, None
-    try:
-        import tempfile
-
-        tmp_fd, tmp_path = tempfile.mkstemp(
-            dir=batch_path.parent, prefix=batch_path.name + ".", suffix=".tmp"
-        )
-        with os.fdopen(tmp_fd, "w") as f:
-            tmp_fd = None  # fdopen took ownership
-            json.dump(raw_jobs, f, indent=2)
-            f.flush()
-            os.fsync(f.fileno())
-        os.replace(tmp_path, batch_path)
-        tmp_path = None
-    finally:
-        if tmp_fd is not None:
-            os.close(tmp_fd)
-        if tmp_path is not None and os.path.exists(tmp_path):
-            os.unlink(tmp_path)
-
-    if failures:
         print(
-            f"\n{len(failures)}/{len(jobs)} failed ({batch_duration}s total)",
+            f"Generating {len(jobs)} audio clips in parallel (max_workers={max_workers})...",
             file=sys.stderr,
         )
-        sys.exit(1)
-    print(
-        f"\nAll {len(jobs)} clips generated ({batch_duration}s total)",
-        file=sys.stderr,
-    )
+        failures: list[tuple[str, str | None]] = []
+
+        batch_t0 = time.monotonic()
+        workers = min(max_workers, len(jobs))
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(generate_one, j, api_url, api_key): j for j in jobs
+            }
+            for future in as_completed(futures):
+                result = future.result()
+                if result.output in job_by_output:
+                    job_by_output[result.output]["_duration_s"] = result.duration_s
+                if result.success:
+                    print(result.output)
+                else:
+                    failures.append((result.output, result.error))
+                    print(f"FAILED: {result.output} — {result.error}", file=sys.stderr)
+
+        batch_duration = round(time.monotonic() - batch_t0, 1)
+
+        # Atomic write: tempfile in same dir + os.replace, so a crash mid-write
+        # leaves the original batch file intact rather than a half-written one.
+        tmp_fd, tmp_path = None, None
+        try:
+            import tempfile
+
+            tmp_fd, tmp_path = tempfile.mkstemp(
+                dir=batch_path.parent, prefix=batch_path.name + ".", suffix=".tmp"
+            )
+            with os.fdopen(tmp_fd, "w") as f:
+                tmp_fd = None  # fdopen took ownership
+                json.dump(raw_jobs, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, batch_path)
+            tmp_path = None
+        finally:
+            if tmp_fd is not None:
+                os.close(tmp_fd)
+            if tmp_path is not None and os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+
+        if failures:
+            print(
+                f"\n{len(failures)}/{len(jobs)} failed ({batch_duration}s total)",
+                file=sys.stderr,
+            )
+            raise typer.Exit(1)
+        print(
+            f"\nAll {len(jobs)} clips generated ({batch_duration}s total)",
+            file=sys.stderr,
+        )
+
+    return app
 
 
 if __name__ == "__main__":
-    main()
+    _build_app()()

--- a/skills/gen-tts/voices/freud.txt
+++ b/skills/gen-tts/voices/freud.txt
@@ -1,7 +1,7 @@
 # Sigmund Freud voice preset (style directive — NOT a Gemini voice ID).
 # Use via:
-#   generate-tts.py --style-preset freud --text "..." --output out.wav
-#   generate-tts.py --style-file voices/freud.txt --text "..." --output out.wav
+#   generate-tts.py single --style-preset freud --text "..." --output out.wav
+#   generate-tts.py single --style-file voices/freud.txt --text "..." --output out.wav
 # Comment lines (starting with '#') are stripped; the remaining body is
 # collapsed to one paragraph and prepended to the text as a director's note.
 # Combine with --voice Charon (or similar baritone) for best results.

--- a/skills/gen-tts/voices/soprano.txt
+++ b/skills/gen-tts/voices/soprano.txt
@@ -1,7 +1,7 @@
 # Tony Soprano voice preset (style directive — NOT a Gemini voice ID).
 # Use via:
-#   generate-tts.py --style-preset soprano --voice Enceladus --text "..." --output out.wav
-#   generate-tts.py --style-file voices/soprano.txt --voice Enceladus --text "..." --output out.wav
+#   generate-tts.py single --style-preset soprano --voice Enceladus --text "..." --output out.wav
+#   generate-tts.py single --style-file voices/soprano.txt --voice Enceladus --text "..." --output out.wav
 # Comment lines (starting with '#') are stripped; the remaining body is
 # collapsed to one paragraph and prepended to the text as a director's note.
 #

--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -180,7 +180,7 @@ kill -TERM <pid-from-doctor>
 # unscoped display-message falls back to the session's most-recently-active
 # pane, which on a box with concurrent Claude sessions is routinely wrong.
 # Let watchdog.py walk /proc/<pid>/stat ppid chain itself.
-python3 ~/.claude/skills/harden-telegram/tools/watchdog.py reload \
+uv run ~/.claude/skills/harden-telegram/tools/watchdog.py reload \
   2>/tmp/watchdog_reload.log &
 disown
 ```

--- a/skills/harden-telegram/tools/watchdog.py
+++ b/skills/harden-telegram/tools/watchdog.py
@@ -637,12 +637,12 @@ def _build_app():
                 log(f"found pane {resolved_pane} for PID {pid}")
             else:
                 log(f"could not find tmux pane for PID {pid}")
-                sys.exit(1)
+                raise typer.Exit(1)
         if not resolved_pane:
             resolved_pane = detect_tmux_pane()
         if not resolved_pane:
             log("ERROR: no pane specified and auto-detect failed. Use --pane or --pid.")
-            sys.exit(1)
+            raise typer.Exit(1)
         cmd_reload(resolved_pane, message=message)
 
     @app.command()
@@ -655,24 +655,24 @@ def _build_app():
 
         if not bun_pid_str or not claude_pid_str:
             log("WATCHDOG_BUN_PID and WATCHDOG_CLAUDE_PID must be set")
-            sys.exit(1)
+            raise typer.Exit(1)
 
         if not tmux_pane:
             log("WATCHDOG_TMUX_PANE is empty/unset — not in a tmux session, exiting")
-            sys.exit(0)
+            raise typer.Exit(0)
 
         try:
             bun_pid = int(bun_pid_str)
             claude_pid = int(claude_pid_str)
         except ValueError:
             log(f"invalid PID values: bun={bun_pid_str!r} claude={claude_pid_str!r}")
-            sys.exit(1)
+            raise typer.Exit(1)
 
         log(f"starting: bun_pid={bun_pid} claude_pid={claude_pid} tmux_pane={tmux_pane}")
 
         # --- Singleton ---
         if not acquire_singleton():
-            sys.exit(0)
+            raise typer.Exit(0)
 
         # --- Signal handling ---
         def handle_signal(signum: int, _frame: object) -> None:

--- a/skills/harden-telegram/tools/watchdog.py
+++ b/skills/harden-telegram/tools/watchdog.py
@@ -1,4 +1,10 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "typer>=0.12",
+# ]
+# ///
 """
 Telegram MCP watchdog — auto-recover Claude Code's Telegram plugin.
 
@@ -596,135 +602,122 @@ def cmd_reload(tmux_pane: str | None = None, message: str | None = None) -> None
     log("=== Reload Test Complete ===")
 
 
-def _parse_cli():
-    """Parse CLI args. Returns (command, pane, pid) or falls through to daemon mode."""
-    # Usage:
-    #   watchdog.py reload [--pane %17] [--pid 12345]
-    #   watchdog.py                          (daemon mode, uses env vars)
-    import argparse
+def _build_app():
+    """Wire Typer app. Called only from __main__ so tests skip the typer import."""
+    import typer
+    from typing import Optional
 
-    parser = argparse.ArgumentParser(description="Telegram MCP watchdog")
-    sub = parser.add_subparsers(dest="command")
-
-    reload_p = sub.add_parser(
-        "reload", help="Send /reload-plugins to Claude's tmux pane"
-    )
-    reload_p.add_argument(
-        "--pane", help="tmux pane ID (e.g. %%17). Auto-detects if omitted."
-    )
-    reload_p.add_argument(
-        "--pid", type=int, help="PID of process in target pane. Used to find the pane."
-    )
-    reload_p.add_argument(
-        "--message",
-        "-m",
-        help="Message to send to Claude after reload (e.g. 'Larry reloaded, I\\'m back')",
+    app = typer.Typer(
+        help="Telegram MCP watchdog — auto-recover Claude Code's Telegram plugin.",
+        add_completion=False,
+        no_args_is_help=True,
     )
 
-    return parser.parse_args()
-
-
-def pane_from_pid(pid: int) -> str | None:
-    """Find the tmux pane containing a given PID.
-
-    Walks the ppid chain from `pid` upward and matches each ancestor against
-    the set of known tmux pane shell pids. Returns the matching pane_id, or
-    None if no ancestor is a tmux pane shell (e.g., caller isn't running in
-    tmux, or target pid is detached).
-    """
-    return resolve_pane_for_pid(pid)
-
-
-def main() -> None:
-    args = _parse_cli()
-
-    if args.command == "reload":
-        # Resolve pane
-        pane = args.pane
-        if not pane and args.pid:
-            log(f"looking up tmux pane for PID {args.pid}...")
-            pane = pane_from_pid(args.pid)
-            if pane:
-                log(f"found pane {pane} for PID {args.pid}")
+    @app.command()
+    def reload(
+        pane: Optional[str] = typer.Option(
+            None, help="tmux pane ID (e.g. %%17). Auto-detects if omitted."
+        ),
+        pid: Optional[int] = typer.Option(
+            None, help="PID of process in target pane. Used to find the pane."
+        ),
+        message: Optional[str] = typer.Option(
+            None,
+            "-m",
+            "--message",
+            help="Message to send to Claude after reload.",
+        ),
+    ) -> None:
+        """Send /reload-plugins to Claude's tmux pane."""
+        resolved_pane = pane
+        if not resolved_pane and pid is not None:
+            log(f"looking up tmux pane for PID {pid}...")
+            resolved_pane = resolve_pane_for_pid(pid)
+            if resolved_pane:
+                log(f"found pane {resolved_pane} for PID {pid}")
             else:
-                log(f"could not find tmux pane for PID {args.pid}")
+                log(f"could not find tmux pane for PID {pid}")
                 sys.exit(1)
-        if not pane:
-            pane = detect_tmux_pane()
-        if not pane:
+        if not resolved_pane:
+            resolved_pane = detect_tmux_pane()
+        if not resolved_pane:
             log("ERROR: no pane specified and auto-detect failed. Use --pane or --pid.")
             sys.exit(1)
-        cmd_reload(pane, message=args.message)
-        return
+        cmd_reload(resolved_pane, message=message)
 
-    # --- Daemon mode: parse environment ---
-    bun_pid_str = os.environ.get("WATCHDOG_BUN_PID", "")
-    claude_pid_str = os.environ.get("WATCHDOG_CLAUDE_PID", "")
-    tmux_pane = os.environ.get("WATCHDOG_TMUX_PANE", "")
+    @app.command()
+    def daemon() -> None:
+        """Run as a watchdog daemon. Reads config from env vars."""
+        # --- Daemon mode: parse environment ---
+        bun_pid_str = os.environ.get("WATCHDOG_BUN_PID", "")
+        claude_pid_str = os.environ.get("WATCHDOG_CLAUDE_PID", "")
+        tmux_pane = os.environ.get("WATCHDOG_TMUX_PANE", "")
 
-    if not bun_pid_str or not claude_pid_str:
-        log("WATCHDOG_BUN_PID and WATCHDOG_CLAUDE_PID must be set")
-        sys.exit(1)
+        if not bun_pid_str or not claude_pid_str:
+            log("WATCHDOG_BUN_PID and WATCHDOG_CLAUDE_PID must be set")
+            sys.exit(1)
 
-    if not tmux_pane:
-        log("WATCHDOG_TMUX_PANE is empty/unset — not in a tmux session, exiting")
-        sys.exit(0)
+        if not tmux_pane:
+            log("WATCHDOG_TMUX_PANE is empty/unset — not in a tmux session, exiting")
+            sys.exit(0)
 
-    try:
-        bun_pid = int(bun_pid_str)
-        claude_pid = int(claude_pid_str)
-    except ValueError:
-        log(f"invalid PID values: bun={bun_pid_str!r} claude={claude_pid_str!r}")
-        sys.exit(1)
+        try:
+            bun_pid = int(bun_pid_str)
+            claude_pid = int(claude_pid_str)
+        except ValueError:
+            log(f"invalid PID values: bun={bun_pid_str!r} claude={claude_pid_str!r}")
+            sys.exit(1)
 
-    log(f"starting: bun_pid={bun_pid} claude_pid={claude_pid} tmux_pane={tmux_pane}")
+        log(f"starting: bun_pid={bun_pid} claude_pid={claude_pid} tmux_pane={tmux_pane}")
 
-    # --- Singleton ---
-    if not acquire_singleton():
-        sys.exit(0)
+        # --- Singleton ---
+        if not acquire_singleton():
+            sys.exit(0)
 
-    # --- Signal handling ---
-    def handle_signal(signum: int, _frame: object) -> None:
-        sig_name = signal.Signals(signum).name
-        log(f"received {sig_name}, exiting")
-        cleanup_pid_file()
-        sys.exit(0)
+        # --- Signal handling ---
+        def handle_signal(signum: int, _frame: object) -> None:
+            sig_name = signal.Signals(signum).name
+            log(f"received {sig_name}, exiting")
+            cleanup_pid_file()
+            sys.exit(0)
 
-    signal.signal(signal.SIGTERM, handle_signal)
-    signal.signal(signal.SIGINT, handle_signal)
+        signal.signal(signal.SIGTERM, handle_signal)
+        signal.signal(signal.SIGINT, handle_signal)
 
-    # --- Main loop ---
-    try:
-        while True:
-            time.sleep(POLL_INTERVAL)
+        # --- Main loop ---
+        try:
+            while True:
+                time.sleep(POLL_INTERVAL)
 
-            # Check Claude first — if Claude is gone, nothing to recover
-            if not is_pid_alive(claude_pid):
-                log("Claude process is dead, nothing to recover — exiting")
-                break
+                # Check Claude first — if Claude is gone, nothing to recover
+                if not is_pid_alive(claude_pid):
+                    log("Claude process is dead, nothing to recover — exiting")
+                    break
 
-            # Check bun
-            if not is_pid_alive(bun_pid):
-                log(f"bun process (PID {bun_pid}) is dead!")
+                # Check bun
+                if not is_pid_alive(bun_pid):
+                    log(f"bun process (PID {bun_pid}) is dead!")
 
-                if do_recovery(tmux_pane):
-                    log("recovery sequence sent, waiting for new bun process")
-                    if wait_for_new_bun():
-                        log(
-                            "new bun process started — new watchdog will take over, exiting"
-                        )
+                    if do_recovery(tmux_pane):
+                        log("recovery sequence sent, waiting for new bun process")
+                        if wait_for_new_bun():
+                            log(
+                                "new bun process started — new watchdog will take over, exiting"
+                            )
+                        else:
+                            log("no new bun process appeared within timeout")
                     else:
-                        log("no new bun process appeared within timeout")
-                else:
-                    log("recovery sequence failed")
-                # Either way, exit — if recovery worked, new watchdog replaces us;
-                # if it failed, we can't do more.
-                break
-    finally:
-        cleanup_pid_file()
+                        log("recovery sequence failed")
+                    # Either way, exit — if recovery worked, new watchdog replaces us;
+                    # if it failed, we can't do more.
+                    break
+        finally:
+            cleanup_pid_file()
 
-    log("watchdog exiting")
+        log("watchdog exiting")
+
+    return app
 
 
 if __name__ == "__main__":
-    main()
+    _build_app()()

--- a/skills/image-explore/SKILL.md
+++ b/skills/image-explore/SKILL.md
@@ -147,7 +147,7 @@ Confirm with user via `AskUserQuestion` before generating. User may add, remove,
 3. **Generate all images in parallel** with a single command:
 
    ```bash
-   uv run "$GEN" --batch directions.json
+   uv run "$GEN" batch directions.json
    ```
 
    Pass `--aspect`, `--ref`, or `--style` if overriding defaults. The script handles env loading,

--- a/skills/image-explore/build-page.py
+++ b/skills/image-explore/build-page.py
@@ -18,7 +18,7 @@
 #    "vibe": "Quiet awe", "shirt": "NORTH", "image": "mountain-v2.webp"}
 # ]
 #
-# Optional debug fields (added by generate.py --batch):
+# Optional debug fields (added by generate.py batch):
 #   "_prompt": "full assembled prompt text"
 #   "_duration_s": 16.2
 # Optional verification fields (added by Phase 3b verify-retry):
@@ -50,7 +50,7 @@ class Direction:
     image: str = ""
     output: str = ""
     group: str = ""
-    # Debug fields (populated by generate.py --batch)
+    # Debug fields (populated by generate.py batch)
     prompt: str = ""
     duration_s: float | None = None
     # Verification fields (populated by Phase 3b verify-retry)

--- a/skills/image-explore/generate.py
+++ b/skills/image-explore/generate.py
@@ -308,7 +308,7 @@ def _build_app():
                 "Error: GOOGLE_API_KEY not found in environment or ~/.env",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            raise typer.Exit(1)
 
         config = GenerateConfig(
             gemini_script=str(chop_root / "skills" / "gen-image" / "gemini-image.sh"),
@@ -322,7 +322,7 @@ def _build_app():
         result = generate_one(direction, config)
         if not result.success:
             print(f"Error: {result.error}", file=sys.stderr)
-            sys.exit(1)
+            raise typer.Exit(1)
         print(result.output)
         print(f"Generated in {result.duration_s}s", file=sys.stderr)
 
@@ -346,7 +346,7 @@ def _build_app():
                 "Error: GOOGLE_API_KEY not found in environment or ~/.env",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            raise typer.Exit(1)
 
         config = GenerateConfig(
             gemini_script=str(chop_root / "skills" / "gen-image" / "gemini-image.sh"),
@@ -359,14 +359,14 @@ def _build_app():
         batch_path = Path(json_file)
         if not batch_path.exists():
             print(f"Error: Batch file not found: {batch_path}", file=sys.stderr)
-            sys.exit(1)
+            raise typer.Exit(1)
 
         with open(batch_path) as f:
             raw_directions = json.load(f)
 
         if not raw_directions:
             print("Error: No directions in batch file", file=sys.stderr)
-            sys.exit(1)
+            raise typer.Exit(1)
 
         print(
             f"Generating {len(raw_directions)} images in parallel...", file=sys.stderr
@@ -416,7 +416,7 @@ def _build_app():
                 f"\n{len(failures)}/{len(raw_directions)} failed ({batch_duration}s total)",
                 file=sys.stderr,
             )
-            sys.exit(1)
+            raise typer.Exit(1)
         print(
             f"\nAll {len(raw_directions)} images generated ({batch_duration}s total)",
             file=sys.stderr,

--- a/skills/image-explore/generate.py
+++ b/skills/image-explore/generate.py
@@ -1,20 +1,23 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "typer>=0.12",
+# ]
+# ///
 # ABOUTME: Wrapper around gemini-image.sh for image generation (single or batch).
 # ABOUTME: Handles env loading, prompt assembly, and ref image resolution safely.
 # ABOUTME: In batch mode, augments the input JSON with _prompt and _duration_s debug fields.
 #
 # Single mode:
-#   generate.py --scene "..." --shirt "TEXT" --output file.webp [options]
+#   generate.py single --scene "..." --shirt "TEXT" --output file.webp [options]
 #
 # Batch mode (parallel):
-#   generate.py --batch directions.json [--aspect 3:4] [--ref path] [--style "..."]
+#   generate.py batch directions.json [--aspect 3:4] [--ref path] [--style "..."]
 #
 # directions.json format:
 #   [{"scene": "...", "shirt": "TEXT", "output": "file.webp"}, ...]
 
-from __future__ import annotations
-
-import argparse
 import json
 import os
 import shutil
@@ -273,79 +276,87 @@ def generate_one(direction: Direction, config: GenerateConfig) -> GenerationResu
     )
 
 
-def main():
-    parser = argparse.ArgumentParser(
-        description="Generate raccoon images via Gemini (single or batch)",
+def _build_app():
+    """Wire Typer app. Called only from __main__ so tests skip the typer import."""
+    import typer
+
+    app = typer.Typer(
+        help="Generate raccoon images via Gemini (single or batch).",
+        add_completion=False,
+        no_args_is_help=True,
     )
 
-    # Batch mode
-    parser.add_argument(
-        "--batch",
-        metavar="JSON",
-        default=None,
-        help="JSON file with directions to generate in parallel",
-    )
+    @app.command()
+    def single(
+        scene: str = typer.Option(..., help="Scene description for the image"),
+        shirt: str = typer.Option(..., help="Text on the raccoon's shirt (max 8 chars)"),
+        output: str = typer.Option(..., help="Output filename (e.g., mountain.webp)"),
+        aspect: str = typer.Option("3:4", help="Aspect ratio (default: 3:4)"),
+        ref: str | None = typer.Option(None, help="Override reference image path"),
+        style: str | None = typer.Option(None, help="Override default raccoon style"),
+        transparent: bool = typer.Option(
+            False,
+            help="Generate on magenta chroma-key background, then strip it via ImageMagick edge-connected flood fill from the 4 corners (preserves interior magenta-tinted pixels)",
+        ),
+    ) -> None:
+        """Generate a single raccoon image."""
+        chop_root = resolve_chop_root()
+        load_env()
 
-    # Single mode
-    parser.add_argument("--scene", default=None, help="Scene description for the image")
-    parser.add_argument(
-        "--shirt", default=None, help="Text on the raccoon's shirt (max 8 chars)"
-    )
-    parser.add_argument(
-        "--output", default=None, help="Output filename (e.g., mountain.webp)"
-    )
+        if not os.environ.get("GOOGLE_API_KEY"):
+            print(
+                "Error: GOOGLE_API_KEY not found in environment or ~/.env",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
-    # Shared options
-    parser.add_argument("--aspect", default="3:4", help="Aspect ratio (default: 3:4)")
-    parser.add_argument("--ref", default=None, help="Override reference image path")
-    parser.add_argument("--style", default=None, help="Override default raccoon style")
-    parser.add_argument(
-        "--transparent",
-        action="store_true",
-        default=False,
-        help="Generate on magenta chroma-key background, then strip it via ImageMagick edge-connected flood fill from the 4 corners (preserves interior magenta-tinted pixels)",
-    )
-
-    args = parser.parse_args()
-
-    # Validate: must be batch or single, not both/neither
-    is_batch = args.batch is not None
-    is_single = args.scene is not None
-    if not is_batch and not is_single:
-        parser.error("Provide --batch JSON or --scene/--shirt/--output for single mode")
-    if is_batch and is_single:
-        parser.error("Cannot use --batch with --scene/--shirt/--output")
-    if is_single and (not args.shirt or not args.output):
-        parser.error("Single mode requires --scene, --shirt, and --output")
-
-    chop_root = resolve_chop_root()
-    load_env()
-
-    if not os.environ.get("GOOGLE_API_KEY"):
-        print(
-            "Error: GOOGLE_API_KEY not found in environment or ~/.env", file=sys.stderr
+        config = GenerateConfig(
+            gemini_script=str(chop_root / "skills" / "gen-image" / "gemini-image.sh"),
+            style=style or read_default_style(chop_root),
+            ref_image=ref or resolve_ref_image(),
+            aspect=aspect,
+            transparent=transparent,
         )
-        sys.exit(1)
 
-    config = GenerateConfig(
-        gemini_script=str(chop_root / "skills" / "gen-image" / "gemini-image.sh"),
-        style=args.style or read_default_style(chop_root),
-        ref_image=args.ref or resolve_ref_image(),
-        aspect=args.aspect,
-        transparent=args.transparent,
-    )
-
-    if is_single:
-        direction = Direction(scene=args.scene, shirt=args.shirt, output=args.output)
+        direction = Direction(scene=scene, shirt=shirt, output=output)
         result = generate_one(direction, config)
         if not result.success:
             print(f"Error: {result.error}", file=sys.stderr)
             sys.exit(1)
         print(result.output)
         print(f"Generated in {result.duration_s}s", file=sys.stderr)
-    else:
-        # Batch mode: read directions JSON and generate in parallel
-        batch_path = Path(args.batch)
+
+    @app.command()
+    def batch(
+        json_file: str = typer.Argument(help="JSON file with directions to generate in parallel"),
+        aspect: str = typer.Option("3:4", help="Aspect ratio (default: 3:4)"),
+        ref: str | None = typer.Option(None, help="Override reference image path"),
+        style: str | None = typer.Option(None, help="Override default raccoon style"),
+        transparent: bool = typer.Option(
+            False,
+            help="Generate on magenta chroma-key background, then strip it via ImageMagick edge-connected flood fill from the 4 corners (preserves interior magenta-tinted pixels)",
+        ),
+    ) -> None:
+        """Generate images in parallel from a JSON manifest."""
+        chop_root = resolve_chop_root()
+        load_env()
+
+        if not os.environ.get("GOOGLE_API_KEY"):
+            print(
+                "Error: GOOGLE_API_KEY not found in environment or ~/.env",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        config = GenerateConfig(
+            gemini_script=str(chop_root / "skills" / "gen-image" / "gemini-image.sh"),
+            style=style or read_default_style(chop_root),
+            ref_image=ref or resolve_ref_image(),
+            aspect=aspect,
+            transparent=transparent,
+        )
+
+        batch_path = Path(json_file)
         if not batch_path.exists():
             print(f"Error: Batch file not found: {batch_path}", file=sys.stderr)
             sys.exit(1)
@@ -390,7 +401,9 @@ def main():
                     print(result.output)
                 else:
                     failures.append((result.output, result.error))
-                    print(f"FAILED: {result.output} — {result.error}", file=sys.stderr)
+                    print(
+                        f"FAILED: {result.output} — {result.error}", file=sys.stderr
+                    )
 
         batch_duration = round(time.monotonic() - batch_t0, 1)
 
@@ -409,6 +422,8 @@ def main():
             file=sys.stderr,
         )
 
+    return app
+
 
 if __name__ == "__main__":
-    main()
+    _build_app()()


### PR DESCRIPTION
## Summary

- **New CLAUDE.md convention**: "Python CLI Apps" section codifying when to use Typer vs stdlib argparse, the `_build_app()` lazy-import pattern, and PEP 723 shebangs
- **Migrated 4 scripts** from argparse to Typer subcommands, following the #151 `telegram_debug.py` reference:
  - `generate-tts.py` → `single` / `batch` (eliminated 3-way mutual exclusion boilerplate)
  - `parakeet-stt.py` → `single` / `batch-dir` / `batch-files` (eliminated exactly-one-of validation)
  - `generate.py` → `single` / `batch` + added uv shebang (was missing)
  - `watchdog.py` → `reload` / `daemon` + added uv shebang (was missing)
- Updated all SKILL.md CLI examples, voice preset comments, and cross-skill references

## Breaking CLI changes

| Script | Old | New |
|--------|-----|-----|
| generate-tts.py | `--text "..." --output f.wav` | `single --text "..." --output f.wav` |
| generate-tts.py | `--batch lines.json` | `batch lines.json` |
| parakeet-stt.py | `--input clip.ogg` | `single clip.ogg` |
| parakeet-stt.py | `--batch-dir /path` | `batch-dir /path` |
| parakeet-stt.py | `--batch-files a.wav b.wav` | `batch-files a.wav b.wav` |
| generate.py | `--scene "..." --shirt X --output f.webp` | `single --scene "..." --shirt X --output f.webp` |
| generate.py | `--batch directions.json` | `batch directions.json` |
| watchdog.py | *(no args = daemon)* | `daemon` |

## Test plan

- [x] `test_watchdog.py` — 25/25 pass (pure function imports, not CLI layer)
- [x] All 4 scripts: `--help`, `<subcommand> --help` render correctly
- [x] No stale argparse-style references in SKILL.md files (grep verified)
- [x] Code review: stale refs fixed, `sys.exit()` → `raise typer.Exit()` consistency
- [ ] Smoke-test actual generation on a live box (requires API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI tools now use explicit subcommands (`single`, `batch`, `reload`, `daemon`) instead of flag-based modes for improved clarity and control.

* **Documentation**
  * Updated invocation examples across image generation, speech-to-text, text-to-speech, and hardening tools to reflect new subcommand interfaces.
  * All scripts now execute via `uv run` for consistent runtime environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->