### PR TITLE
fix(bulk): drop from __future__ import annotations to fix Typer signature-eval crash

### DIFF
--- a/skills/bulk/chop_bulk/bd_show.py
+++ b/skills/bulk/chop_bulk/bd_show.py
@@ -15,8 +15,6 @@ array when the bead is found. Normalize with
 list (see `normalize_bead`).
 """
 
-from __future__ import annotations
-
 import json
 import subprocess
 from typing import Any

--- a/skills/bulk/chop_bulk/common.py
+++ b/skills/bulk/chop_bulk/common.py
@@ -13,8 +13,6 @@ Kept stdlib-only so tests and pre-commit hooks (no uv) can import this
 module directly. Typer lives only in each tool's `_build_app()`.
 """
 
-from __future__ import annotations
-
 import json
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/skills/bulk/chop_bulk/file_read.py
+++ b/skills/bulk/chop_bulk/file_read.py
@@ -14,8 +14,6 @@ Purpose: quick multi-file text inventory without individual `Read`
 calls. Skip-rather-than-load on big files keeps the output JSON sane.
 """
 
-from __future__ import annotations
-
 import json
 import os
 from pathlib import Path

--- a/skills/bulk/chop_bulk/gh_pr_details.py
+++ b/skills/bulk/chop_bulk/gh_pr_details.py
@@ -18,8 +18,6 @@ Typer lives inside `_build_app()` so tests import the pure-function
 layer without `ModuleNotFoundError` on systems lacking typer.
 """
 
-from __future__ import annotations
-
 import json
 import re
 import subprocess

--- a/skills/bulk/chop_bulk/gh_prs_open.py
+++ b/skills/bulk/chop_bulk/gh_prs_open.py
@@ -9,8 +9,6 @@ Under the hood:
     gh pr list --repo <r> --state open --json number,title,headRefName
 """
 
-from __future__ import annotations
-
 import json
 import subprocess
 from typing import Any

--- a/skills/bulk/chop_bulk/up_to_date.py
+++ b/skills/bulk/chop_bulk/up_to_date.py
@@ -17,8 +17,6 @@ installed:
 The discovery happens once at module load — later calls don't re-probe.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import shutil


### PR DESCRIPTION
## Summary

All five `chop-bulk` CLIs (`bulk-gh-pr-details`, `bulk-gh-prs-open`, `bulk-bd-show`, `bulk-up-to-date`, `bulk-file-read`) crash at runtime with:

```
NameError: name 'typer' is not defined
```

## Root cause

Each module under `skills/bulk/chop_bulk/` paired `from __future__ import annotations` with a lazy `import typer` inside `_build_app()`. Under PEP 563, parameter annotations like `ctx: typer.Context` become string literals that Typer evaluates via `inspect.signature()` against the module's `__globals__` — where `typer` is not bound. It's only bound inside `_build_app()`'s local scope.

## Fix

Remove `from __future__ import annotations` from all six modules in `skills/bulk/chop_bulk/`:

- `bd_show.py`
- `common.py`
- `file_read.py`
- `gh_pr_details.py`
- `gh_prs_open.py`
- `up_to_date.py`

None of them use forward references or cyclic type names — all annotations are runtime-evaluable on Python 3.13 (PEP 604 unions, PEP 585 generics).

This also aligns with `CLAUDE.md` line 50, which already forbids `from __future__ import annotations` in this repo:

> Default to `requires-python = ">=3.13"` — no need for `from __future__ import annotations` or compatibility shims.

The bulk-tools PR (#172 / merged from PR #169-adjacent work) slipped past that rule.

## Scope note

Test files under `skills/bulk/tests/` still carry `from __future__ import annotations`. They do NOT exhibit this bug (no lazy-Typer-import pattern — tests call pure functions directly), so they were left unchanged to keep this PR scoped to the observed crash. A follow-up cleanup pass could remove them, but that's a pure style change, not a bug fix.

## Test plan

- [x] `uv tool install --force --reinstall ./skills/bulk/` succeeds
- [x] `bulk-gh-pr-details --help` prints help (was crashing before)
- [x] `bulk-gh-prs-open --help` prints help
- [x] `bulk-bd-show --help` prints help
- [x] `bulk-up-to-date --help` prints help
- [x] `bulk-file-read --help` prints help
- [x] `bulk-gh-pr-details --pretty idvorkin/chop-conventions#169` returns real PR JSON (state=OPEN, mergeable=CONFLICTING)
- [x] `python3 -m unittest discover -s tests -p 'test_*.py'` — 41 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python annotation handling across multiple modules to improve code consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->