### PR TITLE
feat(install-tools): symlink skill CLIs globally + auto-sync via git hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,63 @@ ln -s /path/to/chop-conventions/skills/<skill-name> <project>/.claude/skills/<sk
 
 Machine-level skills go in `~/.claude/skills/` and are available everywhere. Project-level skills go in `<project>/.claude/skills/` and are scoped to that repo.
 
+### Install Globally
+
+Several skills ship CLI helpers (e.g. `gen-tts`, `telegram_debug.py`, `watchdog.py`). Instead of typing the full path like `~/gits/chop-conventions/skills/gen-tts/generate-tts.py single …`, install them as short symlinks in `~/.local/bin`:
+
+```bash
+just bootstrap        # one-time: wires repo-versioned git hooks + runs install-tools
+# — OR —
+just install-tools    # just the symlinks, no hook wiring
+```
+
+After `bootstrap`, the repo-versioned hooks in `githooks/` run `install-tools.py --quiet` on every `git pull` / branch checkout, so new or renamed CLIs stay in sync automatically.
+
+Other targets:
+
+```bash
+just install-tools-dry-run   # preview planned changes
+just uninstall-tools         # remove symlinks that resolve into this repo
+```
+
+`install-tools.py` only touches symlinks whose targets resolve into this repo — it will never clobber unrelated files in `~/.local/bin`.
+
+Currently-exposed CLIs:
+
+| Command                 | Source                                         |
+| ----------------------- | ---------------------------------------------- |
+| `gen-tts`               | `skills/gen-tts/generate-tts.py`               |
+| `tg-doctor`             | `skills/harden-telegram/tools/telegram_debug.py` |
+| `tg-watchdog`           | `skills/harden-telegram/tools/watchdog.py`     |
+| `up-to-date-diag`       | `skills/up-to-date/diagnose.py`                |
+| `up-to-date-hook-trust` | `skills/up-to-date/hook_trust.py`              |
+
+Ensure `~/.local/bin` is on your `$PATH`.
+
+#### Optional: Claude Code SessionStart hook
+
+To re-sync symlinks at the start of every Claude Code session (belt-and-suspenders on top of the git hooks), add this to your `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/gits/chop-conventions/install-tools.py --quiet"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+This is per-user opt-in; the skill deliberately does not mutate global Claude Code settings on its own.
+
 ### Available Skills
 
 | Skill                    | Scope   | Description                                                                      |

--- a/githooks/post-checkout
+++ b/githooks/post-checkout
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# chop-conventions post-checkout hook: re-sync ~/.local/bin symlinks when a
+# checkout changes the tree. Arguments per `git hooks`:
+#   $1 prev_head  $2 new_head  $3 branch_checkout_flag (1=branch, 0=file)
+# We only bother re-syncing on branch/worktree switches (flag == 1).
+set -u
+
+flag="${3:-0}"
+if [ "$flag" != "1" ]; then
+    exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+installer="$repo_root/install-tools.py"
+
+if [ -x "$installer" ]; then
+    "$installer" --quiet || echo "install-tools.py failed (post-checkout); continuing" >&2
+fi
+exit 0

--- a/githooks/post-merge
+++ b/githooks/post-merge
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# chop-conventions post-merge hook: keep ~/.local/bin symlinks in sync with
+# whatever the repo currently exposes. Safe no-op if the installer is
+# missing or fails — we don't want to block `git pull`.
+set -u
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+installer="$repo_root/install-tools.py"
+
+if [ -x "$installer" ]; then
+    "$installer" --quiet || echo "install-tools.py failed (post-merge); continuing" >&2
+fi
+exit 0

--- a/install-tools.py
+++ b/install-tools.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.13"
+# dependencies = [
+#     "typer>=0.12",
+#     "rich>=13.0",
+# ]
+# ///
+"""
+Install chop-conventions skill CLIs as symlinks in ~/.local/bin.
+
+Registry of (source path relative to repo root, target bin name) pairs at
+REGISTRY below. Safe to re-run (idempotent). --uninstall only removes
+symlinks whose targets actually resolve into this repo.
+
+Typical usage:
+    install-tools.py                 # install / refresh symlinks
+    install-tools.py --dry-run       # show planned changes, no writes
+    install-tools.py --uninstall     # remove this repo's symlinks
+    install-tools.py --quiet         # minimal output (for git hooks)
+
+Also auto-discovers uv-shebang scripts under skills/**/tools/ that aren't in
+REGISTRY and warns — catches drift when a new tool is added but forgotten.
+"""
+
+# NOTE: intentionally NOT using `from __future__ import annotations` — Typer
+# reads runtime annotations to build the CLI, and stringified annotations
+# fail to resolve when typer is lazy-imported inside _build_app().
+
+import os
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# (source path relative to repo root, target name in ~/.local/bin)
+REGISTRY: list[tuple[str, str]] = [
+    ("skills/gen-tts/generate-tts.py", "gen-tts"),
+    ("skills/harden-telegram/tools/telegram_debug.py", "tg-doctor"),
+    ("skills/harden-telegram/tools/watchdog.py", "tg-watchdog"),
+    ("skills/up-to-date/diagnose.py", "up-to-date-diag"),
+    ("skills/up-to-date/hook_trust.py", "up-to-date-hook-trust"),
+]
+
+
+@dataclass
+class PlanEntry:
+    source: Path
+    target: Path
+    name: str
+    action: str  # "create", "update", "ok", "skip-missing", "skip-not-exec"
+    note: str = ""
+
+
+def repo_root() -> Path:
+    """Resolve the chop-conventions repo root from this script's location."""
+    script_dir = Path(__file__).resolve().parent
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(script_dir), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return Path(out.stdout.strip()).resolve()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        # Fallback: assume script sits at repo root
+        return script_dir
+
+
+def bin_dir() -> Path:
+    return Path.home() / ".local" / "bin"
+
+
+def registry_source_set(root: Path) -> set[Path]:
+    return {(root / rel).resolve() for rel, _ in REGISTRY}
+
+
+def discover_drift(root: Path) -> list[Path]:
+    """Find executable uv-shebang scripts under skills/**/tools/ not in REGISTRY."""
+    registered = registry_source_set(root)
+    drift: list[Path] = []
+    tools_glob = root.glob("skills/*/tools/*.py")
+    for candidate in tools_glob:
+        if not candidate.is_file():
+            continue
+        resolved = candidate.resolve()
+        if resolved in registered:
+            continue
+        # Must have executable bit
+        if not os.access(candidate, os.X_OK):
+            continue
+        # Must have uv-script shebang
+        try:
+            with candidate.open("r", encoding="utf-8", errors="replace") as f:
+                first_line = f.readline()
+        except OSError:
+            continue
+        if "uv run" in first_line:
+            drift.append(resolved)
+    return sorted(drift)
+
+
+def plan_install(root: Path, bin: Path) -> list[PlanEntry]:
+    plan: list[PlanEntry] = []
+    for rel, name in REGISTRY:
+        source = (root / rel).resolve()
+        target = bin / name
+
+        if not source.exists():
+            plan.append(
+                PlanEntry(
+                    source=source,
+                    target=target,
+                    name=name,
+                    action="skip-missing",
+                    note=f"source does not exist: {source}",
+                )
+            )
+            continue
+
+        exec_ok = os.access(source, os.X_OK)
+        note = "" if exec_ok else "source missing executable bit"
+
+        if target.is_symlink():
+            try:
+                existing = Path(os.readlink(target))
+                existing_resolved = (target.parent / existing).resolve()
+            except OSError:
+                existing_resolved = None
+            if existing_resolved == source:
+                plan.append(
+                    PlanEntry(
+                        source=source,
+                        target=target,
+                        name=name,
+                        action="ok",
+                        note=note,
+                    )
+                )
+                continue
+            plan.append(
+                PlanEntry(
+                    source=source,
+                    target=target,
+                    name=name,
+                    action="update",
+                    note=note,
+                )
+            )
+            continue
+
+        if target.exists():
+            plan.append(
+                PlanEntry(
+                    source=source,
+                    target=target,
+                    name=name,
+                    action="skip-not-exec",
+                    note=f"{target} exists and is not a symlink — leaving alone",
+                )
+            )
+            continue
+
+        plan.append(
+            PlanEntry(
+                source=source, target=target, name=name, action="create", note=note
+            )
+        )
+    return plan
+
+
+def apply_install(plan: list[PlanEntry], dry_run: bool) -> list[PlanEntry]:
+    """Mutate filesystem per plan; returns the same list."""
+    if not dry_run:
+        bin_dir().mkdir(parents=True, exist_ok=True)
+    for entry in plan:
+        if entry.action in {"create", "update"}:
+            if dry_run:
+                continue
+            # Use ln -sf semantics: remove-then-symlink
+            try:
+                if entry.target.is_symlink() or entry.target.exists():
+                    entry.target.unlink()
+                entry.target.symlink_to(entry.source)
+            except OSError as e:
+                entry.note = (entry.note + f"; symlink failed: {e}").lstrip("; ")
+                entry.action = "fail"
+    return plan
+
+
+def plan_uninstall(root: Path, bin: Path) -> list[PlanEntry]:
+    """Only remove symlinks whose resolved target is inside this repo."""
+    root_resolved = root.resolve()
+    plan: list[PlanEntry] = []
+    if not bin.exists():
+        return plan
+    for entry_path in sorted(bin.iterdir()):
+        if not entry_path.is_symlink():
+            continue
+        try:
+            link_target = Path(os.readlink(entry_path))
+            resolved = (entry_path.parent / link_target).resolve()
+        except OSError:
+            continue
+        try:
+            resolved.relative_to(root_resolved)
+        except ValueError:
+            continue
+        plan.append(
+            PlanEntry(
+                source=resolved,
+                target=entry_path,
+                name=entry_path.name,
+                action="remove",
+            )
+        )
+    return plan
+
+
+def apply_uninstall(plan: list[PlanEntry], dry_run: bool) -> list[PlanEntry]:
+    for entry in plan:
+        if dry_run:
+            continue
+        try:
+            entry.target.unlink()
+        except OSError as e:
+            entry.note = f"unlink failed: {e}"
+            entry.action = "fail"
+    return plan
+
+
+def which(name: str) -> str | None:
+    return shutil.which(name)
+
+
+# --- CLI entry-point (lazy import of typer/rich so tests stay stdlib-pure) ---
+
+
+def _build_app():  # pragma: no cover - thin CLI wrapper
+    import typer
+    from rich.console import Console
+    from rich.table import Table
+
+    app = typer.Typer(
+        add_completion=False,
+        help="Install chop-conventions skill CLIs as ~/.local/bin symlinks.",
+    )
+
+    @app.callback(invoke_without_command=True)
+    def main(
+        ctx: typer.Context,
+        dry_run: bool = typer.Option(
+            False, "--dry-run", help="Show planned changes without writing."
+        ),
+        uninstall: bool = typer.Option(
+            False, "--uninstall", help="Remove symlinks that resolve into this repo."
+        ),
+        quiet: bool = typer.Option(
+            False, "--quiet", help="Minimal output (for hook use)."
+        ),
+    ) -> None:
+        if ctx.invoked_subcommand is not None:
+            return
+        console = Console()
+        root = repo_root()
+        bin = bin_dir()
+
+        if uninstall:
+            plan = plan_uninstall(root, bin)
+            apply_uninstall(plan, dry_run)
+            if quiet:
+                # One line per change
+                for entry in plan:
+                    marker = "WOULD" if dry_run else "REMOVED"
+                    if entry.action == "fail":
+                        marker = "FAIL"
+                    console.print(f"{marker} {entry.target}")
+                if not plan:
+                    console.print("No repo-owned symlinks to remove.")
+                return
+
+            if not plan:
+                console.print(
+                    f"[yellow]No symlinks in {bin} point into {root}.[/yellow]"
+                )
+                return
+            table = Table(title="Uninstall plan" + (" (dry-run)" if dry_run else ""))
+            table.add_column("Action")
+            table.add_column("Target")
+            table.add_column("Resolves to")
+            table.add_column("Note")
+            for entry in plan:
+                action_word = "WOULD REMOVE" if dry_run else entry.action.upper()
+                table.add_row(
+                    action_word, str(entry.target), str(entry.source), entry.note
+                )
+            console.print(table)
+            return
+
+        # Install mode
+        plan = plan_install(root, bin)
+        apply_install(plan, dry_run)
+
+        # Drift detection
+        drift = discover_drift(root)
+
+        if quiet:
+            changed = [e for e in plan if e.action in {"create", "update"}]
+            for entry in changed:
+                marker = "WOULD" if dry_run else "LINKED"
+                console.print(f"{marker} {entry.target} -> {entry.source}")
+            warns = [e for e in plan if e.action in {"skip-missing", "fail"}]
+            for entry in warns:
+                console.print(
+                    f"[yellow]WARN {entry.name}: {entry.note}[/yellow]", soft_wrap=True
+                )
+            if drift:
+                console.print(
+                    f"[yellow]WARN {len(drift)} unlinked tool(s) found under skills/**/tools/ — add to REGISTRY or rename.[/yellow]"
+                )
+            return
+
+        table = Table(
+            title="chop-conventions install-tools" + (" (dry-run)" if dry_run else "")
+        )
+        table.add_column("Name")
+        table.add_column("Action")
+        table.add_column("Target")
+        table.add_column("Source")
+        table.add_column("Note")
+        for entry in plan:
+            action_word = entry.action
+            if dry_run and action_word in {"create", "update"}:
+                action_word = f"would-{action_word}"
+            table.add_row(
+                entry.name,
+                action_word,
+                str(entry.target),
+                str(entry.source.relative_to(root))
+                if str(entry.source).startswith(str(root))
+                else str(entry.source),
+                entry.note,
+            )
+        console.print(table)
+
+        # which-check for successfully-installed names
+        if not dry_run:
+            ok_names = [
+                e.name
+                for e in plan
+                if e.action in {"create", "update", "ok"} and e.source.exists()
+            ]
+            if ok_names:
+                wtable = Table(title="which check")
+                wtable.add_column("Name")
+                wtable.add_column("Resolved")
+                for name in ok_names:
+                    resolved = which(name) or "[red]NOT ON PATH[/red]"
+                    wtable.add_row(name, str(resolved))
+                console.print(wtable)
+                if bin.as_posix() not in os.environ.get("PATH", ""):
+                    console.print(
+                        f"[yellow]NOTE:[/yellow] {bin} is not on $PATH in this shell — add it to your rc file."
+                    )
+
+        if drift:
+            console.print(
+                f"\n[yellow]Drift warning:[/yellow] {len(drift)} executable uv-shebang script(s) under skills/**/tools/ not in REGISTRY:"
+            )
+            for path in drift:
+                try:
+                    rel = path.relative_to(root)
+                except ValueError:
+                    rel = path
+                console.print(f"  - {rel}")
+            console.print("[yellow]Add to REGISTRY in install-tools.py.[/yellow]")
+
+    return app
+
+
+if __name__ == "__main__":
+    _build_app()()

--- a/justfile
+++ b/justfile
@@ -5,4 +5,21 @@ fast-test:
     @python3 -c "from pathlib import Path; import subprocess, sys; test_dirs = sorted({str(path.parent) for path in Path('skills').rglob('test_*.py')}); sys.exit(0 if all(subprocess.run(['python3', '-m', 'unittest', 'discover', '-s', test_dir, '-p', 'test_*.py']).returncode == 0 for test_dir in test_dirs) else 1)"
 
 test:
-    @echo "All tests - Add comprehensive tests" 
+    @echo "All tests - Add comprehensive tests"
+
+# Install chop-conventions skill CLIs as symlinks in ~/.local/bin
+install-tools:
+    ./install-tools.py
+
+# Preview install-tools changes without writing anything
+install-tools-dry-run:
+    ./install-tools.py --dry-run
+
+# Remove symlinks in ~/.local/bin that resolve into this repo
+uninstall-tools:
+    ./install-tools.py --uninstall
+
+# One-time: point git at repo-versioned hooks + run initial install-tools
+bootstrap:
+    git config core.hooksPath githooks
+    ./install-tools.py


### PR DESCRIPTION
## Summary

- New `install-tools.py` creates `~/.local/bin` symlinks for the skill CLIs currently in the repo:
  - `gen-tts` → `skills/gen-tts/generate-tts.py`
  - `tg-doctor` → `skills/harden-telegram/tools/telegram_debug.py`
  - `tg-watchdog` → `skills/harden-telegram/tools/watchdog.py`
  - `up-to-date-diag` → `skills/up-to-date/diagnose.py`
  - `up-to-date-hook-trust` → `skills/up-to-date/hook_trust.py`
- Auto-sync via repo-versioned git hooks in `githooks/`: `just bootstrap` sets `core.hooksPath=githooks` once, and every subsequent `git pull` / branch checkout re-runs `install-tools.py --quiet` so new or renamed CLIs stay linked without user intervention.
- Justfile targets: `install-tools`, `install-tools-dry-run`, `uninstall-tools`, `bootstrap`.
- README `Install Globally` section documents the workflow + an opt-in Claude Code `SessionStart` hook snippet for per-session belt-and-suspenders resync (skill does NOT mutate global Claude Code settings automatically).

## Design notes

- **Idempotent**: rerunning creates no duplicate symlinks; `ln -sf` semantics via `unlink + symlink_to`.
- **Uninstall safety**: `--uninstall` only removes symlinks whose `os.readlink` target resolves under the repo root — never clobbers unrelated files in `~/.local/bin`.
- **Drift detection**: auto-scans `skills/*/tools/*.py` for executable uv-shebang scripts that aren't in `REGISTRY` and warns, so forgotten CLIs show up as actionable noise.
- **Missing/non-executable sources**: reported as `skip-missing` / noted in output; never fails the whole install.
- **Repo-rooted**: uses `git rev-parse --show-toplevel` from the script's dir so it works from any worktree.
- **Lazy Typer import**: `_build_app()` lazy-imports `typer`/`rich` per the repo's existing pattern, but intentionally skips `from __future__ import annotations` because Typer reads runtime annotations to build the CLI.

## Test plan

- [x] `./install-tools.py --dry-run` — enumerates planned symlinks, no filesystem writes.
- [x] `./install-tools.py` — creates all 5 symlinks, `which` resolves each, `gen-tts --help` / `tg-doctor --help` execute cleanly end-to-end.
- [x] Second run is a clean no-op (all entries show `ok`).
- [x] `bash githooks/post-merge` and `bash githooks/post-checkout X Y 1` both exit 0 and re-sync.
- [x] `./install-tools.py --uninstall` removes only the 5 repo-owned symlinks; unrelated `~/.local/bin` entries untouched.
- [x] Running with a stale/invalid repo root reports `skip-missing` per entry rather than crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)