### PR TITLE
docs: default to requires-python >= 3.13 for new scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) M
 
 **Default to Python for any non-trivial script, not shell.** Shell is for one-liners and the occasional `just` target. Anything with branching, data structures, or more than ~20 lines should be Python.
 
-- Use the `uv run --script` shebang with an inline PEP 723 dependency block so scripts self-bootstrap — no venvs, no `pip install`, no setup steps for the user. See [`python/uv-shebang-deps.md`](python/uv-shebang-deps.md) and [`python/python-cli.md`](python/python-cli.md).
+- Use the `uv run --script` shebang with an inline PEP 723 dependency block so scripts self-bootstrap — no venvs, no `pip install`, no setup steps for the user. Default to `requires-python = ">=3.13"` — no need for `from __future__ import annotations` or compatibility shims. See [`python/uv-shebang-deps.md`](python/uv-shebang-deps.md) and [`python/python-cli.md`](python/python-cli.md).
 - Stdlib is enough for most helpers. Only add dependencies when they earn their keep (Typer + Rich for user-facing CLIs; plain stdlib for programmatic JSON-emitting helpers).
 - Put pure logic behind functions that can be unit-tested without subprocess mocking. Shell out to external tools (`git`, `gh`, etc.) through a thin wrapper so the business logic stays testable.
 - Working example: [`skills/up-to-date/diagnose.py`](skills/up-to-date/diagnose.py) — stdlib-only, `uv run` shebang, parallelized subprocess calls, unit-tested pure functions.

--- a/python/python-cli.md
+++ b/python/python-cli.md
@@ -65,7 +65,7 @@ app()
 <example>
 # Lazy-import pattern for testability (tests run in system Python without uv)
 # /// script
-# requires-python = ">=3.10"
+# requires-python = ">=3.13"
 # dependencies = [
 #     "typer>=0.12",
 # ]


### PR DESCRIPTION
## Summary

- Standardize on `requires-python = ">=3.13"` as the default for new PEP 723 scripts
- Eliminates need for `from __future__ import annotations` or compatibility shims
- Updated CLAUDE.md convention and python-cli.md lazy-import example

🤖 Generated with [Claude Code](https://claude.com/claude-code)