### PR TITLE
feat(delegate): prepare_dispatch.py replaces Phase 1-3 bash orchestration

### DIFF
--- a/skills/delegate-to-other-repo/SKILL.md
+++ b/skills/delegate-to-other-repo/SKILL.md
@@ -156,30 +156,67 @@ branches off current HEAD, auto-runs `npm install` / `cargo build`, and
 runs baseline tests — none of which are correct for delegating a change
 off a fresh canonical base ref that may be a doc-only edit.
 
-Full shell recipe lives at [`worktree-recipe.md`](worktree-recipe.md).
-Read that file and follow it verbatim. Key points:
+### Preferred: `prepare_dispatch.py`
 
-- Uses `git -C "$T"` throughout
-- Runs `git remote set-head origin --auto` after fetch to refresh
-  stale `refs/remotes/origin/HEAD` (plain `git fetch` does not)
-- Resolves default branch via `symbolic-ref` → `gh repo view` fallback
-  → literal `main`, with explicit `[ -z "$default_branch" ]` guards
-  to avoid a pipe-precedence bug
-- Derives a slug from the task description with a reproducible rule
-  (lowercase → non-alnum collapsed to `-` → ≤40 chars; empty/non-ASCII
-  falls back to `task-<timestamp>`; collisions get `-2`..`-9` suffixes
-  then a timestamp). Collision check covers BOTH `refs/heads/` and
-  `refs/remotes/origin/` to avoid non-fast-forward push rejection
-- Writes `.worktrees/` to `.git/info/exclude` (local-only, untracked,
-  branch-independent) — NOT a `.gitignore` commit. This avoids
-  mutating any branch's history, works regardless of target's
-  current branch, and survives branch-protected defaults
-- Creates the worktree at `.worktrees/delegated-<slug>` on branch
-  `delegated/<slug>` rooted at `$base_ref` — prefers
-  `upstream/<default>` when an `upstream` remote is present (the
-  normal fork-workflow case), else falls back to `origin/<default>`.
-  Basing off upstream avoids starting the subagent on a stale fork
-  ref when `origin` lags canonical.
+Run the helper — it performs all of Phase 1 resolve + Phase 2 worktree
+setup in a single call and returns the inputs Phase 3 needs as JSON:
+
+```bash
+skills/delegate-to-other-repo/prepare_dispatch.py \
+  --target <name|abs-path|rel-path> \
+  --slug <task-slug> \
+  --task "<task description>" \
+  --pretty
+```
+
+Add `--dry-run` to validate and inspect the JSON without creating the
+worktree or writing `.git/info/exclude`.
+
+Output shape:
+
+```json
+{
+  "worktree_path": "/abs/path/to/.worktrees/delegated-<slug>",
+  "branch": "delegated/<slug>",
+  "base_ref": "upstream/main",
+  "base_remote": "upstream",
+  "default_branch": "main",
+  "target_repo_slug": "owner/repo",
+  "session_log": "/path/to/jsonl or null",
+  "slug": "<final-slug-after-collision-resolution>",
+  "errors": []
+}
+```
+
+Non-empty `errors` means the helper stopped before creating the
+worktree — relay the first error to the user and abort. Typical causes:
+target path missing, not a git repo, `owner/repo` slug passed (helper
+does not clone), base ref unreachable after fetch.
+
+The helper does the following in order (all `git -C <target>`, never `cd`):
+
+- Resolves the target path (absolute path / relative path / bare name / rejects `owner/repo` slugs with a clone hint)
+- Fetches `origin` and `upstream` (if present) in parallel via `concurrent.futures`
+- Runs `git remote set-head origin --auto` to refresh stale `refs/remotes/origin/HEAD`
+- Resolves the default branch via `symbolic-ref` → `gh repo view` fallback → literal `main`, with explicit guards between each step (not `||` chains — pipe-precedence bug swallows exit codes)
+- Picks `upstream/<default>` when the `upstream` remote has the ref, else `origin/<default>`
+- Verifies the chosen base ref resolves
+- Sanitizes the slug (lowercase → non-alnum collapsed to `-` → ≤40 chars; non-ASCII / empty → `task-<timestamp>`)
+- Resolves collisions against BOTH `refs/heads/delegated/<slug>` AND `refs/remotes/origin/delegated/<slug>` (heads-only would let the push fail as non-fast-forward)
+- Idempotently appends `.worktrees/` to `<git-common-dir>/info/exclude` — local-only, branch-independent, avoids committing to any branch's `.gitignore`
+- Creates the worktree at `.worktrees/delegated-<slug>` on branch `delegated/<slug>` rooted at the chosen base ref
+- Resolves the parent session's Claude jsonl via `pwd -P` hashed with `[/.]` → `-` (both separators matter — `bar.github.io` hashes to `-bar-github-io`, not `-bar.github.io`)
+- Parses `owner/repo` from `git -C <T> remote get-url origin` (handles both HTTPS and SSH forms)
+
+### Testing
+
+```bash
+cd skills/delegate-to-other-repo && python3 -m unittest test_prepare_dispatch
+```
+
+Pure functions (slug sanitization, default-branch chain, base-ref
+selection, session-log hash, remote-URL parse) are unit-tested in
+isolation — no subprocess mocking required for those.
 
 ### V1 limitation
 
@@ -559,10 +596,24 @@ the brief uses plain-text formatting for all embedded structure
 - `up-to-date` — its `diagnose.py` helper is what the subagent uses
   as a fork-detection shortcut (Cases A and simple B only)
 
+## Manual fallback
+
+If `prepare_dispatch.py` is broken or unavailable (stale checkout,
+Python not on PATH, uv bootstrap failure), drop to the bash recipe at
+[`worktree-recipe.md`](worktree-recipe.md) and follow it verbatim. Same
+semantics — the Python helper was extracted FROM that recipe, and the
+unit tests pin the pure-function behavior byte-for-byte. Prefer the
+Python path whenever both work.
+
 ## Supplementary files
 
