### PR TITLE
fix(gen-image): catch bleed-through holes the old eval missed (#171)

### DIFF
--- a/skills/gen-image/SKILL.md
+++ b/skills/gen-image/SKILL.md
@@ -35,7 +35,8 @@ When `--transparent` is active, `generate.py` runs two complementary evals on th
 
 **(2) Alpha-mask quality signal** (`eval_alpha`, opt-out via `--no-eval`):
 
-- `interior_hole_px` — transparent pixels enclosed by opaque (signals interior damage the alpha-mean misses: Swiss-cheese holes that read as shading on a colored preview background).
+- `interior_hole_px` — pixels in transparent regions that only become enclosed once the opaque mask is morphologically closed by 1 pixel. Isolates flood-fill bleed-through damage: thin 1–2-pixel channels the chroma-strip drills through the character (neck, between fingers, limb outlines) that topologically connect a real interior hole to the outside background so a naive "enclosed transparent" check reports zero. Legitimate design gaps (armpit openings, space between legs) are wider than 2 px and stay unaffected by the closing, so they don't false-alarm.
+- `interior_hole_largest_px` — pixels in the single biggest channel-revealed hole. More stable across images; good thresholding target because one big visible hole is what a human notices.
 - `residual_magenta_px` — opaque pixels still near chroma color (signals trapped magenta pockets corner-seeded flood couldn't reach).
 - `edge_fringe_px` — partial-alpha pixels (signals halo).
 
@@ -43,11 +44,11 @@ Output format:
 
 ```
 eval [healthy] out.webp: alpha=51.3% size=74.0KB
-[eval] /tmp/out.webp: holes=84, residual=132, fringe=0   [OK]
-[eval] /tmp/out.webp: holes=9687, residual=0, fringe=0   [WARN: interior damage likely — check alpha mask]
+[eval] /tmp/out.webp: holes=0 (largest=0), residual=0, fringe=0   [OK]
+[eval] /tmp/out.webp: holes=4508 (largest=4356), residual=0, fringe=0   [WARN: interior damage likely — check alpha mask]
 ```
 
-Thresholds for the mask-quality signal are conservative by default (holes > 200, residual > 500, fringe > 2000). Pass `--no-eval` to skip it. Pass `--eval-strict` to exit nonzero when a mask-quality threshold trips.
+Thresholds for the mask-quality signal are conservative by default (holes > 500, residual > 500, fringe > 2000). Pass `--no-eval` to skip it. Pass `--eval-strict` to exit nonzero when a mask-quality threshold trips.
 
 **Why:** visual inspection on a light or dark background hides interior damage (holes read as shadow/shading). The alpha mask is the ground truth. Baking both evals into the skill makes them the default, so a silently-broken output can't ship. See [/hill-climbing](https://idvork.in/hill-climbing) for the "eval becomes regression guard" pattern.
 

--- a/skills/image-explore/generate.py
+++ b/skills/image-explore/generate.py
@@ -83,10 +83,26 @@ class GenerationResult:
 # the mean catches "strip ate the subject" / "nothing stripped"; these
 # catch "Swiss-cheese holes", "trapped magenta pockets", and "halo".
 EVAL_ALPHA_THRESHOLDS = {
-    "interior_hole_px": 200,
+    "interior_hole_px": 500,
     "residual_magenta_px": 500,
     "edge_fringe_px": 2000,
 }
+
+# Before counting interior holes, morphologically close the opaque mask
+# (dilate then erode by this many pixels). Flood-fill chroma-key can
+# drill 1–2-pixel-wide channels through narrow parts of the character
+# (neck, between fingers, limb outlines), which topologically connect
+# real interior holes to the outside background — naive connected-
+# components then reports holes=0 even when the mask is visibly damaged.
+# Radius 1 seals channels up to 3px wide, which matches every bleed
+# path observed on the Pod Detective calibration set without collapsing
+# legitimate design gaps (between legs, armpit openings) that are 5+ px
+# wide on real character art. See issue #171.
+INTERIOR_HOLE_CLOSE_RADIUS = 1
+# After sealing channels, drop interior components smaller than this —
+# antialiasing specks between fingers / between objects aren't real
+# damage, and they dominate the component count on otherwise-clean images.
+INTERIOR_HOLE_MIN_COMPONENT_PX = 100
 
 
 def resolve_chop_root():
@@ -355,7 +371,9 @@ def evaluate_strip(image_path):
 
     try:
         path_obj = Path(image_path)
-        file_size_kb = round(path_obj.stat().st_size / 1024, 1) if path_obj.exists() else None
+        file_size_kb = (
+            round(path_obj.stat().st_size / 1024, 1) if path_obj.exists() else None
+        )
     except OSError:
         file_size_kb = None
 
@@ -428,15 +446,43 @@ def _format_eval_card(image_path, metrics, warning):
     return line
 
 
-def eval_alpha(image_path, chroma_rgb=(255, 0, 255), tolerance=20):
+def _label_interior(transparent_mask, label):
+    """Return a boolean mask of transparent pixels NOT reachable from
+    the image border. `label` is scipy.ndimage.label injected by the
+    caller so this helper doesn't need its own import."""
+    import numpy as np  # noqa: PLC0415
+
+    labeled, _ = label(transparent_mask)
+    border_labels = set()
+    border_labels.update(labeled[0, :].tolist())
+    border_labels.update(labeled[-1, :].tolist())
+    border_labels.update(labeled[:, 0].tolist())
+    border_labels.update(labeled[:, -1].tolist())
+    border_labels.discard(0)
+    border_mask = np.isin(labeled, list(border_labels))
+    return transparent_mask & ~border_mask
+
+
+def eval_alpha(
+    image_path,
+    chroma_rgb=(255, 0, 255),
+    tolerance=20,
+    close_radius=INTERIOR_HOLE_CLOSE_RADIUS,
+    min_component_px=INTERIOR_HOLE_MIN_COMPONENT_PX,
+):
     """Compute alpha-mask quality metrics for a post-chroma RGBA image.
 
     Detects failure modes orthogonal to evaluate_strip's alpha-mean signal:
-      * interior_hole_px — transparent pixels NOT connected to the image
-        border. These are "eaten" interiors: highlights/glass the flood-fill
-        or fuzzy chroma chewed through and left as holes. On a light preview
-        background these holes read as shading and hide silently — the alpha
-        mask is the only ground truth.
+      * interior_hole_px — transparent pixels NOT reachable from the image
+        border after the opaque mask is morphologically closed. Closing
+        seals the 1–2-pixel bleed channels the flood-fill drills through
+        narrow character parts; without it, a real interior hole connected
+        to the outside by a thin channel gets counted as border-touching
+        and slips through (the issue-#171 failure mode). Tiny components
+        below `min_component_px` are filtered as antialiasing noise.
+      * interior_hole_largest_px — pixels in the single largest interior
+        hole. More stable across images than the total; good for
+        thresholding because one big hole is what a human sees.
       * residual_magenta_px — opaque pixels still near the chroma color.
         Trapped magenta pockets between characters or inside enclosed
         negative space the flood-fill couldn't reach from the corners.
@@ -448,7 +494,7 @@ def eval_alpha(image_path, chroma_rgb=(255, 0, 255), tolerance=20):
     """
     import numpy as np  # noqa: PLC0415 — lazy import, see module header
     from PIL import Image  # noqa: PLC0415
-    from scipy.ndimage import label  # noqa: PLC0415
+    from scipy.ndimage import binary_closing, label  # noqa: PLC0415
 
     arr = np.asarray(Image.open(image_path).convert("RGBA"))
     rgb, a = arr[:, :, :3], arr[:, :, 3]
@@ -461,18 +507,44 @@ def eval_alpha(image_path, chroma_rgb=(255, 0, 255), tolerance=20):
     dist = np.abs(rgb.astype(np.int16) - chroma).sum(axis=2)
     residual = int((opaque & (dist <= tolerance)).sum())
 
-    # Interior holes: label connected components of transparent pixels,
-    # then subtract every component that touches the image border.
-    # What remains is transparent regions fully enclosed by opaque — the
-    # "Swiss-cheese" damage we care about.
-    labeled, _ = label(transparent)
-    border = set()
-    border.update(labeled[0, :].tolist())
-    border.update(labeled[-1, :].tolist())
-    border.update(labeled[:, 0].tolist())
-    border.update(labeled[:, -1].tolist())
-    border.discard(0)  # 0 is the non-transparent background in the labeling
-    interior = int(transparent.sum() - np.isin(labeled, list(border)).sum())
+    # Interior holes: we want to flag flood-fill bleed-through damage but
+    # NOT legitimate design-intentional gaps (armpit openings, space
+    # between legs, gap between fingers). Both show up as "transparent
+    # surrounded by opaque" but they behave differently under morphological
+    # closing of the opaque mask:
+    #   - Design gap: several pixels wide at its opening; closing by 1 px
+    #     barely narrows it, so its topological relationship to the border
+    #     is unchanged.
+    #   - Bleed channel: 1–2 px wide where it pierces the character;
+    #     closing by 1 px seals the channel shut, so what was border-
+    #     connected becomes enclosed and "appears" in the interior set.
+    # The set difference (closed-interior minus open-interior) isolates
+    # exactly the pixels that only became enclosed because of the
+    # channel-sealing. That's the bleed-through signal we actually want.
+    interior_open = _label_interior(~opaque, label)
+    if close_radius > 0:
+        closed_opaque = binary_closing(opaque, iterations=close_radius)
+        interior_closed = _label_interior(~closed_opaque, label)
+        channel_revealed = interior_closed & ~interior_open
+    else:
+        channel_revealed = interior_open
+
+    if min_component_px > 1 and channel_revealed.any():
+        relabeled, _ = label(channel_revealed)
+        sizes = np.bincount(relabeled.ravel())
+        small_labels = np.where(sizes < min_component_px)[0]
+        small_labels = small_labels[small_labels != 0]
+        if small_labels.size:
+            channel_revealed = channel_revealed & ~np.isin(relabeled, small_labels)
+
+    interior = int(channel_revealed.sum())
+    if channel_revealed.any():
+        relabeled, _ = label(channel_revealed)
+        sizes = np.bincount(relabeled.ravel())
+        sizes[0] = 0
+        interior_largest = int(sizes.max())
+    else:
+        interior_largest = 0
 
     # Edge fringe: partial alpha. Some is expected (antialiasing); a lot
     # suggests the chroma removal left a halo.
@@ -480,6 +552,7 @@ def eval_alpha(image_path, chroma_rgb=(255, 0, 255), tolerance=20):
 
     return {
         "interior_hole_px": interior,
+        "interior_hole_largest_px": interior_largest,
         "residual_magenta_px": residual,
         "edge_fringe_px": edge,
     }
@@ -488,9 +561,10 @@ def eval_alpha(image_path, chroma_rgb=(255, 0, 255), tolerance=20):
 def format_eval_line(image_path, metrics, warnings):
     """Render the eval_alpha line printed to stderr."""
     status = f"[WARN: {'; '.join(warnings)}]" if warnings else "[OK]"
+    largest = metrics.get("interior_hole_largest_px", 0)
     return (
         f"[eval] {image_path}: "
-        f"holes={metrics['interior_hole_px']}, "
+        f"holes={metrics['interior_hole_px']} (largest={largest}), "
         f"residual={metrics['residual_magenta_px']}, "
         f"fringe={metrics['edge_fringe_px']}   {status}"
     )

--- a/skills/image-explore/test_generate.py
+++ b/skills/image-explore/test_generate.py
@@ -22,10 +22,12 @@ from generate import (  # noqa: E402
     BORDER_SAMPLE_STEP,
     HEALTHY_ALPHA_MAX_PCT,
     HEALTHY_ALPHA_MIN_PCT,
+    INTERIOR_HOLE_CLOSE_RADIUS,
     NEAR_MAGENTA_L1_TOLERANCE,
     _format_eval_card,
     _parse_srgb,
     _scan_border_for_magenta_seeds,
+    eval_alpha,
     evaluate_strip,
     remove_background,
 )
@@ -328,6 +330,156 @@ class TestEvaluateStrip(unittest.TestCase):
         self.assertIn("subject_eaten", card)
         self.assertIn("\n  WARN:", card)
         self.assertIn("hill-climbing", card)
+
+
+class TestEvalAlphaInteriorHoles(unittest.TestCase):
+    """eval_alpha must catch flood-fill bleed-through channels.
+
+    The issue-#171 failure: a real interior hole gets connected to the
+    image border by a 1–2-pixel-wide transparent channel the flood-fill
+    drilled through a narrow part of the character (neck, between legs).
+    A naive "transparent pixels not touching border" check then reports
+    zero holes. Morphological closing of the opaque mask seals the thin
+    channels, and the hole re-emerges as an enclosed component.
+    """
+
+    def _build_rgba(self, opaque_mask):
+        """Turn a bool opaque_mask into an RGBA array with flat alpha."""
+        import numpy as np  # noqa: PLC0415
+
+        h, w = opaque_mask.shape
+        rgba = np.zeros((h, w, 4), dtype=np.uint8)
+        rgba[..., :3][opaque_mask] = (128, 128, 128)  # neutral opaque fill
+        rgba[..., 3] = np.where(opaque_mask, 255, 0)
+        return rgba
+
+    def _save_and_eval(self, rgba, **eval_kwargs):
+        from PIL import Image  # noqa: PLC0415
+
+        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as f:
+            path = f.name
+        Image.fromarray(rgba, mode="RGBA").save(path)
+        try:
+            return eval_alpha(path, **eval_kwargs)
+        finally:
+            Path(path).unlink(missing_ok=True)
+
+    def _try_import_numpy(self):
+        try:
+            import numpy as np  # noqa: F401, PLC0415
+            from PIL import Image  # noqa: F401, PLC0415
+            from scipy.ndimage import label  # noqa: F401, PLC0415
+        except ImportError:
+            self.skipTest("eval_alpha deps (numpy/pillow/scipy) not installed")
+
+    def test_clean_solid_silhouette_reports_zero_holes(self):
+        """A solid opaque disc on a transparent field — no damage, zero holes."""
+        self._try_import_numpy()
+        import numpy as np  # noqa: PLC0415
+
+        h = w = 200
+        yy, xx = np.ogrid[:h, :w]
+        opaque = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 60**2
+        metrics = self._save_and_eval(self._build_rgba(opaque))
+        self.assertEqual(metrics["interior_hole_px"], 0)
+        self.assertEqual(metrics["interior_hole_largest_px"], 0)
+
+    def test_preexisting_enclosed_hole_without_channel_is_not_flagged(self):
+        """Enclosed transparent disc with no bleed channel — interior at
+        both r=0 and r=1. Set-difference zeroes it out: could be design-
+        intentional (donut hole, glasses rim), so give benefit of doubt.
+        The metric targets flood-fill bleed-through specifically.
+        """
+        self._try_import_numpy()
+        import numpy as np  # noqa: PLC0415
+
+        h = w = 200
+        yy, xx = np.ogrid[:h, :w]
+        body = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 80**2
+        hole = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 20**2
+        opaque = body & ~hole
+        metrics = self._save_and_eval(self._build_rgba(opaque))
+        self.assertEqual(metrics["interior_hole_px"], 0)
+        self.assertEqual(metrics["interior_hole_largest_px"], 0)
+
+    def test_design_gap_armpit_is_not_flagged(self):
+        """Solid body with a 5-px-wide inlet from the border (like an
+        armpit opening between arm and body). Interior_open treats the
+        inlet as border-connected; closing at radius 1 narrows it but
+        doesn't seal it (wider than 2*radius+1). Set-difference = 0.
+        """
+        self._try_import_numpy()
+        import numpy as np  # noqa: PLC0415
+
+        h = w = 200
+        yy, xx = np.ogrid[:h, :w]
+        opaque = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 80**2
+        # Carve a 5-px-wide inlet from the top edge down into the body.
+        inlet = (np.abs(xx - w // 2) <= 2) & (yy <= h // 2)
+        opaque = opaque & ~inlet
+        metrics = self._save_and_eval(self._build_rgba(opaque))
+        self.assertEqual(metrics["interior_hole_px"], 0)
+
+    def test_bleed_channel_hole_still_flagged_after_closing(self):
+        """The issue-#171 failure mode: hole connected to outside via a
+        thin 1-pixel channel. Without closing, reports 0. With the default
+        closing radius, the channel is sealed and the hole re-emerges.
+        """
+        self._try_import_numpy()
+        import numpy as np  # noqa: PLC0415
+
+        h = w = 200
+        yy, xx = np.ogrid[:h, :w]
+        body = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 80**2
+        hole = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 20**2
+        # 1-pixel-wide channel from the hole straight out through the body
+        # to the image border. Emulates a flood-fill bleed path.
+        channel = (np.abs(xx - w // 2) <= 0) & (yy >= h // 2)
+        opaque = body & ~hole & ~channel
+
+        # Confirm the naïve (radius=0) detector misses it.
+        metrics_naive = self._save_and_eval(self._build_rgba(opaque), close_radius=0)
+        self.assertEqual(
+            metrics_naive["interior_hole_px"],
+            0,
+            "test fixture is supposed to hide the hole behind a thin channel",
+        )
+
+        # Default radius must catch it.
+        metrics = self._save_and_eval(self._build_rgba(opaque))
+        hole_area = int(hole.sum())
+        self.assertGreater(
+            metrics["interior_hole_px"],
+            hole_area * 0.5,
+            f"closing (r={INTERIOR_HOLE_CLOSE_RADIUS}) should re-expose the hidden hole",
+        )
+
+    def test_tiny_speckles_below_min_component_are_filtered(self):
+        """Single-pixel transparent dots inside opaque shouldn't register."""
+        self._try_import_numpy()
+        import numpy as np  # noqa: PLC0415
+
+        h = w = 200
+        yy, xx = np.ogrid[:h, :w]
+        body = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 80**2
+        opaque = body.copy()
+        # Scatter 10 isolated 1-pixel interior transparent dots.
+        for dy, dx in [
+            (-40, 0),
+            (-30, 10),
+            (-20, -20),
+            (-10, 15),
+            (0, -30),
+            (10, 25),
+            (20, -5),
+            (30, 20),
+            (-5, 5),
+            (5, -10),
+        ]:
+            opaque[h // 2 + dy, w // 2 + dx] = False
+        metrics = self._save_and_eval(self._build_rgba(opaque))
+        # Each speckle is 1 px (<100), so they should all be filtered.
+        self.assertLess(metrics["interior_hole_largest_px"], 100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Extend `eval_alpha` to detect flood-fill bleed-through damage by comparing interior holes before and after a 1-px morphological close of the opaque mask.
- Add `interior_hole_largest_px` as a companion metric (more stable for thresholding than the total).
- Closes #171.

## Problem

The existing `interior_hole_px` metric reported `holes=0 [OK]` on the Pod Detective hero image shipped at `ecafca5f8`, while a human reviewer could clearly see missing shoulder and neck pixels. The cause: flood-fill chroma-key drilled 1–2-pixel-wide channels through the narrow parts of the character, topologically connecting real interior holes to the outside background. Connected-component labeling then sees one big border-touching region and reports zero enclosed holes.

## Fix

Compute interior holes twice:

1. On the raw opaque mask (what the old eval did).
2. On the opaque mask after `binary_closing(iterations=1)` — seals channels up to 3 px wide.

The set difference (closed-interior minus open-interior) isolates pixels that only become enclosed once the thin channels are sealed. That's the bleed-through signal.

Design-intentional gaps (armpit openings, space between legs) are typically 5+ px wide at their opening, so closing by 1 px doesn't seal them — they stay border-connected in both passes and don't false-alarm.

## Calibration (post-chroma-key-era, default threshold 500)

| image | before | after |
|---|---|---|
| Pod Detective `ecafca5f8` (bad) | `holes=0 [OK]` | `holes=4508 largest=4356 [WARN]` |
| Pod Detective `99d969fad` (bad) | `holes=0 [OK]` | `holes=2612 largest=1009 [WARN]` |
| Pod Detective `375b7f48f` (bad) | `holes=0 [OK]` | `holes=8034 largest=4211 [WARN]` |
| raccoon-hill-climbing (shipped clean) | `holes=0 [OK]` | `holes=0 [OK]` |
| raccoon-ai-team-sport (shipped clean) | `holes=1637 [WARN]` | `holes=0 [OK]` |
| raccoon-ai-native-em-plates (legit leg gaps) | `holes=5129 [WARN]` | `holes=0 [OK]` |
| raccoon-year-of-chaos-wonder (legit leg gaps) | `holes=7431 [WARN]` | `holes=0 [OK]` |

The old eval was noisy on shipped images with legitimate design gaps. The new set-difference semantics are quieter on those AND catches the bleed-through cases the old eval was blind to.

## Test plan

- [x] New unit tests pass (`test_generate.py::TestEvalAlphaInteriorHoles`): clean silhouette, preexisting enclosed hole (not flagged — could be design intent), design-gap armpit inlet (not flagged), bleed-channel hole (flagged — fixture's naive r=0 reports 0, r=1 finds it), speckle filter.
- [x] All 23 `test_generate.py` tests pass.
- [x] Calibration confirmed against 3 known-bad + 4 known-clean samples.

Note: pre-commit ran with `SKIP=test` because unrelated `skills/harden-telegram/tests/test_watchdog.py` tests are failing on upstream/main at the time of commit (see tip of `main`, not touched by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)