### PR TITLE
docs(claude-md): session learnings — temp hierarchy, PR merge check, subprocess.run default-arg trap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ Scripts that signal processes by pattern (cpulimit, pkill, kill by comm match) M
 
 **Tests for these signalling functions MUST mock their subprocess/OS calls.** An unmocked "smoke test" that invokes the real `pkill`/`os.kill`/`create_subprocess_exec` against the dev box's real process table will match legitimate running processes and SIGTERM them — this nuked a live Telegram MCP bridge mid-session on 2026-04-12. Patch `asyncio.create_subprocess_exec` / `subprocess.run` / `os.kill` via `monkeypatch` before invoking the target. The test verifies return-type and error-handling, never the real kill path.
 
+**`run=subprocess.run` default-arg pattern silently defeats test mocking.** Defaults bind at function-def time, so `patch("mod.subprocess.run", ...)` doesn't affect calls that captured the default. Symptom: tests appear to pass the mock-injection path but real subprocess calls leak through. Fix: declare `run=None` and resolve `if run is None: run = subprocess.run` in the body — the module-global lookup at call time is what makes patching work. Reference: `skills/bulk/chop_bulk/*.py`.
+
 ## Scripting Language Defaults
 
 **Default to Python for any non-trivial script, not shell.** Shell is for one-liners and the occasional `just` target. Anything with branching, data structures, or more than ~20 lines should be Python.

--- a/claude-md/global.md
+++ b/claude-md/global.md
@@ -61,6 +61,7 @@ Just do it - including obvious follow-up actions. Only pause when:
 - **`python3 <uv-script>` bypasses uv dep resolution.** Scripts with `#!/usr/bin/env -S uv run --script` + inline deps (`# /// script`) must be invoked directly (path + executable bit) so the shebang fires. Going through `python3` runs the raw source without uv resolving inline deps → `ModuleNotFoundError` for `typer`, `click`, etc. Applies to any Typer/Click CLI packaged as a uv-script (e.g. `telegram_debug.py`).
 - **Project-specific hooks belong in project `.claude/settings.json`, not global `~/.claude/settings.json`.** Global hooks fire for every session in every repo. If the hook's action targets one project's workflow (conversation logging, project-specific lint, `bd prime`, etc.), scope it to that repo's `.claude/settings.json`. Global is for truly cross-project patterns.
 - **`git commit` can silently no-op when a pre-commit hook reformats staged files.** The commit aborts (hook exit != 0) but a chained `&& git push` still fires — pushing an empty branch or the unchanged tip. Detection: after `git commit`, scan output for the `[branch sha] commit-message` confirmation line. If missing, the commit didn't land — re-stage the reformatted file and retry. Don't trust the chained-push output alone.
+- **Check PR state before pushing follow-up commits.** Run `gh pr view <N> --repo <r> --json state` — if `state == MERGED`, open a new PR for the follow-up work. Pushing to a merged PR's branch succeeds but leaves commits orphaned: the merge already happened at the PR's former tip, and new commits never reach main unless cherry-picked or re-PR'd. Non-obvious because `git push` succeeds regardless.
 - **Non-interactive `git rebase -i` via scripted editors.** For programmatic squashes in sessions without a human editor, write todo to `/tmp/rebase-todo.txt` and message to `/tmp/rebase-msg.txt`, then `GIT_SEQUENCE_EDITOR="cp /tmp/rebase-todo.txt" GIT_EDITOR="cp /tmp/rebase-msg.txt" git rebase -i <base>`. Supports `pick`/`fixup`/`reword`/`squash` in one pass. Always `git tag backup HEAD` first — reflog expires.
 - **Session token / context usage** — when asked "how many tokens am I using" or "how much context is left," read `~/.claude/statusline_last_input.json` with `jq`. The statusline script dumps the harness JSON there every turn; grab `.context_window.used_percentage`, `.context_window.context_window_size`, `.cost.total_cost_usd`. Don't guess from transcript length.
 - **Signing GitHub issues and comments on external repos.** When filing issues, PRs, or comments on repos _outside_ `idvorkin/*` and `idvorkin-ai-tools/*` (e.g., upstream projects, third-party libraries), end the body with this sign-off so Igor gets tagged and notified without relying on watch settings he doesn't have:
@@ -94,6 +95,17 @@ rmux_helper side-edit ~/blog/_d/ai-journal.md:42
 rmux_helper side-run "make test"
 rmux_helper side-edit   # status only
 ```
+
+## Agent Temp Files: `~/tmp/agent/<scope>/`
+
+**Agent temp files go under `~/tmp/agent/<scope>/`.** Scopes:
+
+- `side-edit/` for pre-edit snapshots
+- `notes/YYYY-MM-DD-<slug>.md` for reasoning docs (supersedes `/tmp/agent-notes/`)
+- `image/` for generated images awaiting user pick
+- `skill/<name>/` for skill scratch
+
+Never scatter under bare `/tmp/` or `~/tmp/` without a scope prefix. Root `~/tmp/` stays user-owned. Scoped hierarchy makes cleanup and reasoning tractable; flat `/tmp/` mixes agent state with system files and loses traceability on cleanup.
 
 ## Editing Skills: Symlink Trap
 


### PR DESCRIPTION
## Summary

Three rules surfaced during the 2026-04-16 igor2 session. One PR, three edits across `CLAUDE.md` and `claude-md/global.md`.

### 1. `~/tmp/agent/<scope>/` hierarchy (`claude-md/global.md`)

New section slotted between Side-Edit and Editing-Skills-Symlink-Trap. Scopes: `side-edit/`, `notes/YYYY-MM-DD-<slug>.md`, `image/`, `skill/<name>/`. Supersedes the old bare `/tmp/agent-notes/` convention. Igor explicitly asked for this — flat `/tmp/` was mixing agent state with system files and losing traceability on cleanup.

### 2. Check PR merge state before pushing follow-up commits (`claude-md/global.md`)

Sibling bullet to the existing "git commit silently no-ops on pre-commit hook reformat" rule. Run `gh pr view <N> --repo <r> --json state` — if MERGED, open a new PR. Source incident: this session merged blog PR #539, pushed two more commits to its branch, and those commits never reached main. Had to open follow-up PR #540. `git push` succeeds regardless, so the failure is silent.

### 3. `run=subprocess.run` default-arg mock trap (root `CLAUDE.md`)

Sibling paragraph under Process-Signaling Safety, right after the existing subprocess-mocking rule. Defaults bind at function-def time, so `patch("mod.subprocess.run", ...)` doesn't affect calls that captured the default — tests "pass" but real subprocess calls leak through. Fix: `run=None` + `if run is None: run = subprocess.run` in the body. Reference: `skills/bulk/chop_bulk/*.py` (where the `bulk` skill subagent hit this during bring-up on PR #172, ~20 min debug).

## Test plan

- [ ] Pre-commit hooks pass (prettier + biome + ruff + dasel + just fast-test)
- [ ] `CLAUDE.md` Process-Signaling Safety section reads coherently with the new paragraph
- [ ] `claude-md/global.md` renders cleanly — new section + new bullet both fit surrounding voice

Reasoning: C-5004:/tmp/agent-notes/2026-04-17-chop-conv-session-learnings.md