-- [`worktree-recipe.md`](worktree-recipe.md) — full shell recipe for
-  Phase 2, with safety checks and fallback chains
+- [`prepare_dispatch.py`](prepare_dispatch.py) — preferred Phase 1-3
+  helper (resolves target, fetches, picks base ref, slug-collision
+  resolves, creates worktree, emits JSON)
+- [`test_prepare_dispatch.py`](test_prepare_dispatch.py) — unit tests
+  for the helper's pure functions and dry-run orchestration
+- [`worktree-recipe.md`](worktree-recipe.md) — manual-fallback shell
+  recipe with full commentary on every step
 - [`brief-template.md`](brief-template.md) — the full self-contained
   brief the parent substitutes slots into and passes to Agent
 - [`fork-detection.md`](fork-detection.md) — the 4-case decision tree

--- a/skills/delegate-to-other-repo/prepare_dispatch.py
+++ b/skills/delegate-to-other-repo/prepare_dispatch.py
@@ -1,0 +1,578 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "typer>=0.12",
+# ]
+# ///
+"""Prepare a delegated-worktree dispatch for the delegate-to-other-repo skill.
+
+Replaces Phases 1-3 of the skill's bash recipe with a single typed helper:
+
+  * resolve the target repo path from user input (abs/rel path or bare name)
+  * fetch origin (+ upstream in parallel when present)
+  * refresh refs/remotes/origin/HEAD
+  * resolve default branch via symbolic-ref -> gh fallback -> literal "main"
+  * choose base ref (upstream/<default> if upstream exists, else origin/<default>)
+  * validate base ref is reachable
+  * sanitize + collision-check the task slug across heads AND origin refs
+  * idempotently write .worktrees/ to .git/info/exclude
+  * create the worktree on branch `delegated/<slug>`
+  * resolve the parent session's Claude jsonl via pwd hash (pwd -P, [/.] -> -)
+  * parse owner/repo slug from origin URL
+
+Output: a single JSON object on stdout with all the data the parent needs
+to render a brief. The parent still owns brief rendering — this helper
+only collects inputs.
+
+Pure functions (slug sanitization, default-branch chain, session-log hash,
+remote URL parsing, base-ref selection) are importable from
+test_prepare_dispatch.py without any deps (typer is lazy-imported inside
+_build_app()).
+
+Usage:
+    prepare_dispatch.py --target <name|path> --slug <slug> --task "<desc>"
+    prepare_dispatch.py ... --dry-run   # validate + emit JSON, do not mutate
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import re
+import subprocess
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Callable
+
+
+# ---------- Pure functions (unit-tested) ----------
+
+
+# Slug sanitization mirrors worktree-recipe.md §4 — lowercase, non-alnum
+# collapsed to `-`, strip leading/trailing `-`, cut to 40 chars, re-strip.
+_SLUG_INVALID_RE = re.compile(r"[^a-z0-9]+")
+_SLUG_MAX_LEN = 40
+
+
+def sanitize_slug(raw: str) -> str | None:
+    """Return a kebab-case slug, or None if the input produced nothing usable.
+
+    Rules match worktree-recipe.md §4:
+      1. Lowercase
+      2. Collapse runs of non-[a-z0-9] to a single `-`
+      3. Strip leading/trailing `-`
+      4. Truncate to 40 chars, re-strip trailing `-`
+
+    Non-ASCII input collapses entirely to `-` under step 2 and is stripped
+    to an empty string by step 3 — caller falls back to a timestamp form.
+    """
+    lowered = raw.lower()
+    collapsed = _SLUG_INVALID_RE.sub("-", lowered).strip("-")
+    if not collapsed:
+        return None
+    truncated = collapsed[:_SLUG_MAX_LEN].rstrip("-")
+    return truncated or None
+
+
+def timestamp_slug(now: _dt.datetime | None = None) -> str:
+    """Fallback slug when sanitize returns None."""
+    n = now if now is not None else _dt.datetime.now()
+    return f"task-{n.strftime('%Y%m%d-%H%M%S')}"
+
+
+def resolve_unique_slug(
+    base_slug: str,
+    ref_exists: Callable[[str], bool],
+    now: _dt.datetime | None = None,
+) -> str:
+    """Append -2..-9 suffixes if `delegated/<slug>` collides, else timestamp form.
+
+    `ref_exists(candidate)` should return True iff either
+    `refs/heads/delegated/<candidate>` or
+    `refs/remotes/origin/delegated/<candidate>` exists — caller owns the
+    actual git invocation. Checking both is load-bearing: heads-only missed
+    a case where origin had the name, which then rejected the push as
+    non-fast-forward (force-push is prohibited).
+    """
+    if not ref_exists(base_slug):
+        return base_slug
+    for i in range(2, 10):
+        candidate = f"{base_slug}-{i}"
+        if not ref_exists(candidate):
+            return candidate
+    return timestamp_slug(now)
+
+
+def choose_default_branch(
+    symbolic_ref_out: str | None,
+    gh_default_out: str | None,
+) -> str:
+    """Pick a default-branch name from the chain symbolic-ref -> gh -> 'main'.
+
+    Each step MUST be an explicit guard. Piping through `|| echo main`
+    swallows empty output and falsely claims success — verified in the
+    worktree-recipe notes (T=/tmp/nonexistent recipe returned '').
+    """
+    if symbolic_ref_out:
+        # `git symbolic-ref --short refs/remotes/origin/HEAD` returns
+        # `origin/main`. Strip any `origin/` prefix defensively.
+        name = symbolic_ref_out.strip()
+        if name.startswith("origin/"):
+            name = name[len("origin/") :]
+        if name:
+            return name
+    if gh_default_out:
+        name = gh_default_out.strip()
+        if name:
+            return name
+    return "main"
+
+
+def choose_base(
+    default_branch: str,
+    upstream_has_ref: bool,
+) -> tuple[str, str]:
+    """Return `(base_remote, base_ref)` — upstream preferred when reachable.
+
+    When both `upstream` and `origin` exist (fork workflow), canonical main
+    lives on upstream and `origin/<default>` may lag. Basing the worktree
+    on stale origin forces rebase at runtime — a real incident 2026-04-16.
+    """
+    if upstream_has_ref:
+        return "upstream", f"upstream/{default_branch}"
+    return "origin", f"origin/{default_branch}"
+
+
+# Owner/repo parse covers both HTTPS and SSH remote URL forms.
+# HTTPS: https://github.com/owner/repo[.git]
+# SSH:   git@github.com:owner/repo[.git]
+_REMOTE_SLUG_RE = re.compile(
+    r"""
+    ^
+    (?:https?://[^/]+/|git@[^:]+:)   # scheme-or-ssh host prefix
+    (?P<owner>[^/]+)/(?P<repo>[^/]+?)
+    (?:\.git)?$
+    """,
+    re.VERBOSE,
+)
+
+
+def parse_repo_slug(url: str) -> str | None:
+    """Return `owner/repo` from a git remote URL, or None on no match."""
+    m = _REMOTE_SLUG_RE.match(url.strip())
+    if not m:
+        return None
+    return f"{m['owner']}/{m['repo']}"
+
+
+def session_log_hash_of(path: str) -> str:
+    """Hash a cwd path into Claude Code's project-dir convention.
+
+    Two gotchas (both bite in practice — see SKILL.md §Session log resolution):
+
+      1. Both `/` and `.` become `-`. A repo at
+         `/home/foo/gits/bar.github.io` hashes to
+         `-home-foo-gits-bar-github-io`, NOT ...`bar.github.io`. The regex
+         uses `[/.]` to catch both.
+      2. Callers MUST pass the physical path (os.path.realpath / pwd -P),
+         not the logical one. Claude hashes the physical path; a symlinked
+         shortcut produces a hash that matches no project dir.
+    """
+    return re.sub(r"[/.]", "-", path)
+
+
+def find_newest_jsonl(project_dir: Path) -> str | None:
+    """Return the newest `*.jsonl` under `project_dir` by mtime, or None.
+
+    Stdlib only — this is a ~/bin/ls -t equivalent that doesn't shell out.
+    """
+    if not project_dir.is_dir():
+        return None
+    candidates = sorted(
+        project_dir.glob("*.jsonl"),
+        key=lambda p: p.stat().st_mtime,
+        reverse=True,
+    )
+    return str(candidates[0]) if candidates else None
+
+
+def resolve_session_log(
+    cwd_physical: str,
+    repo_toplevel: str | None,
+    home: Path,
+) -> str | None:
+    """Find the parent session's jsonl via cwd hash, then repo-toplevel hash.
+
+    Both lookups use the same hash convention (`[/.]` -> `-`). Returns None
+    if neither yields a jsonl — parent will omit the historical-context
+    section of the brief. Parallel sessions in the same cwd resolve to
+    "whichever jsonl was most recently written" — an accepted v1 ambiguity.
+    """
+    base = home / ".claude" / "projects"
+    cwd_dir = base / session_log_hash_of(cwd_physical)
+    found = find_newest_jsonl(cwd_dir)
+    if found:
+        return found
+    if repo_toplevel and repo_toplevel != cwd_physical:
+        top_dir = base / session_log_hash_of(repo_toplevel)
+        return find_newest_jsonl(top_dir)
+    return None
+
+
+def resolve_target_path(
+    target: str, cwd: Path, home: Path
+) -> tuple[Path | None, str | None]:
+    """Return `(resolved_path, error)` for the caller's target argument.
+
+    Rules mirror SKILL.md §1a:
+      * absolute path -> use it
+      * relative path -> resolve against cwd
+      * bare name -> `~/gits/<name>`
+      * `owner/repo` slug -> error (skill does not clone)
+
+    Does not stat the path — caller validates existence via git-is-inside.
+    """
+    if not target:
+        return None, "empty target"
+    # owner/repo slug: exactly one `/`, no other path separators or dots
+    if (
+        target.count("/") == 1
+        and not target.startswith((".", "/"))
+        and "\\" not in target
+    ):
+        owner, repo = target.split("/", 1)
+        if owner and repo and "/" not in repo:
+            return None, (
+                f"'{target}' looks like an owner/repo slug. This skill does not "
+                f"clone repos. Run `gh repo clone {target} ~/gits/{repo}` first, "
+                "then retry with `--target " + repo + "`."
+            )
+    p = Path(target)
+    if p.is_absolute():
+        return p, None
+    if "/" in target or target.startswith("."):
+        return (cwd / p).resolve(), None
+    # bare name -> ~/gits/<name>
+    return home / "gits" / target, None
+
+
+# ---------- Thin I/O wrappers (not unit-tested — mocked via fake_git in tests) ----------
+
+
+def _run(
+    cmd: list[str], *, check: bool = False, cwd: str | None = None
+) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=check, cwd=cwd)
+
+
+def _git(target: str, *args: str, check: bool = False) -> subprocess.CompletedProcess:
+    return _run(["git", "-C", target, *args], check=check)
+
+
+def _remote_exists(target: str, name: str) -> bool:
+    proc = _git(target, "remote")
+    if proc.returncode != 0:
+        return False
+    return name in {ln.strip() for ln in proc.stdout.splitlines() if ln.strip()}
+
+
+def _rev_parse_verify(target: str, ref: str) -> bool:
+    proc = _git(target, "rev-parse", "--verify", "--quiet", ref)
+    return proc.returncode == 0
+
+
+def _ref_exists_anywhere(target: str) -> Callable[[str], bool]:
+    """Return a closure that checks both heads and origin refs for a slug."""
+
+    def _check(slug: str) -> bool:
+        for ref in (
+            f"refs/heads/delegated/{slug}",
+            f"refs/remotes/origin/delegated/{slug}",
+        ):
+            if _rev_parse_verify(target, ref):
+                return True
+        return False
+
+    return _check
+
+
+def _get_repo_slug(target: str) -> str | None:
+    proc = _git(target, "remote", "get-url", "origin")
+    if proc.returncode != 0:
+        return None
+    return parse_repo_slug(proc.stdout.strip())
+
+
+def _symbolic_ref_origin_head(target: str) -> str | None:
+    proc = _git(target, "symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _gh_default_branch(slug: str | None) -> str | None:
+    if not slug:
+        return None
+    proc = _run(
+        [
+            "gh",
+            "repo",
+            "view",
+            slug,
+            "--json",
+            "defaultBranchRef",
+            "-q",
+            ".defaultBranchRef.name",
+        ]
+    )
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def _fetch_remote(target: str, name: str) -> subprocess.CompletedProcess:
+    return _git(target, "fetch", name, "--quiet")
+
+
+def _git_common_dir(target: str) -> Path | None:
+    # `--path-format=absolute` is load-bearing: plain `--git-common-dir`
+    # returns a path relative to cwd, and this helper never cd's into the
+    # target. Without `--path-format=absolute` the append below would land
+    # in the caller's cwd (verified incident on 2026-04-16).
+    proc = _git(target, "rev-parse", "--path-format=absolute", "--git-common-dir")
+    if proc.returncode != 0:
+        return None
+    out = proc.stdout.strip()
+    return Path(out) if out else None
+
+
+def _ensure_exclude(target: str) -> tuple[bool, str | None]:
+    """Idempotently append `.worktrees/` to `<git-common-dir>/info/exclude`.
+
+    Returns `(wrote, error)`. `wrote=False` and `error=None` means the
+    entry was already present.
+    """
+    common = _git_common_dir(target)
+    if common is None:
+        return False, "git rev-parse --git-common-dir failed"
+    info = common / "info"
+    exclude_file = info / "exclude"
+    try:
+        if exclude_file.is_file():
+            existing = exclude_file.read_text()
+            for line in existing.splitlines():
+                if line.strip() == ".worktrees/":
+                    return False, None
+        info.mkdir(parents=True, exist_ok=True)
+        with exclude_file.open("a", encoding="utf-8") as f:
+            f.write("\n# Added by delegate-to-other-repo skill\n.worktrees/\n")
+    except OSError as e:
+        return False, f"write to {exclude_file} failed: {e}"
+    return True, None
+
+
+def _worktree_add(
+    target: str, path: str, branch: str, base_ref: str
+) -> subprocess.CompletedProcess:
+    return _git(target, "worktree", "add", path, "-b", branch, base_ref)
+
+
+# ---------- Orchestrator ----------
+
+
+def run_prepare(
+    target_raw: str,
+    slug_raw: str,
+    task: str,
+    dry_run: bool,
+    cwd: Path,
+    home: Path,
+) -> dict[str, Any]:
+    """Execute all prepare phases and return a JSON-serializable dict.
+
+    On any pre-mutation error, returns early with a populated `errors` list
+    and an unpopulated `worktree_path`. When `dry_run=True`, skips the
+    mutation steps (worktree add, exclude write) but still returns the
+    JSON that would have been emitted.
+    """
+    errors: list[str] = []
+    result: dict[str, Any] = {
+        "worktree_path": None,
+        "branch": None,
+        "base_ref": None,
+        "base_remote": None,
+        "default_branch": None,
+        "target_repo_slug": None,
+        "session_log": None,
+        "task": task,
+        "dry_run": dry_run,
+        "errors": errors,
+    }
+
+    # ---- resolve target path ----
+    target_path, err = resolve_target_path(target_raw, cwd, home)
+    if err or target_path is None:
+        errors.append(err or "could not resolve target")
+        return result
+    target_str = str(target_path)
+    result["target"] = target_str
+
+    if not target_path.exists():
+        errors.append(f"target does not exist: {target_str}")
+        return result
+
+    inside = _git(target_str, "rev-parse", "--is-inside-work-tree")
+    if inside.returncode != 0 or inside.stdout.strip() != "true":
+        errors.append(f"target is not a git repo: {target_str}")
+        return result
+
+    # Parse slug from origin URL upfront — we need it as a gh fallback input
+    # and for the final JSON output.
+    repo_slug = _get_repo_slug(target_str)
+    result["target_repo_slug"] = repo_slug
+    if repo_slug is None:
+        errors.append(
+            f"could not parse owner/repo from `git -C {target_str} remote get-url origin`"
+        )
+        return result
+
+    # ---- fetch origin (+ upstream in parallel if present) ----
+    has_upstream = _remote_exists(target_str, "upstream")
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        origin_fut = pool.submit(_fetch_remote, target_str, "origin")
+        upstream_fut = (
+            pool.submit(_fetch_remote, target_str, "upstream") if has_upstream else None
+        )
+        origin_proc = origin_fut.result()
+        upstream_proc = upstream_fut.result() if upstream_fut else None
+
+    if origin_proc.returncode != 0:
+        errors.append(f"git fetch origin failed: {origin_proc.stderr.strip()}")
+        return result
+    if upstream_proc is not None and upstream_proc.returncode != 0:
+        # Non-fatal — we can still fall back to origin/<default>.
+        errors.append(
+            f"git fetch upstream failed (continuing with origin base): "
+            f"{upstream_proc.stderr.strip()}"
+        )
+        has_upstream = False
+
+    # Refresh origin/HEAD — plain `git fetch` does NOT. Idempotent no-op.
+    _git(target_str, "remote", "set-head", "origin", "--auto")
+
+    # ---- default branch chain ----
+    sym = _symbolic_ref_origin_head(target_str)
+    gh_out = _gh_default_branch(repo_slug) if not sym else None
+    default_branch = choose_default_branch(sym, gh_out)
+    result["default_branch"] = default_branch
+
+    # ---- base ref selection ----
+    upstream_ref_reachable = has_upstream and _rev_parse_verify(
+        target_str, f"upstream/{default_branch}"
+    )
+    base_remote, base_ref = choose_base(default_branch, upstream_ref_reachable)
+    result["base_remote"] = base_remote
+    result["base_ref"] = base_ref
+
+    if not _rev_parse_verify(target_str, base_ref):
+        errors.append(f"{base_ref} is not reachable in {target_str} after fetch")
+        return result
+
+    # ---- slug sanitization + collision resolution ----
+    clean = sanitize_slug(slug_raw) or sanitize_slug(task) or timestamp_slug()
+    final_slug = resolve_unique_slug(clean, _ref_exists_anywhere(target_str))
+    branch = f"delegated/{final_slug}"
+    worktree_path = str(target_path / ".worktrees" / f"delegated-{final_slug}")
+    result["slug"] = final_slug
+    result["branch"] = branch
+    result["worktree_path"] = worktree_path
+
+    # ---- session log resolution ----
+    cwd_physical = str(cwd.resolve())
+    toplevel_proc = _git(".", "rev-parse", "--show-toplevel")
+    repo_toplevel = (
+        toplevel_proc.stdout.strip() if toplevel_proc.returncode == 0 else None
+    )
+    result["session_log"] = resolve_session_log(cwd_physical, repo_toplevel, home)
+
+    if dry_run:
+        return result
+
+    # ---- mutations (skipped on --dry-run) ----
+    _wrote, exclude_err = _ensure_exclude(target_str)
+    if exclude_err:
+        errors.append(exclude_err)
+        return result
+
+    wt_proc = _worktree_add(target_str, worktree_path, branch, base_ref)
+    if wt_proc.returncode != 0:
+        errors.append(f"git worktree add failed: {wt_proc.stderr.strip()}")
+        # The previously-populated worktree_path is now misleading since
+        # nothing was created; clear it so the parent doesn't dispatch.
+        result["worktree_path"] = None
+        return result
+
+    return result
+
+
+# ---------- CLI ----------
+
+
+def _build_app():
+    """Wire up the Typer app. Called only when executed as a script so
+    tests and module-importers don't need `typer` on their PYTHONPATH."""
+    import typer
+
+    app = typer.Typer(
+        add_completion=False,
+        help="Prepare a delegated-worktree dispatch (delegate-to-other-repo Phase 1-3).",
+        no_args_is_help=True,
+    )
+
+    @app.callback(invoke_without_command=True)
+    def main(
+        target: str = typer.Option(
+            ...,
+            "--target",
+            help="Target repo: absolute path, relative path, or bare name (resolved under ~/gits/).",
+        ),
+        slug: str = typer.Option(
+            ...,
+            "--slug",
+            help="Task slug; sanitized and collision-checked against refs/heads/ AND refs/remotes/origin/.",
+        ),
+        task: str = typer.Option(
+            ...,
+            "--task",
+            help="Task description (passed through to the brief — no semantic interpretation).",
+        ),
+        dry_run: bool = typer.Option(
+            False,
+            "--dry-run",
+            help="Validate + emit JSON, but do not create the worktree or write .git/info/exclude.",
+        ),
+        pretty: bool = typer.Option(
+            False, "--pretty", help="Pretty-print JSON output."
+        ),
+    ) -> None:
+        """Prepare a worktree and emit structured JSON for the parent skill."""
+        data = run_prepare(
+            target_raw=target,
+            slug_raw=slug,
+            task=task,
+            dry_run=dry_run,
+            cwd=Path.cwd(),
+            home=Path.home(),
+        )
+        indent = 2 if pretty else None
+        json.dump(data, sys.stdout, indent=indent)
+        sys.stdout.write("\n")
+        raise typer.Exit(1 if data["errors"] else 0)
+
+    return app
+
+
+if __name__ == "__main__":
+    _build_app()()

--- a/skills/delegate-to-other-repo/test_prepare_dispatch.py
+++ b/skills/delegate-to-other-repo/test_prepare_dispatch.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+"""Unit tests for prepare_dispatch.py pure functions + dry-run orchestration.
+
+Run with: python3 -m unittest test_prepare_dispatch
+
+Typer is NOT imported anywhere in this file — the helper's CLI is wired up
+in `_build_app()` which lives behind the `if __name__ == "__main__":`
+guard. Tests exercise pure functions directly and drive the orchestrator
+through a stubbed subprocess layer.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+# Ensure the sibling module is importable when invoked via
+# `python3 -m unittest` from the skill directory. `unittest discover`
+# already puts the start dir on sys.path; the insert below is for
+# pytest + pyright parity without adding a conftest.py to the staging set.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+import prepare_dispatch  # noqa: E402 — sibling import after sys.path shim above
+from prepare_dispatch import (  # noqa: E402 — sibling import after sys.path shim above
+    choose_base,
+    choose_default_branch,
+    find_newest_jsonl,
+    parse_repo_slug,
+    resolve_session_log,
+    resolve_target_path,
+    resolve_unique_slug,
+    sanitize_slug,
+    session_log_hash_of,
+    timestamp_slug,
+)
+
+
+class TestSanitizeSlug(unittest.TestCase):
+    def test_ascii_passthrough(self):
+        self.assertEqual(sanitize_slug("fix-typo"), "fix-typo")
+
+    def test_lowercasing(self):
+        self.assertEqual(sanitize_slug("Fix-Typo"), "fix-typo")
+
+    def test_non_alnum_collapsed(self):
+        self.assertEqual(sanitize_slug("add  fancy_feature!!"), "add-fancy-feature")
+
+    def test_leading_and_trailing_stripped(self):
+        self.assertEqual(sanitize_slug("--leading--trailing--"), "leading-trailing")
+
+    def test_length_cap_at_40_with_trailing_dash_stripped(self):
+        # Build an input that, after sanitization, puts a `-` exactly at position 40
+        # so truncation leaves a trailing dash to strip.
+        raw = (
+            "a" * 39 + " " + "b" * 10
+        )  # -> "aaaa...a-bbbb...b", cut to 40 = "aaaa...a-"
+        out = sanitize_slug(raw)
+        self.assertIsNotNone(out)
+        assert out is not None  # narrowing for type-checkers
+        self.assertLessEqual(len(out), 40)
+        self.assertFalse(out.endswith("-"))
+
+    def test_empty_input_returns_none(self):
+        self.assertIsNone(sanitize_slug(""))
+
+    def test_pure_punctuation_returns_none(self):
+        self.assertIsNone(sanitize_slug("!!!---???"))
+
+    def test_non_ascii_returns_none(self):
+        # Greek/Japanese characters don't survive step 2.
+        self.assertIsNone(sanitize_slug("αβγ 日本語"))
+
+
+class TestTimestampSlug(unittest.TestCase):
+    def test_format(self):
+        import datetime
+
+        now = datetime.datetime(2026, 4, 17, 9, 30, 0)
+        self.assertEqual(timestamp_slug(now), "task-20260417-093000")
+
+
+class TestResolveUniqueSlug(unittest.TestCase):
+    def test_clean(self):
+        self.assertEqual(
+            resolve_unique_slug("fix-thing", ref_exists=lambda _s: False),
+            "fix-thing",
+        )
+
+    def test_one_existing_suffix_2(self):
+        def fake(s: str) -> bool:
+            return s == "fix-thing"
+
+        self.assertEqual(resolve_unique_slug("fix-thing", fake), "fix-thing-2")
+
+    def test_eight_existing_hits_limit_then_timestamp(self):
+        import datetime
+
+        # -2..-9 all taken (8 entries) plus the base — falls through to timestamp.
+        taken = {"fix-thing"} | {f"fix-thing-{i}" for i in range(2, 10)}
+
+        now = datetime.datetime(2026, 4, 17, 9, 30, 0)
+        out = resolve_unique_slug("fix-thing", lambda s: s in taken, now=now)
+        self.assertEqual(out, "task-20260417-093000")
+
+    def test_gap_in_middle_picks_lowest_free(self):
+        taken = {"fix-thing", "fix-thing-2", "fix-thing-4"}
+        self.assertEqual(
+            resolve_unique_slug("fix-thing", lambda s: s in taken),
+            "fix-thing-3",
+        )
+
+
+class TestChooseDefaultBranch(unittest.TestCase):
+    def test_symbolic_ref_present(self):
+        self.assertEqual(choose_default_branch("origin/main", None), "main")
+
+    def test_symbolic_ref_without_prefix(self):
+        self.assertEqual(choose_default_branch("trunk", None), "trunk")
+
+    def test_falls_through_to_gh(self):
+        self.assertEqual(choose_default_branch(None, "master"), "master")
+
+    def test_falls_through_to_main(self):
+        self.assertEqual(choose_default_branch(None, None), "main")
+
+    def test_empty_symbolic_ref_falls_through(self):
+        self.assertEqual(choose_default_branch("", "trunk"), "trunk")
+
+    def test_whitespace_only_gh_falls_through_to_main(self):
+        self.assertEqual(choose_default_branch(None, "   "), "main")
+
+
+class TestChooseBase(unittest.TestCase):
+    def test_upstream_preferred_when_reachable(self):
+        self.assertEqual(
+            choose_base("main", upstream_has_ref=True), ("upstream", "upstream/main")
+        )
+
+    def test_origin_fallback_when_upstream_missing(self):
+        self.assertEqual(
+            choose_base("main", upstream_has_ref=False), ("origin", "origin/main")
+        )
+
+    def test_origin_fallback_when_upstream_unreachable(self):
+        # upstream_has_ref=False covers both "no upstream remote" and
+        # "upstream exists but ref unreachable" — single boolean.
+        self.assertEqual(
+            choose_base("master", upstream_has_ref=False), ("origin", "origin/master")
+        )
+
+
+class TestParseRepoSlug(unittest.TestCase):
+    def test_https_with_git_suffix(self):
+        self.assertEqual(
+            parse_repo_slug("https://github.com/idvorkin/chop-conventions.git"),
+            "idvorkin/chop-conventions",
+        )
+
+    def test_https_without_git_suffix(self):
+        self.assertEqual(
+            parse_repo_slug("https://github.com/idvorkin/chop-conventions"),
+            "idvorkin/chop-conventions",
+        )
+
+    def test_ssh_with_git_suffix(self):
+        self.assertEqual(
+            parse_repo_slug("git@github.com:idvorkin/chop-conventions.git"),
+            "idvorkin/chop-conventions",
+        )
+
+    def test_ssh_without_git_suffix(self):
+        self.assertEqual(
+            parse_repo_slug("git@github.com:idvorkin/blog"),
+            "idvorkin/blog",
+        )
+
+    def test_gibberish_returns_none(self):
+        self.assertIsNone(parse_repo_slug("not a url"))
+
+
+class TestSessionLogHash(unittest.TestCase):
+    def test_slash_replaced(self):
+        self.assertEqual(
+            session_log_hash_of("/home/foo/gits/bar"),
+            "-home-foo-gits-bar",
+        )
+
+    def test_dot_also_replaced(self):
+        # Load-bearing: `.github.io` -> `-github-io`, not `.github.io`.
+        self.assertEqual(
+            session_log_hash_of("/home/foo/gits/bar.github.io"),
+            "-home-foo-gits-bar-github-io",
+        )
+
+
+class TestResolveSessionLog(unittest.TestCase):
+    def test_symlinked_cwd_uses_physical_path(self):
+        # Build a temp home with a .claude/projects/<hash> dir keyed to the
+        # PHYSICAL path; caller passes the physical path so it must find the jsonl.
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            real_repo = home / "gits" / "myrepo.github.io"
+            real_repo.mkdir(parents=True)
+            physical = str(real_repo)
+
+            # Put a jsonl under the PHYSICAL hash directory.
+            hash_dir = home / ".claude" / "projects" / session_log_hash_of(physical)
+            hash_dir.mkdir(parents=True)
+            jsonl = hash_dir / "session-1.jsonl"
+            jsonl.write_text("")
+
+            # Caller resolved the symlink to `physical` via os.path.realpath.
+            found = resolve_session_log(physical, physical, home)
+            self.assertEqual(found, str(jsonl))
+
+    def test_falls_back_to_repo_toplevel(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            # cwd hash dir doesn't exist; toplevel hash dir does.
+            toplevel = "/home/x/gits/other"
+            hash_dir = home / ".claude" / "projects" / session_log_hash_of(toplevel)
+            hash_dir.mkdir(parents=True)
+            jsonl = hash_dir / "session-1.jsonl"
+            jsonl.write_text("")
+
+            found = resolve_session_log("/home/x/wt", toplevel, home)
+            self.assertEqual(found, str(jsonl))
+
+    def test_returns_none_when_neither_resolves(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            found = resolve_session_log("/nowhere/cwd", "/nowhere/toplevel", home)
+            self.assertIsNone(found)
+
+    def test_picks_newest_jsonl_by_mtime(self):
+        with tempfile.TemporaryDirectory() as td:
+            home = Path(td)
+            physical = "/tmp/phys"
+            hash_dir = home / ".claude" / "projects" / session_log_hash_of(physical)
+            hash_dir.mkdir(parents=True)
+            older = hash_dir / "old.jsonl"
+            newer = hash_dir / "new.jsonl"
+            older.write_text("")
+            newer.write_text("")
+            # Force mtime order so the test doesn't race the clock resolution.
+            os.utime(older, (1_000_000, 1_000_000))
+            os.utime(newer, (2_000_000, 2_000_000))
+            self.assertEqual(find_newest_jsonl(hash_dir), str(newer))
+
+
+class TestResolveTargetPath(unittest.TestCase):
+    def setUp(self):
+        self.cwd = Path("/home/dev/gits/blog6")
+        self.home = Path("/home/dev")
+
+    def test_absolute_path(self):
+        p, err = resolve_target_path("/absolute/elsewhere", self.cwd, self.home)
+        self.assertIsNone(err)
+        self.assertEqual(p, Path("/absolute/elsewhere"))
+
+    def test_bare_name_resolves_to_home_gits(self):
+        p, err = resolve_target_path("other-repo", self.cwd, self.home)
+        self.assertIsNone(err)
+        self.assertEqual(p, Path("/home/dev/gits/other-repo"))
+
+    def test_owner_repo_slug_errors(self):
+        p, err = resolve_target_path("idvorkin/chop", self.cwd, self.home)
+        self.assertIsNone(p)
+        assert err is not None
+        self.assertIn("gh repo clone", err)
+
+
+class TestRunPrepareDryRun(unittest.TestCase):
+    """Orchestrator smoke test using stubbed subprocess calls."""
+
+    def _fake_git(self, script):
+        """Return a fake `_git(target, *args, check=False)` closure.
+
+        `script` is a list of `(matcher, returncode, stdout, stderr)` tuples
+        where `matcher(args_tuple)` returns True for the command this entry
+        should handle. Entries are consumed in-order; unmatched calls raise.
+        """
+        import subprocess
+
+        def fake(target: str, *args: str, check: bool = False):
+            for matcher, rc, out, err in script:
+                if matcher(args):
+                    return subprocess.CompletedProcess(
+                        args=["git", "-C", target, *args],
+                        returncode=rc,
+                        stdout=out,
+                        stderr=err,
+                    )
+            raise AssertionError(f"unexpected git call: {args}")
+
+        return fake
+
+    def test_dry_run_does_not_mutate(self):
+        """--dry-run must not call worktree add or write the exclude file."""
+        import subprocess
+
+        # Matchers — single-shot; not consumed.
+        def is_(*expected):
+            return lambda args: tuple(args[: len(expected)]) == expected
+
+        script = [
+            # Order doesn't matter — matchers are evaluated per-call.
+            (is_("rev-parse", "--is-inside-work-tree"), 0, "true\n", ""),
+            (
+                is_("remote", "get-url", "origin"),
+                0,
+                "git@github.com:idvorkin/blog.git\n",
+                "",
+            ),
+            (is_("remote"), 0, "origin\nupstream\n", ""),
+            (is_("fetch", "origin"), 0, "", ""),
+            (is_("fetch", "upstream"), 0, "", ""),
+            (is_("remote", "set-head", "origin", "--auto"), 0, "", ""),
+            (
+                is_("symbolic-ref", "--short", "refs/remotes/origin/HEAD"),
+                0,
+                "origin/main\n",
+                "",
+            ),
+            (is_("rev-parse", "--verify", "--quiet", "upstream/main"), 0, "", ""),
+            (
+                is_("rev-parse", "--verify", "--quiet", "refs/heads/delegated/my-slug"),
+                1,
+                "",
+                "",
+            ),
+            (
+                is_(
+                    "rev-parse",
+                    "--verify",
+                    "--quiet",
+                    "refs/remotes/origin/delegated/my-slug",
+                ),
+                1,
+                "",
+                "",
+            ),
+            (is_("rev-parse", "--show-toplevel"), 0, "/home/dev/gits/blog6\n", ""),
+        ]
+
+        write_calls: list[str] = []
+
+        def fake_worktree_add(*a, **kw):
+            write_calls.append("worktree_add")
+            return subprocess.CompletedProcess(
+                args=a, returncode=0, stdout="", stderr=""
+            )
+
+        def fake_ensure_exclude(target):
+            write_calls.append("ensure_exclude")
+            return True, None
+
+        with (
+            mock.patch.object(
+                prepare_dispatch, "_git", side_effect=self._fake_git(script)
+            ),
+            mock.patch.object(
+                prepare_dispatch, "_worktree_add", side_effect=fake_worktree_add
+            ),
+            mock.patch.object(
+                prepare_dispatch, "_ensure_exclude", side_effect=fake_ensure_exclude
+            ),
+        ):
+            with tempfile.TemporaryDirectory() as td:
+                home = Path(td)
+                target_dir = home / "gits" / "blog"
+                target_dir.mkdir(parents=True)
+                result = prepare_dispatch.run_prepare(
+                    target_raw="blog",
+                    slug_raw="my-slug",
+                    task="do the thing",
+                    dry_run=True,
+                    cwd=Path(td),
+                    home=home,
+                )
+
+        self.assertEqual(result["errors"], [])
+        self.assertEqual(result["slug"], "my-slug")
+        self.assertEqual(result["branch"], "delegated/my-slug")
+        self.assertEqual(result["base_remote"], "upstream")
+        self.assertEqual(result["base_ref"], "upstream/main")
+        self.assertEqual(result["default_branch"], "main")
+        self.assertEqual(result["target_repo_slug"], "idvorkin/blog")
+        self.assertTrue(
+            result["worktree_path"].endswith("/.worktrees/delegated-my-slug")
+        )
+        # Load-bearing: dry-run emits the JSON but never calls the mutating helpers.
+        self.assertEqual(write_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Replaces ~15 bash steps in `delegate-to-other-repo`'s Phase 1-3 with a single typed Python helper (`prepare_dispatch.py`) that returns structured JSON. Matches the existing diagnostics-as-code pattern from `skills/up-to-date/diagnose.py` — pure functions, unit-testable in isolation, `concurrent.futures` for the network-bound parallel fetch, Typer CLI via the `_build_app()` lazy-import pattern so tests don't need `typer` on PYTHONPATH.

## What changed

- **New**: `skills/delegate-to-other-repo/prepare_dispatch.py` — does the target-path resolution, `git fetch origin` + `upstream` (parallel), `remote set-head --auto`, default-branch chain (`symbolic-ref` → `gh repo view` → `"main"` with explicit guards between each step to avoid the pipe-precedence bug documented in `worktree-recipe.md`), base-ref selection (upstream-preferred), slug sanitization + collision resolution across BOTH `refs/heads/` and `refs/remotes/origin/`, idempotent `.worktrees/` exclude write, worktree add, session-log resolution via `pwd -P` hashed with `[/.]` → `-` (both separators matter), and `owner/repo` parse from the origin URL. Emits JSON the parent consumes to render the brief.
- **New**: `skills/delegate-to-other-repo/test_prepare_dispatch.py` — 37 stdlib `unittest` cases covering slug sanitization (ASCII, lowercasing, non-alnum, length cap, empty, non-ASCII), slug collision (clean/one-hit/gap/wraparound-to-timestamp), default-branch chain (symbolic-ref present, gh fallback, main fallback, empty/whitespace edge cases), session-log hash (both `/` AND `.` → `-`), base-ref selection (upstream preferred / origin fallback), remote URL parse (HTTPS + SSH), and a dry-run orchestrator smoke test with a stubbed git subprocess layer that verifies `--dry-run` never calls `git worktree add` or writes `.git/info/exclude`.
- **Modified**: `skills/delegate-to-other-repo/SKILL.md` — Phase 1-3 section now points at the helper with the JSON output shape and a bulleted summary of what it does; full bash recipe demoted to "Manual fallback" (matches `/up-to-date`'s pattern). Common-mistakes and red-flags sections unchanged — those are subagent-facing rules that still apply.

## Why

- **15 bash steps → 1 Python call**: less surface area, testable pure functions, single JSON blob instead of multiple shell variables the parent has to track.
- **Diagnostics-as-code pattern**: matches `skills/up-to-date/diagnose.py` (parent reads JSON, not prose). Paths and semantics rot silently in prose; code errors loudly.
- **Parallelized fetch**: `origin` and `upstream` fetches run concurrently via `concurrent.futures.ThreadPoolExecutor` — both are network-bound, sequential wait was pure waste.
- **Reliability**: the slug-collision, default-branch chain, and session-log hash logic are now unit-tested pinning the exact behavior documented in `worktree-recipe.md` — the recipe's pipe-precedence bug guard and both-separator-hash-regex are now test-enforced, not just prose.

## Test plan

- [x] `cd skills/delegate-to-other-repo && python3 -m unittest test_prepare_dispatch` — 37 tests pass
- [x] Dry-run smoke test on `/home/developer/gits/blog6` (fork workflow with both `origin` and `upstream` — exercises the upstream-preferred path): returns correct `base_remote: "upstream"`, `base_ref: "upstream/main"`, `target_repo_slug: "idvorkin-ai-tools/idvorkin.github.io"`, no worktree created, no exclude write
- [x] Error-path smoke test: `--target idvorkin/blog` (owner/repo slug) returns `errors: ["...looks like an owner/repo slug..."]` and exits 1
- [x] Bare-name resolution: `--target blog6` resolves to `/home/developer/gits/blog6` correctly

## What's deferred

- **Brief rendering**: stays in the parent. The parent has the `<TASK>` text and may want to hand-edit before dispatch; rendering is where parent judgment lives. Helper returns _inputs_, not the final brief.
- **Target-file existence validation**: the task brief may reference a file path that doesn't exist in the target repo. Detecting this requires semantic knowledge of what "the task references" that the helper doesn't have at this level. Worth a follow-up once the shape settles.
- **`gh pr create` orchestration**: stays in the subagent, which handles fork detection at dispatch time.

— Keeping my human friend @idvorkin in the loop!