### PR TITLE
background-usage: document cost, recommend 12h default cadence

### DIFF
--- a/skills/background-usage/SKILL.md
+++ b/skills/background-usage/SKILL.md
@@ -10,6 +10,18 @@ Check your Claude Code plan usage without blocking your current session.
 
 **Always dispatch this to a background Agent subagent.** Do NOT run the steps inline.
 
+## Cost & cadence
+
+Each invocation spawns a hidden tmux Claude session and costs **~40k tokens**. Pick a cadence accordingly:
+
+| Session type | Recommended cadence |
+| --- | --- |
+| Default / coaching | `/clock 12h /background-usage` |
+| Leak-hunting an unexpected spike | `/clock 4h /background-usage` |
+| Deep-work batch running overnight | Skip unless actively pacing |
+
+At 4h cadence (six fires/day), monitoring alone is ~240k tokens/day — a meaningful slice of the weekly cap. Default to 12h; only drop to 4h when actively hunting a burn-rate anomaly.
+
 ## How to run
 
 Spawn a background Agent that reads and executes `_impl.md` in this skill's directory:


### PR DESCRIPTION
On 2026-04-21 Igor hit 84% of the Claude Code weekly cap, with a meaningful slice attributable to the `/background-usage` skill firing every 4h from `startup-larry`. Each invocation spawns a hidden tmux Claude session and costs ~40k tokens — at 4h cadence that is six fires/day, or ~240k tokens/day of monitoring overhead alone. Nothing in the skill surface signalled this, so downstream callers landed on the aggressive cadence.

This PR adds a `Cost & cadence` section to `skills/background-usage/SKILL.md` with a small table: default / coaching sessions use `/clock 12h`, leak-hunting drops to `/clock 4h`, deep-work batches skip monitoring unless actively pacing. The default recommendation becomes 12h. No behavioural changes to the skill itself; `_impl.md` is untouched.

— Keeping my human friend @idvorkin in the loop!