### PR TITLE
docs(global): snapshot files before side-edit for diff-on-return

### DIFF
--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -89,6 +89,8 @@ Use `rmux_helper side-run <CMD>` to run a shell command in the side pane. If nvi
 
 Both commands print pane status (pane_id, nvim running, current file) to stdout. Call with no args for status only.
 
+- **Before `side-edit`, snapshot the file** to `~/tmp/agent/side-edit/<basename>.pre.<ts>`. When the user returns saying "merge my edits," `diff` against that snapshot — the live file on disk is the only other source, so without the snapshot you can't see deltas. Idempotent; safe to snapshot on every invocation.
+
 ```bash
 rmux_helper side-edit ~/blog/_d/ai-journal.md:42
 rmux_helper side-run "make test"


### PR DESCRIPTION
## Summary

- Adds a bullet to `claude-md/global.md` under the Side-Edit section codifying the pre-edit snapshot convention.
- Before `rmux_helper side-edit`, write the file to `~/tmp/agent/side-edit/<basename>.pre.<ts>`.
- Gives the agent a baseline to `diff` against when the user returns saying "merge my edits" — otherwise the live file on disk is the only source and deltas are invisible.

## Why

Igor side-edited a writing-editor spec file in a tmux side pane, then asked me to merge his manual edits later in the same session. No pre-edit baseline existed, so there was no way to mechanically see what he'd changed. Convention applies globally — every future `side-edit` invocation benefits from a snapshot.

## Test plan

- [x] Edit confirmed in `claude-md/global.md` Side-Edit section, placed before the closing code block
- [x] Voice matches neighboring bullets (bold lead, em-dash phrasing)
- [ ] Propagates on next `/up-to-date` via the symlinked `@~/.claude/claude-md/global.md` import