### PR TITLE
gen-image: rip magenta flood-fill, Recraft is the only bg-removal path

### DIFF
--- a/skills/gen-image/SKILL.md
+++ b/skills/gen-image/SKILL.md
@@ -19,47 +19,45 @@ Parse the user's input for:
 - **`--api-url 'url'`**: Override the Gemini API endpoint (default below)
 - **`--count N`**: Max number of images to generate (default: 3)
 - **`--aspect 'W:H'`**: Aspect ratio via `imageConfig` (default: 3:4, portrait). Valid values: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`
-- **`--transparent`**: Generate on magenta chroma-key background (`#FF00FF`), then strip it via ImageMagick **border-seeded flood fill**. The scanner samples pixels along every image edge and keeps only the ones that are actually near `#FF00FF` as flood seeds — so shots where Gemini rendered grass/scenery into some corners (which broke the earlier 4-corners-only approach when flood-fill started from grass at 30% fuzz and ate the subject) still strip cleanly. Only magenta pixels reachable from the image edges are made transparent; interior magenta-tinted pixels (pink fur highlights, glass reflections, lobster-claw reds) are preserved automatically. Fast (sub-second) and pixel-accurate — no ML needed. Requires `magick` (ImageMagick). If the subject fills the frame and no border pixel is near-magenta, the strip is skipped with an error rather than producing a swiss-cheese result. After the strip, two layered evals auto-run — see **Automatic eval** below.
-- **`--bg-remover {magenta|recraft}`**: Choose the background-removal backend used by `--transparent`. Default `magenta` (the border-seeded flood fill described above — offline, ~1s/image, free). Pass `recraft` to route through Recraft's `removeBackground` API instead — soft-mask edges on hair/fur, no `subject_eaten` / `interior_pockets` failure modes from flood-fill, and works on AI outputs with irregular edges. **Cost:** ~$0.01/call. **Latency:** ~7-40s/call (vs ~1s magenta). **Requires:** `RECRAFT_API_TOKEN` in env or `~/.env` and a network connection. Recraft is opt-in to preserve offline robustness and zero-cost defaults; the magenta flood-fill stays the default for everyday work. The alpha-mask eval pass runs on the Recraft output too — same thresholds, same regression guard. See bead `igor2-88g.61` for smoke-test results (alpha-mean within 0.2% of the magenta path, cleaner edges, smaller files).
-- **`--no-eval`**: Skip the alpha-mask eval pass that looks for interior holes, residual magenta, and edge fringe (needs numpy/pillow/scipy — the `uv run --script` shebang installs them automatically, but plain `python3` invocations without `uv` may need this flag). The alpha-mean signal still runs.
+- **`--transparent`**: Generate on a uniform magenta background, then strip it via Recraft's `removeBackground` API. Soft-mask edges on hair/fur, no flood-fill / corner-seed failure modes, and works on AI outputs with irregular edges. **Cost:** ~$0.01/call. **Latency:** ~7-40s/call. **Requires:** `RECRAFT_API_TOKEN` in env or `~/.env` and a network connection. After the strip, two layered evals auto-run — see **Automatic eval** below.
+- **`--no-eval`**: Skip the alpha-mask eval pass that looks for interior holes and edge fringe (needs numpy/pillow/scipy — the `uv run --script` shebang installs them automatically, but plain `python3` invocations without `uv` may need this flag). The alpha-mean signal still runs.
 - **`--eval-strict`**: Exit nonzero when any alpha-mask eval threshold trips. Useful when a calling agent wants to retry or fail loudly instead of silently shipping a broken alpha mask.
 
 ### Automatic eval
 
-When `--transparent` is active, `generate.py` runs two complementary evals on the output and prints metrics to stderr.
+When `--transparent` is active, `generate.py` runs two complementary evals on the Recraft output and prints metrics to stderr. Both signals are bg-removal-mechanism-agnostic — they measure the alpha channel of the finished RGBA image, so they work as a regression guard against any future stripper too.
 
 **(1) Alpha-mean signal** (`evaluate_strip`, always on — same thresholds `test_generate.py` asserts):
 
 - Status `healthy` — alpha mean in 15–85% band.
-- Status `subject_eaten` — alpha mean below 15%; the strip ate the subject. Regenerate with a magenta border on all four sides.
+- Status `subject_eaten` — alpha mean below 15%; the strip ate the subject. Recraft may have misidentified the subject — regenerate, or inspect the source.
 - Status `nothing_stripped` — alpha mean above 85%; subject fills the frame. Widen the crop.
 
 **(2) Alpha-mask quality signal** (`eval_alpha`, opt-out via `--no-eval`):
 
-- `interior_hole_px` — pixels in transparent regions that only become enclosed once the opaque mask is morphologically closed by 1 pixel. Isolates flood-fill bleed-through damage: thin 1–2-pixel channels the chroma-strip drills through the character (neck, between fingers, limb outlines) that topologically connect a real interior hole to the outside background so a naive "enclosed transparent" check reports zero. Legitimate design gaps (armpit openings, space between legs) are wider than 2 px and stay unaffected by the closing, so they don't false-alarm.
+- `interior_hole_px` — pixels in transparent regions that only become enclosed once the opaque mask is morphologically closed by 1 pixel. Isolates bleed-through damage: thin 1–2-pixel channels through the character (neck, between fingers, limb outlines) that topologically connect a real interior hole to the outside background so a naive "enclosed transparent" check reports zero. Legitimate design gaps (armpit openings, space between legs) are wider than 2 px and stay unaffected by the closing, so they don't false-alarm.
 - `interior_hole_largest_px` — pixels in the single biggest channel-revealed hole. More stable across images; good thresholding target because one big visible hole is what a human notices.
-- `residual_magenta_px` — opaque pixels still near chroma color (signals trapped magenta pockets corner-seeded flood couldn't reach).
-- `edge_fringe_px` — partial-alpha pixels (signals halo).
+- `edge_fringe_px` — partial-alpha pixels (signals halo — a known Recraft tradeoff on hair/fur edges).
 
 Output format:
 
 ```
 eval [healthy] out.webp: alpha=51.3% size=74.0KB
-[eval] /tmp/out.webp: holes=0 (largest=0), residual=0, fringe=0   [OK]
-[eval] /tmp/out.webp: holes=4508 (largest=4356), residual=0, fringe=0   [WARN: interior damage likely — check alpha mask]
+[eval] /tmp/out.webp: holes=0 (largest=0), fringe=0   [OK]
+[eval] /tmp/out.webp: holes=4508 (largest=4356), fringe=0   [WARN: interior damage likely — check alpha mask]
 ```
 
-Thresholds for the mask-quality signal are conservative by default (holes > 500, residual > 500, fringe > 2000). Pass `--no-eval` to skip it. Pass `--eval-strict` to exit nonzero when a mask-quality threshold trips.
+Thresholds for the mask-quality signal are conservative by default (holes > 500, fringe > 2000). Pass `--no-eval` to skip it. Pass `--eval-strict` to exit nonzero when a mask-quality threshold trips.
 
 **Why:** visual inspection on a light or dark background hides interior damage (holes read as shadow/shading). The alpha mask is the ground truth. Baking both evals into the skill makes them the default, so a silently-broken output can't ship. See [/hill-climbing](https://idvork.in/hill-climbing) for the "eval becomes regression guard" pattern.
 
 ## Configuration
 
-- **Auth**: `GOOGLE_API_KEY` — auto-loaded from `~/.env` by `generate.py`
-- **Recraft auth (optional)**: `RECRAFT_API_TOKEN` — auto-loaded from `~/.env` (tolerates `export KEY=val` form) by `recraft_bg_remove.py`. Only needed when you pass `--bg-remover recraft`. Check the account balance any time with `./skills/gen-image/recraft_bg_remove.py balance` (no credits consumed).
+- **Auth (Gemini)**: `GOOGLE_API_KEY` — auto-loaded from `~/.env` by `generate.py`
+- **Auth (Recraft)**: `RECRAFT_API_TOKEN` — auto-loaded from `~/.env` (tolerates `export KEY=val` form) by `recraft_bg_remove.py`. Required for `--transparent` (the only bg-removal path). Check the account balance any time with `./skills/gen-image/recraft_bg_remove.py balance` (no credits consumed). Each strip costs ~$0.01.
 - **Default style**: Read from `raccoon-style.txt` (in this skill's directory) by `generate.py`
 - **Reference image**: Auto-resolved by `generate.py` (searches `~/gits/blog*/images/raccoon-nerd.webp`)
-- **Low-level scripts**: `gemini-image.sh` handles single Gemini API calls; `recraft_bg_remove.py` (Typer + uv-shebang, stdlib-only HTTP layer) handles Recraft `removeBackground` calls. Both used internally by `generate.py`. The Recraft script honors the output extension: `.webp` is converted via `cwebp -q 90` (matching the magenta-path quality settings) so file sizes and visuals stay consistent across both backends.
+- **Low-level scripts**: `gemini-image.sh` handles single Gemini API calls; `recraft_bg_remove.py` (Typer + uv-shebang, stdlib-only HTTP layer) handles Recraft `removeBackground` calls. Both used internally by `generate.py`. The Recraft script honors the output extension: `.webp` is converted via `cwebp -q 90` so file sizes and visuals match `gemini-image.sh`'s direct WebP output.
 - **Generation wrapper**: `../image-explore/generate.py` handles env loading, style, ref image, and parallel batch execution
 
 When `--style` is provided, it **replaces** the default raccoon style entirely (it is not appended).
@@ -148,11 +146,9 @@ Use `generate.py` from the `image-explore` skill. It handles env loading (`~/.en
 
 5. If generation fails, report the error and ask if the user wants to retry with a modified prompt or skip.
 
-**Auto-eval runs on every generation.** When `--transparent` is set, `generate.py` runs two complementary evals right after the chroma-key pass — the alpha-mean signal (always) and the alpha-mask quality signal (interior holes, residual magenta, edge fringe; opt-out via `--no-eval`). Details and thresholds in the **Automatic eval** subsection above. See [/hill-climbing](https://idvork.in/hill-climbing) for the "eval becomes regression guard" pattern.
+**Auto-eval runs on every generation.** When `--transparent` is set, `generate.py` runs two complementary evals right after the Recraft pass — the alpha-mean signal (always) and the alpha-mask quality signal (interior holes, edge fringe; opt-out via `--no-eval`). Details and thresholds in the **Automatic eval** subsection above. See [/hill-climbing](https://idvork.in/hill-climbing) for the "eval becomes regression guard" pattern.
 
-**Verifying transparent output.** Don't judge chroma-key quality by compositing on a solid background — interior holes read as the background color. Extract the alpha channel as a mask: `magick out.webp -alpha extract mask.png`. A clean mask is a solid silhouette; swiss-cheese holes mean the chroma ate interior color data.
-
-**Never chain chroma passes on different magenta tones** (e.g. a second pass on `#E040E0` to catch pink shadow remnants). It eats magenta-tinted highlights inside fluffy characters. If the first pass has fringe, regenerate the source with a stricter prompt (`no shadow on ground, no gradient, no environment`) rather than filtering harder.
+**Verifying transparent output.** Don't judge bg-strip quality by compositing on a solid background — interior holes read as the background color. Extract the alpha channel as a mask: `magick out.webp -alpha extract mask.png`. A clean mask is a solid silhouette; swiss-cheese holes or visible halo mean the strip mis-segmented the subject.
 
 ### Phase 5: Insert References (Optional)
 

--- a/skills/gen-image/SKILL.md
+++ b/skills/gen-image/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: gen-image
 description: "Analyze content and generate illustrations via Gemini image API"
-argument-hint: "<post-or-topic> [--count N] [--aspect W:H] [--style '...'] [--ref path] [--transparent] [--api-url url]"
+argument-hint: "<post-or-topic> [--count N] [--aspect W:H] [--style '...'] [--ref path] [--transparent] [--fast/--no-fast] [--api-url url]"
 allowed-tools: Bash, Read, Write, Glob, Grep, AskUserQuestion, WebFetch
 ---
 
@@ -20,6 +20,7 @@ Parse the user's input for:
 - **`--count N`**: Max number of images to generate (default: 3)
 - **`--aspect 'W:H'`**: Aspect ratio via `imageConfig` (default: 3:4, portrait). Valid values: `1:1`, `2:3`, `3:2`, `3:4`, `4:3`, `4:5`, `5:4`, `9:16`, `16:9`, `21:9`
 - **`--transparent`**: Generate on a uniform magenta background, then strip it via Recraft's `removeBackground` API. Soft-mask edges on hair/fur, no flood-fill / corner-seed failure modes, and works on AI outputs with irregular edges. **Cost:** ~$0.01/call. **Latency:** ~7-40s/call. **Requires:** `RECRAFT_API_TOKEN` in env or `~/.env` and a network connection. After the strip, two layered evals auto-run — see **Automatic eval** below.
+- **`--fast` / `--no-fast`**: Pick the Gemini image-generation model. **Default is `--fast`** (`gemini-3.1-flash-image-preview`) — cheaper, lower latency, the historical behavior. `--no-fast` swaps in `gemini-3-pro-image-preview` (Pro), which is more obedient to style directives but slower and more expensive. Use `--no-fast` when Flash is ignoring or mangling specific instructions in the prompt (shirt text, exact framing, character details). The selected model is passed to `gemini-image.sh` via the `GEMINI_IMAGE_MODEL` env var.
 - **`--no-eval`**: Skip the alpha-mask eval pass that looks for interior holes and edge fringe (needs numpy/pillow/scipy — the `uv run --script` shebang installs them automatically, but plain `python3` invocations without `uv` may need this flag). The alpha-mean signal still runs.
 - **`--eval-strict`**: Exit nonzero when any alpha-mask eval threshold trips. Useful when a calling agent wants to retry or fail loudly instead of silently shipping a broken alpha mask.
 

--- a/skills/gen-image/gemini-image.sh
+++ b/skills/gen-image/gemini-image.sh
@@ -5,8 +5,15 @@
 # Usage: gemini-image.sh <prompt> <output-file> [api-url] [ref-image...]
 #
 # Environment:
-#   GOOGLE_API_KEY   (required) — your Google API key
-#   ASPECT_RATIO     (optional) — aspect ratio, e.g. "3:4" (default: 3:4)
+#   GOOGLE_API_KEY      (required) — your Google API key
+#   ASPECT_RATIO        (optional) — aspect ratio, e.g. "3:4" (default: 3:4)
+#   GEMINI_IMAGE_MODEL  (optional) — model id used to derive the default
+#                        API URL when no explicit api-url positional is
+#                        passed. Defaults to gemini-3.1-flash-image-preview
+#                        (the "fast" Flash model). Set to
+#                        gemini-3-pro-image-preview for the Pro model
+#                        (slower / more expensive / more obedient to
+#                        style directives). Ignored if api-url is set.
 #
 # Reference images are passed as additional positional arguments after
 # the API URL. They are sent as inline_data parts alongside the text
@@ -16,7 +23,16 @@ set -euo pipefail
 
 PROMPT="${1:?Usage: gemini-image.sh <prompt> <output-file> [api-url] [ref-image...]}"
 OUTPUT="${2:?Usage: gemini-image.sh <prompt> <output-file> [api-url] [ref-image...]}"
-API_URL="${3:-https://generativelanguage.googleapis.com/v1beta/models/gemini-3.1-flash-image-preview:generateContent}"
+GEMINI_IMAGE_MODEL="${GEMINI_IMAGE_MODEL:-gemini-3.1-flash-image-preview}"
+DEFAULT_API_URL="https://generativelanguage.googleapis.com/v1beta/models/${GEMINI_IMAGE_MODEL}:generateContent"
+# Treat an empty third arg ("") as "use default" so callers that always
+# pass a positional placeholder (e.g. generate.py) can opt into env-var
+# model selection without rewriting their call sites.
+if [[ $# -ge 3 && -n "${3}" ]]; then
+    API_URL="${3}"
+else
+    API_URL="$DEFAULT_API_URL"
+fi
 REF_IMAGES=()
 if [[ $# -gt 3 ]]; then
     shift 3

--- a/skills/gen-image/recraft_bg_remove.py
+++ b/skills/gen-image/recraft_bg_remove.py
@@ -6,7 +6,7 @@
 # ]
 # ///
 # ABOUTME: Strip image background via Recraft's removeBackground API.
-# ABOUTME: Drop-in replacement for the magenta-flood-fill chroma path in gen-image.
+# ABOUTME: The bg-removal path used by gen-image's --transparent flag.
 #
 # Usage:
 #   recraft_bg_remove.py strip <input> <output>      # CLI mode
@@ -54,10 +54,9 @@ SUPPORTED_EXTS = {".png", ".jpg", ".jpeg", ".webp"}
 # unexpected errors (a few hundred bytes); guard against silent truncation.
 MIN_OUTPUT_BYTES = 1024
 
-# WebP conversion quality when the caller asks for `.webp` output. Matches
-# what gemini-image.sh uses (`cwebp -q 90`) so files coming out of the
-# Recraft path are visually consistent with files coming out of the
-# Gemini-magenta path (no quality cliff).
+# WebP conversion quality when the caller asks for `.webp` output.
+# Matches what gemini-image.sh uses (`cwebp -q 90`) so file sizes and
+# visuals stay consistent with Gemini's direct WebP output.
 WEBP_QUALITY = 90
 
 
@@ -104,9 +103,7 @@ def _validate_input(input_path: str) -> str | None:
     if size == 0:
         return f"input is empty: {input_path}"
     if size > MAX_FILE_BYTES:
-        return (
-            f"input is {size} bytes, exceeds Recraft's {MAX_FILE_BYTES}-byte limit"
-        )
+        return f"input is {size} bytes, exceeds Recraft's {MAX_FILE_BYTES}-byte limit"
     if p.suffix.lower() not in SUPPORTED_EXTS:
         return (
             f"unsupported extension {p.suffix!r}; "
@@ -157,19 +154,17 @@ def _build_multipart(input_path: str) -> tuple[bytes, str]:
     return body, f"multipart/form-data; boundary={boundary}"
 
 
-def _write_with_format(
-    img_bytes: bytes, output_path: str
-) -> tuple[bool, str | None]:
+def _write_with_format(img_bytes: bytes, output_path: str) -> tuple[bool, str | None]:
     """Persist Recraft's PNG bytes at output_path, converting if the
     caller requested .webp.
 
     Recraft's removeBackground endpoint only emits PNG with alpha. If
     the caller asks for .webp, we go PNG → cwebp → WebP-with-alpha (same
-    `cwebp -q 90` invocation gemini-image.sh uses for the magenta path,
-    so visual quality stays consistent). For any other extension, we
-    write the PNG bytes verbatim (caller's problem if they asked for
-    .jpg — alpha would be dropped). Falls back to PNG if cwebp is
-    missing, with a clear message rather than silent rename.
+    `cwebp -q 90` invocation gemini-image.sh uses, so visual quality
+    stays consistent with the upstream Gemini output). For any other
+    extension, we write the PNG bytes verbatim (caller's problem if they
+    asked for .jpg — alpha would be dropped). Falls back to PNG if cwebp
+    is missing, with a clear message rather than silent rename.
     """
     out = Path(output_path)
     out.parent.mkdir(parents=True, exist_ok=True)
@@ -215,9 +210,10 @@ def strip_background(
 ) -> tuple[bool, str | None]:
     """Strip the background from input_path; write transparent image to output_path.
 
-    Drop-in replacement for the magenta flood-fill — same (success, error)
-    contract as remove_background() in generate.py so the caller can swap
-    implementations without touching the eval flow.
+    Returns (success: bool, error: str | None). Called from generate.py's
+    remove_background_recraft() under --transparent — Recraft is the only
+    bg-removal path. The post-strip eval pass (alpha-mean + interior-hole +
+    edge-fringe) runs on the result downstream.
 
     Output format follows the extension on `output_path`:
         - .png  → Recraft's PNG-with-alpha bytes verbatim

--- a/skills/image-explore/generate.py
+++ b/skills/image-explore/generate.py
@@ -42,6 +42,14 @@ GREENSCREEN_PROMPT = (
     "uniform flat magenta everywhere behind the character."
 )
 
+# Gemini image-generation models. `fast` is the default (Flash), matching
+# the historical behavior of gemini-image.sh; `pro` swaps in the Pro model
+# (more obedient to style directives, slower and more expensive). The
+# selected id is plumbed to gemini-image.sh via the GEMINI_IMAGE_MODEL
+# env var — the script uses it to derive the default API URL.
+GEMINI_FAST_MODEL = "gemini-3.1-flash-image-preview"
+GEMINI_PRO_MODEL = "gemini-3-pro-image-preview"
+
 
 @dataclass
 class Direction:
@@ -64,6 +72,10 @@ class GenerateConfig:
     eval_strict: bool = False
     # Path to the Recraft script (skills/gen-image/recraft_bg_remove.py).
     recraft_script: str | None = None
+    # Gemini image-generation model id. Plumbed to gemini-image.sh via
+    # the GEMINI_IMAGE_MODEL env var. Defaults to the Flash ("fast")
+    # model; --no-fast on the CLI swaps in the Pro model.
+    gemini_model: str = GEMINI_FAST_MODEL
 
 
 @dataclass
@@ -476,6 +488,7 @@ def generate_one(direction: Direction, config: GenerateConfig) -> GenerationResu
 
     env = os.environ.copy()
     env["ASPECT_RATIO"] = config.aspect
+    env["GEMINI_IMAGE_MODEL"] = config.gemini_model
 
     print(f"Generating: {direction.output}", file=sys.stderr)
     t0 = time.monotonic()
@@ -586,6 +599,15 @@ def _build_app():
             False,
             help="Generate on a uniform magenta background, then strip it via Recraft's removeBackground API (~$0.01/call, ~7-40s/image, requires RECRAFT_API_TOKEN). Soft-mask edges on hair/fur, no flood-fill failure modes.",
         ),
+        fast: bool = typer.Option(
+            True,
+            "--fast/--no-fast",
+            help=(
+                f"Pick the Gemini image model. --fast (default) uses {GEMINI_FAST_MODEL} "
+                f"(Flash, cheaper/faster). --no-fast uses {GEMINI_PRO_MODEL} (Pro: more "
+                "obedient to style directives, slower, more expensive)."
+            ),
+        ),
         no_eval: bool = typer.Option(
             False,
             "--no-eval",
@@ -619,6 +641,7 @@ def _build_app():
             recraft_script=str(
                 chop_root / "skills" / "gen-image" / "recraft_bg_remove.py"
             ),
+            gemini_model=GEMINI_FAST_MODEL if fast else GEMINI_PRO_MODEL,
         )
 
         direction = Direction(scene=scene, shirt=shirt, output=output)
@@ -646,6 +669,15 @@ def _build_app():
         transparent: bool = typer.Option(
             False,
             help="Generate on a uniform magenta background, then strip it via Recraft's removeBackground API (~$0.01/call, ~7-40s/image, requires RECRAFT_API_TOKEN). Soft-mask edges on hair/fur, no flood-fill failure modes.",
+        ),
+        fast: bool = typer.Option(
+            True,
+            "--fast/--no-fast",
+            help=(
+                f"Pick the Gemini image model. --fast (default) uses {GEMINI_FAST_MODEL} "
+                f"(Flash, cheaper/faster). --no-fast uses {GEMINI_PRO_MODEL} (Pro: more "
+                "obedient to style directives, slower, more expensive)."
+            ),
         ),
         no_eval: bool = typer.Option(
             False,
@@ -680,6 +712,7 @@ def _build_app():
             recraft_script=str(
                 chop_root / "skills" / "gen-image" / "recraft_bg_remove.py"
             ),
+            gemini_model=GEMINI_FAST_MODEL if fast else GEMINI_PRO_MODEL,
         )
 
         batch_path = Path(json_file)

--- a/skills/image-explore/generate.py
+++ b/skills/image-explore/generate.py
@@ -21,18 +21,17 @@
 # directions.json format:
 #   [{"scene": "...", "shirt": "TEXT", "output": "file.webp"}, ...]
 #
-# Numpy/Pillow/Scipy power the --transparent post-strip eval_alpha()
-# pathway (interior holes / residual magenta / edge fringe) and are
-# lazy-imported there. The `uv run --script` shebang auto-installs them;
-# running via plain `python3` works as long as --transparent is off or
-# --no-eval is set.
+# Background removal under --transparent always goes through Recraft's
+# removeBackground API (skills/gen-image/recraft_bg_remove.py). Numpy/
+# Pillow/Scipy power the post-strip eval_alpha() pathway (interior holes
+# / edge fringe) and are lazy-imported there. The `uv run --script`
+# shebang auto-installs them; running via plain `python3` works as long
+# as --transparent is off or --no-eval is set.
 
 import json
 import os
-import shutil
 import subprocess
 import sys
-import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -60,16 +59,10 @@ class GenerateConfig:
     aspect: str
     transparent: bool = False
     # Layered alpha-mask eval on top of evaluate_strip's alpha-mean signal.
-    # Detects interior holes, residual magenta pockets, and edge fringe.
+    # Detects interior holes and edge fringe in the Recraft output.
     eval_alpha: bool = True
     eval_strict: bool = False
-    # Background remover for --transparent: "magenta" (default — offline,
-    # ~1s/image, free) or "recraft" (Recraft API, ~7-15s/image, ~$0.01/call,
-    # cleaner soft-mask edges on hair/fur). The eval pass runs on the output
-    # of EITHER path, so the regression guard is identical. Recraft is opt-in
-    # to preserve offline robustness. See bead igor2-88g.61.
-    bg_remover: str = "magenta"
-    # Path to the Recraft script (only used when bg_remover == "recraft").
+    # Path to the Recraft script (skills/gen-image/recraft_bg_remove.py).
     recraft_script: str | None = None
 
 
@@ -89,27 +82,21 @@ class GenerationResult:
 # triggers a [WARN] on the eval line (and, under --eval-strict, a
 # nonzero exit). These complement evaluate_strip's alpha-mean signal —
 # the mean catches "strip ate the subject" / "nothing stripped"; these
-# catch "Swiss-cheese holes", "trapped magenta pockets", and "halo".
+# catch "Swiss-cheese holes" and "halo".
 EVAL_ALPHA_THRESHOLDS = {
     "interior_hole_px": 500,
-    "residual_magenta_px": 500,
     "edge_fringe_px": 2000,
 }
 
 # Before counting interior holes, morphologically close the opaque mask
-# (dilate then erode by this many pixels). Flood-fill chroma-key can
-# drill 1–2-pixel-wide channels through narrow parts of the character
-# (neck, between fingers, limb outlines), which topologically connect
-# real interior holes to the outside background — naive connected-
-# components then reports holes=0 even when the mask is visibly damaged.
-# Radius 1 seals channels up to 3px wide, which matches every bleed
-# path observed on the Pod Detective calibration set without collapsing
-# legitimate design gaps (between legs, armpit openings) that are 5+ px
-# wide on real character art. See issue #171.
+# (dilate then erode by this many pixels). Recraft's mask is generally
+# clean, but if a thin connector ever pierces the silhouette, sealing
+# 1-2-pixel channels keeps the interior-hole metric accurate. Radius 1
+# matches the original tuning for the calibration set.
 INTERIOR_HOLE_CLOSE_RADIUS = 1
 # After sealing channels, drop interior components smaller than this —
-# antialiasing specks between fingers / between objects aren't real
-# damage, and they dominate the component count on otherwise-clean images.
+# antialiasing specks aren't real damage, and they dominate the
+# component count on otherwise-clean images.
 INTERIOR_HOLE_MIN_COMPONENT_PX = 100
 
 
@@ -175,115 +162,31 @@ def read_default_style(chop_root):
     )
 
 
-# Flood-seed scan: sample points along the image border and seed the
-# flood-fill only from points that are actually near the magenta chroma-key
-# color. This handles the case where Gemini frames the shot with the
-# subject or its scenery extending to some of the image edges — the older
-# "flood from all 4 corners" approach assumed every corner is chroma-bg,
-# and when the bottom corners rendered as grass or stone, a 30%-fuzz flood
-# started from grass and ate the subject.
-#
-# Constants below: sampling step along each edge (smaller = more seeds, more
-# robust; larger = cheaper). Near-magenta tolerance is stricter than the
-# flood fuzz on purpose — we want to seed only from "definitely background"
-# pixels and let the flood itself handle the gradient at the subject edge.
-BORDER_SAMPLE_STEP = 8
-NEAR_MAGENTA_L1_TOLERANCE = 70  # sum of |r-255| + |g| + |b-255|
-FLOOD_FUZZ_PERCENT = 30
-
 # Post-strip eval thresholds — the same metrics the unit tests assert on,
 # reused as a runtime regression guard. See /hill-climbing for why the
 # same eval that drives the search becomes infrastructure after it.
 # Alpha mean (0..100): percentage of pixels fully opaque. Below
-# HEALTHY_ALPHA_MIN_PCT means the strip ate the subject (chroma invariant
-# was violated); above HEALTHY_ALPHA_MAX_PCT means nearly nothing was
-# transparent (subject likely fills the frame, strip effectively a no-op).
+# HEALTHY_ALPHA_MIN_PCT means the strip ate the subject; above
+# HEALTHY_ALPHA_MAX_PCT means nearly nothing was transparent (subject
+# likely fills the frame, strip effectively a no-op).
 HEALTHY_ALPHA_MIN_PCT = 15.0
 HEALTHY_ALPHA_MAX_PCT = 85.0
-
-
-def _parse_srgb(fragment):
-    """Parse 'srgb(r,g,b)' or 'srgba(r,g,b,a)' — return (r,g,b) ints, or None.
-
-    Requires at least 3 comma-separated integer components inside the parens.
-    A malformed 'srgb(1,2)' returns None rather than a 2-tuple, so callers
-    can always unpack the result as (r,g,b) without a bounds check.
-    """
-    fragment = fragment.strip()
-    if not fragment.startswith(("srgb(", "srgba(")):
-        return None
-    try:
-        parts = fragment.split("(", 1)[1].rstrip(")").split(",")
-        if len(parts) < 3:
-            return None
-        return tuple(int(p) for p in parts[:3])
-    except (ValueError, IndexError):
-        return None
-
-
-def _scan_border_for_magenta_seeds(magick_bin, image_path, w, h):
-    """Return list of (x,y) border pixels within NEAR_MAGENTA_L1_TOLERANCE of #FF00FF.
-
-    Uses a single magick invocation: build a format string that dumps every
-    sampled border pixel separated by '|'. Much cheaper than per-pixel
-    subprocess calls on large borders.
-    """
-    positions = []
-    step = BORDER_SAMPLE_STEP
-    for x in range(0, w, step):
-        positions.append((x, 0))
-        positions.append((x, h - 1))
-    for y in range(0, h, step):
-        positions.append((0, y))
-        positions.append((w - 1, y))
-
-    fmt = "|".join(f"%[pixel:p{{{x},{y}}}]" for x, y in positions)
-    result = subprocess.run(
-        [magick_bin, image_path, "-format", fmt, "info:"],
-        capture_output=True,
-        text=True,
-    )
-    if result.returncode != 0:
-        return None, f"magick border probe failed: {result.stderr.strip()}"
-
-    seeds = []
-    fragments = result.stdout.split("|")
-    if len(fragments) != len(positions):
-        return None, (
-            f"border probe returned {len(fragments)} fragments, expected {len(positions)}"
-        )
-    for (x, y), frag in zip(positions, fragments):
-        rgb = _parse_srgb(frag)
-        if rgb is None:
-            continue
-        r, g, b = rgb
-        if abs(r - 255) + abs(g) + abs(b - 255) <= NEAR_MAGENTA_L1_TOLERANCE:
-            seeds.append((x, y))
-    return seeds, None
 
 
 def remove_background_recraft(image_path, recraft_script):
     """Strip the background via Recraft's removeBackground API.
 
-    Drop-in replacement for remove_background()'s magenta-flood-fill path.
-    Returns (success: bool, error: str | None) with identical contract so
-    the caller can swap implementations without changing the eval flow.
-
-    Tradeoffs vs the magenta path: ~7-40s of API latency per image (vs
-    ~1s flood-fill), ~$0.01/call, requires RECRAFT_API_TOKEN in env or
-    ~/.env, and a network connection. In return: soft-mask edges on
-    hair/fur, no `subject_eaten` / `interior_pockets` failure modes from
-    flood-fill, and works on AI outputs with irregular edges. The same
-    evaluate_strip + eval_alpha guards still run on the result — if
-    Recraft regresses, the alpha-mean / interior-hole signals catch it.
-
-    See bead igor2-88g.61 for smoke-test results (alpha-mean within 0.2%
-    of magenta on the bash-curl smoke, cleaner edges, smaller files).
+    Returns (success: bool, error: str | None). The same evaluate_strip +
+    eval_alpha guards run on the result downstream — if Recraft regresses,
+    the alpha-mean / interior-hole signals catch it.
 
     Implementation: shells out to skills/gen-image/recraft_bg_remove.py
     (Typer + uv-shebang, stdlib-only HTTP layer). The script self-bootstraps
     its typer dep via uv. We invoke its `strip` subcommand by absolute path
     so the shebang fires.
+
+    Cost / latency: ~$0.01/call, ~7-40s wall. Requires RECRAFT_API_TOKEN
+    in env or ~/.env.
     """
     if not recraft_script or not Path(recraft_script).exists():
         return False, (
@@ -304,100 +207,8 @@ def remove_background_recraft(image_path, recraft_script):
     return True, None
 
 
-def remove_background(image_path):
-    """Strip the magenta chroma-key background using border-seeded flood fill.
-
-    Images are generated on a KNOWN solid #FF00FF background, so chroma-key
-    stripping is pixel-accurate without ML. The older one-pass
-    `-fuzz 30% -transparent #FF00FF` approach kills every magenta-ish pixel
-    globally, including magenta-tinted highlights *inside* the character
-    (pink fur, specular glass reflections, lobster-claw reds) — leaving
-    swiss-cheese holes in the alpha.
-
-    The flood-fill strategy only transparents pixels reachable from the
-    image border, so interior magenta-tinted pixels are preserved by the
-    character's own silhouette. Seeding the flood needs to find actual
-    chroma-background pixels on the border — hard-coding the 4 corners
-    fails whenever Gemini frames a shot with grass, sky, or scenery
-    touching an image edge (seen in practice: dense grass rendered into
-    the bottom corners, flood started from grass at 30% fuzz and ate the
-    subject). Instead, sample the border ring, keep only samples that are
-    actually near #FF00FF, and seed the flood from all of them.
-
-    If no border pixels are near-magenta — the subject fills the whole
-    frame — skip the strip rather than eat the subject, and let the caller
-    decide what to do.
-    """
-    magick = shutil.which("magick") or shutil.which("convert")
-    if not magick:
-        return False, "magick not found — install ImageMagick"
-
-    probe = subprocess.run(
-        [magick, "identify", "-format", "%w %h", image_path],
-        capture_output=True,
-        text=True,
-    )
-    if probe.returncode != 0:
-        return False, f"magick identify failed: {probe.stderr.strip()}"
-    try:
-        w, h = (int(x) for x in probe.stdout.split())
-    except ValueError:
-        return False, f"could not parse image dimensions: {probe.stdout!r}"
-
-    seeds, err = _scan_border_for_magenta_seeds(magick, image_path, w, h)
-    if err is not None:
-        return False, err
-    if not seeds:
-        return False, (
-            "no magenta chroma-key background detected on the image border; "
-            "skipping strip. Regenerate with a prompt that leaves a magenta "
-            "border on all four sides of the frame."
-        )
-
-    with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
-        tmp_path = tmp.name
-
-    draws = []
-    for x, y in seeds:
-        draws += ["-draw", f"color {x},{y} floodfill"]
-
-    try:
-        cmd = [
-            magick,
-            image_path,
-            "-alpha",
-            "set",
-            "-fuzz",
-            f"{FLOOD_FUZZ_PERCENT}%",
-            "-fill",
-            "none",
-            *draws,
-            "-quality",
-            "90",
-            tmp_path,
-        ]
-        result = subprocess.run(cmd, capture_output=True, text=True)
-        if result.returncode != 0:
-            return False, f"magick flood-fill failed: {result.stderr.strip()}"
-
-        ext = Path(image_path).suffix.lower()
-        if ext == ".webp":
-            conv = subprocess.run(
-                [magick, tmp_path, "-quality", "90", image_path],
-                capture_output=True,
-                text=True,
-            )
-            if conv.returncode != 0:
-                return False, f"magick webp convert failed: {conv.stderr.strip()}"
-        else:
-            shutil.copy2(tmp_path, image_path)
-        return True, None
-    finally:
-        Path(tmp_path).unlink(missing_ok=True)
-
-
 def evaluate_strip(image_path):
-    """Compute chroma-strip quality metrics for a finished image.
+    """Compute bg-strip quality metrics for a finished image.
 
     Returns (metrics_dict, warning_str_or_None). The metrics dict always
     has the same keys so the caller can log them uniformly; warning is
@@ -406,12 +217,18 @@ def evaluate_strip(image_path):
     test_generate.py's integration suite, so test + runtime share the
     same definition of "healthy."
 
+    General-purpose alpha-mean signal: works on any RGBA output,
+    including Recraft's PNG-with-alpha. Independent of the upstream
+    bg-removal mechanism.
+
     Keys in the metrics dict:
     - alpha_mean_pct: percentage of pixels fully opaque (0..100)
     - file_size_kb: size on disk, rounded
     - status: one of "healthy", "subject_eaten", "nothing_stripped",
       "eval_failed"
     """
+    import shutil  # noqa: PLC0415
+
     magick = shutil.which("magick") or shutil.which("convert")
     if magick is None:
         return (
@@ -458,9 +275,8 @@ def evaluate_strip(image_path):
         status = "subject_eaten"
         warning = (
             f"alpha_mean={alpha_pct}% is below {HEALTHY_ALPHA_MIN_PCT}%: "
-            "the strip likely ate the subject. Usually means chroma-bg "
-            "wasn't present on every image border — regenerate with a "
-            "prompt that leaves a solid magenta border on all four sides."
+            "the strip likely ate the subject. Recraft may have misidentified "
+            "the subject — regenerate, or inspect the source image."
         )
     elif alpha_pct > HEALTHY_ALPHA_MAX_PCT:
         status = "nothing_stripped"
@@ -515,28 +331,26 @@ def _label_interior(transparent_mask, label):
 
 def eval_alpha(
     image_path,
-    chroma_rgb=(255, 0, 255),
-    tolerance=20,
     close_radius=INTERIOR_HOLE_CLOSE_RADIUS,
     min_component_px=INTERIOR_HOLE_MIN_COMPONENT_PX,
 ):
-    """Compute alpha-mask quality metrics for a post-chroma RGBA image.
+    """Compute alpha-mask quality metrics for a post-strip RGBA image.
 
-    Detects failure modes orthogonal to evaluate_strip's alpha-mean signal:
+    Detects failure modes orthogonal to evaluate_strip's alpha-mean signal.
+    General-purpose: works on any RGBA output, regardless of how the
+    background was removed.
+
       * interior_hole_px — transparent pixels NOT reachable from the image
         border after the opaque mask is morphologically closed. Closing
-        seals the 1–2-pixel bleed channels the flood-fill drills through
-        narrow character parts; without it, a real interior hole connected
-        to the outside by a thin channel gets counted as border-touching
-        and slips through (the issue-#171 failure mode). Tiny components
-        below `min_component_px` are filtered as antialiasing noise.
+        seals 1-2-pixel bleed channels that connect a real interior hole
+        to the outside background, which would otherwise let it slip
+        through a naive border-touching check. Tiny components below
+        `min_component_px` are filtered as antialiasing noise.
       * interior_hole_largest_px — pixels in the single largest interior
         hole. More stable across images than the total; good for
         thresholding because one big hole is what a human sees.
-      * residual_magenta_px — opaque pixels still near the chroma color.
-        Trapped magenta pockets between characters or inside enclosed
-        negative space the flood-fill couldn't reach from the corners.
-      * edge_fringe_px — partial-alpha pixels. Large counts suggest halo.
+      * edge_fringe_px — partial-alpha pixels. Large counts suggest halo —
+        a known Recraft tradeoff on hair/fur edges.
 
     Deps (numpy, pillow, scipy) are lazy-imported so callers that pass
     --no-eval (or don't touch --transparent) never hit an ImportError on
@@ -547,21 +361,15 @@ def eval_alpha(
     from scipy.ndimage import binary_closing, label  # noqa: PLC0415
 
     arr = np.asarray(Image.open(image_path).convert("RGBA"))
-    rgb, a = arr[:, :, :3], arr[:, :, 3]
+    a = arr[:, :, 3]
     opaque = a > 128
     transparent = a < 16
 
-    # Residual magenta: opaque pixels whose RGB is still within tolerance
-    # of the chroma color. L1 distance on int16 to avoid uint8 overflow.
-    chroma = np.array(chroma_rgb, dtype=np.int16)
-    dist = np.abs(rgb.astype(np.int16) - chroma).sum(axis=2)
-    residual = int((opaque & (dist <= tolerance)).sum())
-
-    # Interior holes: we want to flag flood-fill bleed-through damage but
-    # NOT legitimate design-intentional gaps (armpit openings, space
-    # between legs, gap between fingers). Both show up as "transparent
-    # surrounded by opaque" but they behave differently under morphological
-    # closing of the opaque mask:
+    # Interior holes: we want to flag bleed-through damage but NOT
+    # legitimate design-intentional gaps (armpit openings, space between
+    # legs, gap between fingers). Both show up as "transparent surrounded
+    # by opaque" but they behave differently under morphological closing
+    # of the opaque mask:
     #   - Design gap: several pixels wide at its opening; closing by 1 px
     #     barely narrows it, so its topological relationship to the border
     #     is unchanged.
@@ -597,13 +405,12 @@ def eval_alpha(
         interior_largest = 0
 
     # Edge fringe: partial alpha. Some is expected (antialiasing); a lot
-    # suggests the chroma removal left a halo.
+    # suggests a halo around the subject.
     edge = int(((~opaque) & (~transparent)).sum())
 
     return {
         "interior_hole_px": interior,
         "interior_hole_largest_px": interior_largest,
-        "residual_magenta_px": residual,
         "edge_fringe_px": edge,
     }
 
@@ -615,7 +422,6 @@ def format_eval_line(image_path, metrics, warnings):
     return (
         f"[eval] {image_path}: "
         f"holes={metrics['interior_hole_px']} (largest={largest}), "
-        f"residual={metrics['residual_magenta_px']}, "
         f"fringe={metrics['edge_fringe_px']}   {status}"
     )
 
@@ -627,11 +433,6 @@ def check_eval_thresholds(metrics, thresholds=EVAL_ALPHA_THRESHOLDS):
         warnings.append(
             f"interior damage likely (holes={metrics['interior_hole_px']} "
             f"> {thresholds['interior_hole_px']}) — check alpha mask"
-        )
-    if metrics["residual_magenta_px"] > thresholds["residual_magenta_px"]:
-        warnings.append(
-            f"residual magenta (residual={metrics['residual_magenta_px']} "
-            f"> {thresholds['residual_magenta_px']}) — trapped pocket"
         )
     if metrics["edge_fringe_px"] > thresholds["edge_fringe_px"]:
         warnings.append(
@@ -695,21 +496,17 @@ def generate_one(direction: Direction, config: GenerateConfig) -> GenerationResu
     eval_alpha_metrics = None
     eval_alpha_warnings = None
     if config.transparent:
-        # Dispatch on bg_remover. Magenta is offline + ~1s/image; Recraft
-        # is API-backed (~7-15s, ~$0.01/call) but produces cleaner edges on
-        # hair/fur. Either way, the eval pass below runs on the output —
-        # the regression guard (alpha-mean + interior-hole + residual +
-        # fringe) is identical for both paths.
+        # Recraft is the only bg-removal path. ~7-40s of API latency per
+        # image, ~$0.01/call. The eval pass below runs on the result —
+        # alpha-mean catches "subject eaten" / "nothing stripped";
+        # eval_alpha catches interior holes and edge fringe.
         print(
-            f"Removing background ({config.bg_remover}): {direction.output}",
+            f"Removing background (recraft): {direction.output}",
             file=sys.stderr,
         )
-        if config.bg_remover == "recraft":
-            success, err = remove_background_recraft(
-                direction.output, config.recraft_script
-            )
-        else:
-            success, err = remove_background(direction.output)
+        success, err = remove_background_recraft(
+            direction.output, config.recraft_script
+        )
         if not success:
             return GenerationResult(
                 output=direction.output,
@@ -721,17 +518,17 @@ def generate_one(direction: Direction, config: GenerateConfig) -> GenerationResu
         # Auto-eval the strip: the same metrics asserted in test_generate.py
         # become the runtime regression guard. Healthy strips print a quiet
         # one-liner; failed strips print a loud warning with actionable
-        # guidance (regenerate the prompt vs. widen the crop).
+        # guidance.
         metrics, warning = evaluate_strip(direction.output)
         print(
             _format_eval_card(direction.output, metrics, warning),
             file=sys.stderr,
         )
 
-        # Layered alpha-mask eval — catches interior holes, trapped
-        # magenta pockets, and halo fringe that the alpha-mean signal
-        # above can't detect. Best-effort: missing deps or errors log
-        # and continue rather than failing the generation.
+        # Layered alpha-mask eval — catches interior holes and halo
+        # fringe that the alpha-mean signal above can't detect.
+        # Best-effort: missing deps or errors log and continue rather
+        # than failing the generation.
         if config.eval_alpha:
             try:
                 eval_alpha_metrics = eval_alpha(direction.output)
@@ -787,34 +584,22 @@ def _build_app():
         style: str | None = typer.Option(None, help="Override default raccoon style"),
         transparent: bool = typer.Option(
             False,
-            help="Generate on magenta chroma-key background, then strip it via ImageMagick edge-connected flood fill from the 4 corners (preserves interior magenta-tinted pixels)",
-        ),
-        bg_remover: str = typer.Option(
-            "magenta",
-            "--bg-remover",
-            help="Background remover for --transparent: 'magenta' (default — offline flood-fill, ~1s/image, free) or 'recraft' (Recraft API, ~7-15s/image, ~$0.01/call, cleaner soft-mask edges on hair/fur). Recraft requires RECRAFT_API_TOKEN in env or ~/.env. The alpha-mask eval still runs on either output.",
+            help="Generate on a uniform magenta background, then strip it via Recraft's removeBackground API (~$0.01/call, ~7-40s/image, requires RECRAFT_API_TOKEN). Soft-mask edges on hair/fur, no flood-fill failure modes.",
         ),
         no_eval: bool = typer.Option(
             False,
             "--no-eval",
-            help="Skip the post-chroma alpha-mask eval (interior holes, residual magenta, edge fringe). Needs numpy/pillow/scipy — the uv shebang installs them, but bare python3 callers may need this.",
+            help="Skip the post-strip alpha-mask eval (interior holes, edge fringe). Needs numpy/pillow/scipy — the uv shebang installs them, but bare python3 callers may need this.",
         ),
         eval_strict: bool = typer.Option(
             False,
             "--eval-strict",
-            help="Exit 2 if any eval threshold trips (interior holes, residual magenta, edge fringe). Useful for CI / calling agents that want to retry or fail loudly.",
+            help="Exit 2 if any eval threshold trips (interior holes, edge fringe). Useful for CI / calling agents that want to retry or fail loudly.",
         ),
     ) -> None:
         """Generate a single raccoon image."""
         chop_root = resolve_chop_root()
         load_env()
-
-        if bg_remover not in ("magenta", "recraft"):
-            print(
-                f"Error: --bg-remover must be 'magenta' or 'recraft' (got {bg_remover!r})",
-                file=sys.stderr,
-            )
-            raise typer.Exit(1)
 
         if not os.environ.get("GOOGLE_API_KEY"):
             print(
@@ -831,7 +616,6 @@ def _build_app():
             transparent=transparent,
             eval_alpha=not no_eval,
             eval_strict=eval_strict,
-            bg_remover=bg_remover,
             recraft_script=str(
                 chop_root / "skills" / "gen-image" / "recraft_bg_remove.py"
             ),
@@ -861,17 +645,12 @@ def _build_app():
         style: str | None = typer.Option(None, help="Override default raccoon style"),
         transparent: bool = typer.Option(
             False,
-            help="Generate on magenta chroma-key background, then strip it via ImageMagick edge-connected flood fill from the 4 corners (preserves interior magenta-tinted pixels)",
-        ),
-        bg_remover: str = typer.Option(
-            "magenta",
-            "--bg-remover",
-            help="Background remover for --transparent: 'magenta' (default — offline flood-fill, ~1s/image, free) or 'recraft' (Recraft API, ~7-15s/image, ~$0.01/call, cleaner soft-mask edges on hair/fur). Recraft requires RECRAFT_API_TOKEN in env or ~/.env. The alpha-mask eval still runs on either output.",
+            help="Generate on a uniform magenta background, then strip it via Recraft's removeBackground API (~$0.01/call, ~7-40s/image, requires RECRAFT_API_TOKEN). Soft-mask edges on hair/fur, no flood-fill failure modes.",
         ),
         no_eval: bool = typer.Option(
             False,
             "--no-eval",
-            help="Skip the post-chroma alpha-mask eval (interior holes, residual magenta, edge fringe). Needs numpy/pillow/scipy — the uv shebang installs them, but bare python3 callers may need this.",
+            help="Skip the post-strip alpha-mask eval (interior holes, edge fringe). Needs numpy/pillow/scipy — the uv shebang installs them, but bare python3 callers may need this.",
         ),
         eval_strict: bool = typer.Option(
             False,
@@ -882,13 +661,6 @@ def _build_app():
         """Generate images in parallel from a JSON manifest."""
         chop_root = resolve_chop_root()
         load_env()
-
-        if bg_remover not in ("magenta", "recraft"):
-            print(
-                f"Error: --bg-remover must be 'magenta' or 'recraft' (got {bg_remover!r})",
-                file=sys.stderr,
-            )
-            raise typer.Exit(1)
 
         if not os.environ.get("GOOGLE_API_KEY"):
             print(
@@ -905,7 +677,6 @@ def _build_app():
             transparent=transparent,
             eval_alpha=not no_eval,
             eval_strict=eval_strict,
-            bg_remover=bg_remover,
             recraft_script=str(
                 chop_root / "skills" / "gen-image" / "recraft_bg_remove.py"
             ),

--- a/skills/image-explore/test_generate.py
+++ b/skills/image-explore/test_generate.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
-"""Unit tests for generate.py pure helpers and the remove_background pipeline.
+"""Unit tests for generate.py pure helpers and the post-strip eval path.
 
 Run with: python3 -m unittest test_generate.py
 
-The remove_background / _scan_border_for_magenta_seeds tests shell out to
-ImageMagick to build tiny synthetic fixtures on the fly. If magick isn't
-on PATH the integration tests skip themselves (keeps the fast-test loop
-green on dev machines without ImageMagick installed).
+The eval tests shell out to ImageMagick to build tiny synthetic alpha
+fixtures on the fly. If magick isn't on PATH the integration tests skip
+themselves (keeps the fast-test loop green on dev machines without
+ImageMagick installed).
+
+Recraft API itself is NOT exercised here — that path requires a network
+round trip and burns credits. The eval functions are general-purpose
+alpha-mask checks that operate on any RGBA image, so the fixtures synth
+their own pre-stripped images.
 """
 
 import shutil
@@ -19,17 +24,12 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent))
 
 from generate import (  # noqa: E402
-    BORDER_SAMPLE_STEP,
     HEALTHY_ALPHA_MAX_PCT,
     HEALTHY_ALPHA_MIN_PCT,
     INTERIOR_HOLE_CLOSE_RADIUS,
-    NEAR_MAGENTA_L1_TOLERANCE,
     _format_eval_card,
-    _parse_srgb,
-    _scan_border_for_magenta_seeds,
     eval_alpha,
     evaluate_strip,
-    remove_background,
 )
 
 
@@ -44,198 +44,15 @@ def _draw_image(magick_bin, out_path, *args):
     subprocess.run(cmd, check=True, capture_output=True)
 
 
-class TestParseSrgb(unittest.TestCase):
-    """_parse_srgb handles the string forms magick emits via %[pixel:...]."""
-
-    def test_srgb_triplet(self):
-        self.assertEqual(_parse_srgb("srgb(255,0,255)"), (255, 0, 255))
-
-    def test_srgba_quadruplet_returns_rgb_only(self):
-        # magick sometimes emits srgba(r,g,b,a); we only need the first 3.
-        self.assertEqual(_parse_srgb("srgba(68,72,43,255)"), (68, 72, 43))
-
-    def test_leading_and_trailing_whitespace_tolerated(self):
-        self.assertEqual(_parse_srgb("  srgb(10,20,30)  "), (10, 20, 30))
-
-    def test_unrecognized_format_returns_none(self):
-        self.assertIsNone(_parse_srgb("#FF00FF"))
-        self.assertIsNone(_parse_srgb("rgb(1,2,3)"))
-        self.assertIsNone(_parse_srgb(""))
-
-    def test_garbage_inside_parens_returns_none(self):
-        self.assertIsNone(_parse_srgb("srgb(not,a,number)"))
-        self.assertIsNone(_parse_srgb("srgb(1,2)"))
-
-
-class TestNearMagentaToleranceInvariants(unittest.TestCase):
-    """The tolerance constant is deliberately narrower than the flood fuzz."""
-
-    def test_pure_magenta_within_tolerance(self):
-        r, g, b = 255, 0, 255
-        self.assertLessEqual(
-            abs(r - 255) + abs(g) + abs(b - 255), NEAR_MAGENTA_L1_TOLERANCE
-        )
-
-    def test_typical_grass_outside_tolerance(self):
-        # Real failing sample from the raccoon-hill regression — grass pixel
-        # that ended up in a corner and seeded the flood at 30% fuzz.
-        r, g, b = 68, 72, 43
-        self.assertGreater(
-            abs(r - 255) + abs(g) + abs(b - 255), NEAR_MAGENTA_L1_TOLERANCE
-        )
-
-
-@REQUIRES_MAGICK
-class TestScanBorderForMagentaSeeds(unittest.TestCase):
-    """Seed scanner must find magenta pixels along the border and reject non-magenta."""
-
-    def setUp(self):
-        self.tmpdir = tempfile.mkdtemp()
-        # 200x200 keeps the test fast while still yielding many sample points
-        # at the default BORDER_SAMPLE_STEP=8.
-        self.size = 200
-
-    def tearDown(self):
-        import shutil as _sh
-
-        _sh.rmtree(self.tmpdir, ignore_errors=True)
-
-    def _scan(self, image_path):
-        seeds, err = _scan_border_for_magenta_seeds(
-            MAGICK, str(image_path), self.size, self.size
-        )
-        self.assertIsNone(err, f"unexpected scan error: {err}")
-        return seeds
-
-    def test_all_magenta_border_yields_many_seeds(self):
-        # Pure magenta canvas — every sampled border pixel is a seed.
-        path = Path(self.tmpdir) / "full-magenta.png"
-        _draw_image(MAGICK, path, "-size", f"{self.size}x{self.size}", "xc:#FF00FF")
-        seeds = self._scan(path)
-        # With step=8 on a 200x200, we sample 4*(200/8) = 100 unique edge points
-        # (some corner duplicates cancel because top/bottom/left/right each hit
-        # every 8px independently). Seeds should be well over half.
-        self.assertGreater(len(seeds), 50)
-
-    def test_grass_in_bottom_corners_still_finds_top_seeds(self):
-        # Reproduces the raccoon-hill regression: top half magenta, bottom
-        # half grass. Scanner should seed from the top edge + the top portion
-        # of left/right edges, and skip the bottom.
-        path = Path(self.tmpdir) / "half-grass.png"
-        _draw_image(
-            MAGICK,
-            path,
-            "-size",
-            f"{self.size}x{self.size}",
-            "xc:#FF00FF",
-            "-fill",
-            "#44482b",  # grass color
-            "-draw",
-            f"rectangle 0,{self.size // 2} {self.size - 1},{self.size - 1}",
-        )
-        seeds = self._scan(path)
-        self.assertGreater(
-            len(seeds), 0, "should find seeds on the magenta portion of the border"
-        )
-        # No seed should come from the grass half (y > size/2).
-        for x, y in seeds:
-            self.assertLess(
-                y,
-                self.size // 2 + BORDER_SAMPLE_STEP,
-                f"seed {(x, y)} landed in the grass half — scanner should reject it",
-            )
-
-    def test_no_magenta_on_border_returns_empty(self):
-        # Solid green canvas — nothing on the border is near magenta.
-        path = Path(self.tmpdir) / "no-magenta.png"
-        _draw_image(MAGICK, path, "-size", f"{self.size}x{self.size}", "xc:#2E8B2E")
-        seeds = self._scan(path)
-        self.assertEqual(
-            seeds, [], "subject-fills-frame case must return empty seed list"
-        )
-
-
-@REQUIRES_MAGICK
-class TestRemoveBackgroundIntegration(unittest.TestCase):
-    """End-to-end: remove_background on synthetic fixtures."""
-
-    def setUp(self):
-        self.tmpdir = Path(tempfile.mkdtemp())
-
-    def tearDown(self):
-        import shutil as _sh
-
-        _sh.rmtree(self.tmpdir, ignore_errors=True)
-
-    def _alpha_mean_percent(self, path):
-        assert MAGICK is not None, "REQUIRES_MAGICK should have skipped this test"
-        out = subprocess.check_output(
-            [MAGICK, str(path), "-format", "%[fx:mean.a*100]", "info:"], text=True
-        )
-        return float(out.strip())
-
-    def test_magenta_border_colored_center_strips_cleanly(self):
-        # 200x200 with a 40px solid magenta border on all four sides and a
-        # solid green center. Post-strip: alpha mean should be ~ (center area
-        # / total) = (120*120)/(200*200) = 36%.
-        path = self.tmpdir / "bordered.png"
-        _draw_image(
-            MAGICK,
-            path,
-            "-size",
-            "200x200",
-            "xc:#FF00FF",
-            "-fill",
-            "#2E8B2E",
-            "-draw",
-            "rectangle 40,40 159,159",
-        )
-        ok, err = remove_background(str(path))
-        self.assertTrue(ok, f"expected success, got error: {err}")
-        alpha = self._alpha_mean_percent(path)
-        self.assertGreater(alpha, 25.0, "subject was eaten")
-        self.assertLess(alpha, 50.0, "too much background survived")
-
-    def test_subject_fills_frame_returns_guarded_error(self):
-        # Solid green canvas — no magenta on the border. Must NOT silently
-        # strip (the old regression eats everything). Must return an error
-        # mentioning how to fix the prompt.
-        path = self.tmpdir / "no-magenta.png"
-        _draw_image(MAGICK, path, "-size", "200x200", "xc:#2E8B2E")
-        ok, err = remove_background(str(path))
-        self.assertFalse(ok, "should refuse to strip when no border magenta")
-        self.assertIsNotNone(err)
-        self.assertIn("magenta", err.lower())
-
-    def test_grass_in_bottom_corners_now_strips_instead_of_eating_subject(self):
-        # The regression fixture: magenta top half, grass bottom half. Old
-        # algorithm (4-corner flood) ate the whole canvas because the bottom
-        # corners started the flood from grass. New algorithm must strip
-        # only the top half.
-        path = self.tmpdir / "half-grass.png"
-        _draw_image(
-            MAGICK,
-            path,
-            "-size",
-            "200x200",
-            "xc:#FF00FF",
-            "-fill",
-            "#44482b",
-            "-draw",
-            "rectangle 0,100 199,199",
-        )
-        ok, err = remove_background(str(path))
-        self.assertTrue(ok, f"expected success, got error: {err}")
-        alpha = self._alpha_mean_percent(path)
-        # Top 100 rows were magenta (should become transparent), bottom 100
-        # were grass (should remain opaque). Expect alpha ~50%.
-        self.assertGreater(alpha, 40.0, "old-style failure mode — scanner ate too much")
-        self.assertLess(alpha, 60.0, "scanner missed magenta on the top half")
-
-
 @REQUIRES_MAGICK
 class TestEvaluateStrip(unittest.TestCase):
-    """evaluate_strip reports metrics + warnings; same thresholds as the integration tests."""
+    """evaluate_strip reports general-purpose alpha-mean metrics + warnings.
+
+    The function is bg-removal-mechanism-agnostic — it just measures the
+    alpha channel of the finished RGBA image, so the same thresholds
+    apply whether the upstream stripper was Recraft, the old flood-fill,
+    or anything else.
+    """
 
     def setUp(self):
         self.tmpdir = Path(tempfile.mkdtemp())
@@ -270,7 +87,7 @@ class TestEvaluateStrip(unittest.TestCase):
 
     def test_subject_eaten_reports_loud_warning(self):
         # Mostly transparent canvas with a 5x5 dot of opacity — alpha far below
-        # the HEALTHY_ALPHA_MIN_PCT threshold. Matches the regression failure mode.
+        # the HEALTHY_ALPHA_MIN_PCT threshold. The "subject eaten" failure mode.
         path = self.tmpdir / "mostly-eaten.png"
         _draw_image(
             MAGICK,
@@ -287,15 +104,14 @@ class TestEvaluateStrip(unittest.TestCase):
         self.assertEqual(metrics["status"], "subject_eaten")
         self.assertIsNotNone(warning)
         self.assertIn("subject", warning.lower())
-        self.assertIn("magenta border", warning.lower())
         self.assertLess(metrics["alpha_mean_pct"], HEALTHY_ALPHA_MIN_PCT)
 
     def test_nothing_stripped_reports_loud_warning(self):
         # All-opaque canvas written as PNG32 (alpha channel forced). Plain PNG
         # strips an all-opaque alpha channel as a size optimization, which would
-        # make the read-back report alpha=0. After remove_background() the
-        # output always has an alpha channel, so this fixture is closer to the
-        # real runtime input to evaluate_strip.
+        # make the read-back report alpha=0. After remove_background_recraft()
+        # the output always has an alpha channel, so this fixture is closer to
+        # the real runtime input to evaluate_strip.
         path = self.tmpdir / "all-opaque.png"
         assert MAGICK is not None, "REQUIRES_MAGICK should have skipped this test"
         subprocess.run(
@@ -333,14 +149,13 @@ class TestEvaluateStrip(unittest.TestCase):
 
 
 class TestEvalAlphaInteriorHoles(unittest.TestCase):
-    """eval_alpha must catch flood-fill bleed-through channels.
+    """eval_alpha catches interior holes via mask-closing set difference.
 
-    The issue-#171 failure: a real interior hole gets connected to the
-    image border by a 1–2-pixel-wide transparent channel the flood-fill
-    drilled through a narrow part of the character (neck, between legs).
-    A naive "transparent pixels not touching border" check then reports
-    zero holes. Morphological closing of the opaque mask seals the thin
-    channels, and the hole re-emerges as an enclosed component.
+    General-purpose alpha-mask check: works on any RGBA output regardless
+    of how the bg was removed. The thin-channel test case below was the
+    motivating regression for the close_radius/min_component_px tuning,
+    and remains a useful guard against any stripper that drills narrow
+    transparent paths through a silhouette.
     """
 
     def _build_rgba(self, opaque_mask):
@@ -388,7 +203,7 @@ class TestEvalAlphaInteriorHoles(unittest.TestCase):
         """Enclosed transparent disc with no bleed channel — interior at
         both r=0 and r=1. Set-difference zeroes it out: could be design-
         intentional (donut hole, glasses rim), so give benefit of doubt.
-        The metric targets flood-fill bleed-through specifically.
+        The metric targets bleed-through specifically.
         """
         self._try_import_numpy()
         import numpy as np  # noqa: PLC0415
@@ -421,9 +236,11 @@ class TestEvalAlphaInteriorHoles(unittest.TestCase):
         self.assertEqual(metrics["interior_hole_px"], 0)
 
     def test_bleed_channel_hole_still_flagged_after_closing(self):
-        """The issue-#171 failure mode: hole connected to outside via a
-        thin 1-pixel channel. Without closing, reports 0. With the default
-        closing radius, the channel is sealed and the hole re-emerges.
+        """Hole connected to outside via a thin 1-pixel channel. Without
+        closing, reports 0. With the default closing radius, the channel
+        is sealed and the hole re-emerges. Original motivating case for
+        the close_radius tuning (issue-#171); still a useful guard for
+        any stripper that drills narrow channels through the silhouette.
         """
         self._try_import_numpy()
         import numpy as np  # noqa: PLC0415
@@ -433,7 +250,7 @@ class TestEvalAlphaInteriorHoles(unittest.TestCase):
         body = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 80**2
         hole = (yy - h // 2) ** 2 + (xx - w // 2) ** 2 <= 20**2
         # 1-pixel-wide channel from the hole straight out through the body
-        # to the image border. Emulates a flood-fill bleed path.
+        # to the image border. Emulates a bleed path.
         channel = (np.abs(xx - w // 2) <= 0) & (yy >= h // 2)
         opaque = body & ~hole & ~channel
 

--- a/skills/image-explore/test_generate.py
+++ b/skills/image-explore/test_generate.py
@@ -20,16 +20,22 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).parent))
 
 from generate import (  # noqa: E402
+    GEMINI_FAST_MODEL,
+    GEMINI_PRO_MODEL,
     HEALTHY_ALPHA_MAX_PCT,
     HEALTHY_ALPHA_MIN_PCT,
     INTERIOR_HOLE_CLOSE_RADIUS,
+    Direction,
+    GenerateConfig,
     _format_eval_card,
     eval_alpha,
     evaluate_strip,
+    generate_one,
 )
 
 
@@ -297,6 +303,58 @@ class TestEvalAlphaInteriorHoles(unittest.TestCase):
         metrics = self._save_and_eval(self._build_rgba(opaque))
         # Each speckle is 1 px (<100), so they should all be filtered.
         self.assertLess(metrics["interior_hole_largest_px"], 100)
+
+
+class TestGeminiModelSelection(unittest.TestCase):
+    """generate_one plumbs config.gemini_model into the subprocess env via
+    GEMINI_IMAGE_MODEL, which gemini-image.sh reads to derive the API URL.
+
+    These tests mock subprocess.run so they don't hit the network; they
+    just assert on the env dict the subprocess was called with.
+    """
+
+    def _make_config(self, gemini_model):
+        return GenerateConfig(
+            gemini_script="/fake/gemini-image.sh",
+            style="fake-style",
+            ref_image=None,
+            aspect="3:4",
+            transparent=False,  # skip Recraft + eval paths
+            gemini_model=gemini_model,
+        )
+
+    def _make_direction(self):
+        return Direction(scene="fake scene", shirt="X", output="/tmp/fake.webp")
+
+    def test_fast_default_passes_flash_model_in_env(self):
+        config = self._make_config(GEMINI_FAST_MODEL)
+        direction = self._make_direction()
+
+        with patch("generate.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            generate_one(direction, config)
+
+        self.assertEqual(mock_run.call_count, 1)
+        call_kwargs = mock_run.call_args.kwargs
+        env = call_kwargs["env"]
+        self.assertEqual(env["GEMINI_IMAGE_MODEL"], "gemini-3.1-flash-image-preview")
+
+    def test_no_fast_passes_pro_model_in_env(self):
+        config = self._make_config(GEMINI_PRO_MODEL)
+        direction = self._make_direction()
+
+        with patch("generate.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="", stderr=""
+            )
+            generate_one(direction, config)
+
+        self.assertEqual(mock_run.call_count, 1)
+        call_kwargs = mock_run.call_args.kwargs
+        env = call_kwargs["env"]
+        self.assertEqual(env["GEMINI_IMAGE_MODEL"], "gemini-3-pro-image-preview")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

PR #181 made Recraft the opt-in bg-remover under `--bg-remover recraft`. Stage 1 expanded test showed Recraft cleaner on the v2/v3 contaminated cases — the preservative failure modes (occasional halo, missed wisp) beat the destructive ones (subject_eaten, swiss-cheese interior). With Recraft proven superior, the magenta flood-fill path is dead weight that nobody should reach for again.

This PR removes the entire magenta path so Recraft is the *only* bg-removal backend. ~420 net LOC deleted, simpler maintenance surface, no `--bg-remover` flag to think about.

## What's gone

`skills/image-explore/generate.py`:

- `remove_background()` (border-seeded flood fill) and helpers (`_scan_border_for_magenta_seeds`, `_parse_srgb`)
- Tunables: `BORDER_SAMPLE_STEP`, `NEAR_MAGENTA_L1_TOLERANCE`, `FLOOD_FUZZ_PERCENT`
- `--bg-remover {magenta|recraft}` flag (collapsed: `--transparent` always uses Recraft)
- `GenerateConfig.bg_remover` field and the dispatch branch in `generate_one()`
- `residual_magenta_px` metric (magenta-specific) and its `EVAL_ALPHA_THRESHOLDS` entry
- `shutil` / `tempfile` imports the magenta path needed (no longer used at module scope)

`skills/image-explore/test_generate.py`:

- `TestParseSrgb`, `TestNearMagentaToleranceInvariants`, `TestScanBorderForMagentaSeeds`, `TestRemoveBackgroundIntegration` — 13 magenta-specific tests gone

`skills/gen-image/SKILL.md`:

- Long `--transparent` flood-fill paragraph replaced with one-line Recraft description
- `--bg-remover` documentation dropped
- Configuration: `RECRAFT_API_TOKEN` now marked required
- "Never chain chroma passes on different magenta tones" tip removed (magenta-specific)
- Eval section updated: `eval_alpha` now lists `interior_hole_px` + `edge_fringe_px` (no `residual_magenta_px`)

## What's kept

- `skills/gen-image/recraft_bg_remove.py` — unchanged code path (the new way), light comment edits to drop "drop-in replacement for magenta" framing
- `skills/gen-image/raccoon-style.txt` — unchanged (still tells Gemini to render on `#FF00FF`, which gives Recraft a uniform background to segment cleanly)
- `skills/gen-image/gemini-image.sh` — upstream of bg removal, untouched
- `evaluate_strip()` and `eval_alpha()` — both general-purpose alpha-mask checks. The `interior_hole_px` morphological-closing trick still earns its keep against any future stripper that drills narrow channels through a silhouette. The `residual_magenta_px` field is the only field tied to the magenta path, so that one was dropped.
- `GREENSCREEN_PROMPT` constant — gen-side instruction to Gemini, kept as upstream context. Recraft works on any background, but a clean uniform one segments more reliably.

## Tests

```
$ uvx --with numpy --with pillow --with scipy python3 -m unittest discover -s skills/image-explore -p 'test_*.py'
..........
Ran 10 tests in 0.296s
OK
```

10/10 pass with deps; 5 skip cleanly on stock python3 without scipy/numpy/pillow (existing pattern). Pre-PR baseline was 23 tests (5 skipped) — the 13 removed were the magenta-specific suites.

`just fast-test` has pre-existing failures in `skills/harden-telegram/server/tests/test_watchdog.py` (5 errors, 2 failures) that exist on `upstream/main` — unrelated to this PR. Per the chop-conventions CLAUDE.md `Pre-commit test hook can corrupt the outer repo` workaround (#109), committed with `SKIP=test`.

## Test plan

- [x] Run `python3 -m unittest discover -s skills/image-explore -p 'test_*.py'` — 10/10 pass
- [x] Run with deps: `uvx --with numpy --with pillow --with scipy ...` — 10/10 pass, no skips
- [x] `ruff check` and `ruff format --check` clean on all 4 changed files
- [x] `prettier --check` clean on `SKILL.md`
- [x] `generate.py --help` prints, `single --help` shows `--transparent` without `--bg-remover`
- [ ] One end-to-end `--transparent` smoke against Recraft with a fresh raccoon (Igor's call — costs $0.01 each)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `--bg-remover` CLI option; `--transparent` now uses unified background removal.
  * `--transparent` now requires `RECRAFT_API_TOKEN` environment variable (previously optional).
  * Transparent evaluation output changed: residual magenta metric removed; interior hole and fringe metrics retained.

* **Documentation**
  * Updated transparent background generation documentation with configuration requirements and workflow details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->