### PR TITLE
fix(up-to-date): compute can_force_align from real cherry data on main

### DIFF
--- a/skills/up-to-date/diagnose.py
+++ b/skills/up-to-date/diagnose.py
@@ -309,9 +309,7 @@ def classify_machine(
         if mac_ver_nonempty:
             reasons.append("platform.system()==Darwin + mac_ver non-empty")
             return "mac", reasons
-        reasons.append(
-            "platform.system()==Darwin but mac_ver empty — falling through"
-        )
+        reasons.append("platform.system()==Darwin but mac_ver empty — falling through")
         return "unknown", reasons
     if system == "Linux":
         if home_developer_exists:
@@ -610,7 +608,9 @@ def check_shared_claude_md(
 # ---------- post-up-to-date hook detection ----------
 
 
-def check_post_up_to_date(repo_toplevel: Path | None) -> tuple[str | None, list[dict[str, Any]]]:
+def check_post_up_to_date(
+    repo_toplevel: Path | None,
+) -> tuple[str | None, list[dict[str, Any]]]:
     """Locate `<repo>/.claude/post-up-to-date.md` and enforce symlink refusal.
 
     Returns `(path_or_none, errors)`. If the hook exists as a symlink,
@@ -898,9 +898,10 @@ def run_diagnose() -> dict[str, Any]:
     else:
         worktree_entries = parse_worktree_list(worktree_proc.stdout)
 
-    # Run per-branch `git cherry` in parallel. This subsumes the old
-    # single-HEAD cherry call — HEAD is in local_branch_names if it's not
-    # detached, so we get its result from the same batch.
+    # Run per-branch `git cherry` in parallel for the absorption/worktree
+    # audit. HEAD's result comes from this batch when HEAD is a feature
+    # branch; when HEAD *is* the default branch it gets a dedicated call
+    # (head_cherry below) because the batch deliberately excludes it.
     #
     # Include any worktree branch not already in local_branch_names (e.g.
     # a worktree branch from a different remote context). De-dupe via set.
@@ -909,16 +910,32 @@ def run_diagnose() -> dict[str, Any]:
         if wt.branch:
             cherry_targets.add(wt.branch)
     # Skip the source's default branch — we never audit it against itself
-    # for absorption (it IS the absorption target).
+    # for absorption (it IS the absorption target), and downstream
+    # consumers of cherry_by_branch (absorbable_branches, the worktree
+    # "absorbed" flags) rely on it being absent.
     cherry_targets.discard(default_branch)
 
+    # When HEAD is the default branch it was excluded from the batch
+    # above, yet can_force_align and the ahead_patch_* fields still need
+    # real patch-equivalence data — so run a dedicated cherry call for it.
+    # The result stays OUT of cherry_by_branch so the absorption audit
+    # never sees the default branch.
+    head_cherry: CherryAnalysis | None = None
+    total_cherry_calls = len(cherry_targets) + (1 if is_main else 0)
     cherry_by_branch: dict[str, CherryAnalysis] = {}
-    if cherry_targets:
-        with ThreadPoolExecutor(max_workers=min(10, len(cherry_targets))) as pool:
+    if total_cherry_calls:
+        with ThreadPoolExecutor(max_workers=min(10, total_cherry_calls)) as pool:
             cherry_futs = {
                 b: pool.submit(git_proc, "cherry", "-v", src_default, b, check=False)
                 for b in cherry_targets
             }
+            head_cherry_fut = (
+                pool.submit(
+                    git_proc, "cherry", "-v", src_default, branch_name, check=False
+                )
+                if is_main
+                else None
+            )
             for b, fut in cherry_futs.items():
                 proc = fut.result()
                 if proc.returncode != 0:
@@ -927,14 +944,37 @@ def run_diagnose() -> dict[str, Any]:
                     )
                     continue
                 cherry_by_branch[b] = parse_cherry_status(proc.stdout.strip())
+            if head_cherry_fut is not None:
+                proc = head_cherry_fut.result()
+                if proc.returncode != 0:
+                    errors.append(
+                        f"git cherry -v {src_default} {branch_name} failed: "
+                        f"{proc.stderr.strip()}"
+                    )
+                else:
+                    head_cherry = parse_cherry_status(proc.stdout.strip())
 
-    # HEAD's cherry result flows into the existing branch block.
-    cherry = cherry_by_branch.get(
-        branch_name, CherryAnalysis(unique_commits=[], equivalent_commits=[])
-    )
+    # HEAD's cherry result: the dedicated call when HEAD is the default
+    # branch, the batch otherwise. The empty fallback covers detached
+    # HEAD and errored cherry calls.
+    if head_cherry is not None:
+        cherry = head_cherry
+    else:
+        cherry = cherry_by_branch.get(
+            branch_name, CherryAnalysis(unique_commits=[], equivalent_commits=[])
+        )
     ahead_patch_unique_commits = cherry.unique_commits[:10]
     ahead_patch_equivalent_commits = cherry.equivalent_commits[:10]
-    can_force_align = is_main and ahead > 0 and not cherry.unique_commits
+    # True only when a *successful* cherry call proved every ahead commit
+    # patch-equivalent upstream. head_cherry is None when the call failed
+    # (or HEAD isn't the default branch) — never grant force-push license
+    # on missing data.
+    can_force_align = (
+        is_main
+        and ahead > 0
+        and head_cherry is not None
+        and not head_cherry.unique_commits
+    )
 
     leftover_commits = [] if is_main else ahead_patch_unique_commits
 

--- a/skills/up-to-date/test_diagnose.py
+++ b/skills/up-to-date/test_diagnose.py
@@ -692,8 +692,12 @@ class TestRunDiagnoseChopRootUnresolved(unittest.TestCase):
             _git("add", "README.md")
             _git("commit", "-q", "-m", "initial")
 
+            # Build from the scrubbed git_env, NOT os.environ — inheriting
+            # GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE from a pre-commit
+            # runner would redirect diagnose.py's child git calls
+            # (including `git fetch --prune`) into the outer repo (#109).
             env = {
-                **os.environ,
+                **git_env,
                 "CHOP_CONVENTIONS_ROOT": str(Path(td) / "nowhere"),
                 "HOME": str(fake_home),
             }
@@ -725,6 +729,138 @@ class TestRunDiagnoseChopRootUnresolved(unittest.TestCase):
                 f"expected exactly one chop_root_unresolved error, "
                 f"got errors={data['errors']!r}",
             )
+
+
+class TestRunDiagnoseForceAlignOnMain(unittest.TestCase):
+    """Regression tests for can_force_align computed ON the default branch.
+
+    diagnose.py discards the default branch from the parallel `git
+    cherry` batch (it must stay out of the absorption audit), and a
+    prior version then read HEAD's cherry result from that same batch —
+    so on main the lookup always hit the empty fallback and
+    `can_force_align` was True whenever main was ahead for ANY reason,
+    including genuinely unique local commits. That granted destructive
+    force-push license (SKILL.md: true only when every ahead commit is
+    patch-equivalent upstream). The fix runs a dedicated `git cherry`
+    call for HEAD when HEAD *is* the default branch.
+
+    Exercised end-to-end via a subprocess invocation against a real
+    throwaway origin repo + clone, like TestRunDiagnoseChopRootUnresolved.
+    """
+
+    DIAGNOSE_PATH = Path(__file__).parent / "diagnose.py"
+
+    @staticmethod
+    def _scrubbed_env() -> dict[str, str]:
+        # Drop GIT_* vars a pre-commit runner may have set — otherwise
+        # GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE redirect every git
+        # call below (and diagnose.py's child git calls) into the outer
+        # repo running the hook (#109).
+        return {k: v for k, v in os.environ.items() if not k.startswith("GIT_")}
+
+    def _git(self, cwd: Path, *args: str, env: dict[str, str]) -> None:
+        subprocess.run(
+            ["git", *args], cwd=cwd, check=True, capture_output=True, env=env
+        )
+
+    def _configure_identity(self, repo: Path, env: dict[str, str]) -> None:
+        self._git(repo, "config", "user.email", "test@test", env=env)
+        self._git(repo, "config", "user.name", "test", env=env)
+        self._git(repo, "config", "commit.gpgsign", "false", env=env)
+
+    def _setup_origin_and_clone(
+        self, td: str, git_env: dict[str, str]
+    ) -> tuple[Path, Path]:
+        """Origin repo with one commit on `main`, plus a clone of it."""
+        origin = Path(td) / "origin"
+        local = Path(td) / "local"
+        origin.mkdir()
+        self._git(origin, "init", "-q", "-b", "main", env=git_env)
+        self._configure_identity(origin, git_env)
+        (origin / "README.md").write_text("# r\n", encoding="utf-8")
+        self._git(origin, "add", "README.md", env=git_env)
+        self._git(origin, "commit", "-q", "-m", "initial", env=git_env)
+        subprocess.run(
+            ["git", "clone", "-q", str(origin), str(local)],
+            cwd=td,
+            check=True,
+            capture_output=True,
+            env=git_env,
+        )
+        self._configure_identity(local, git_env)
+        return origin, local
+
+    def _commit_file(
+        self,
+        repo: Path,
+        filename: str,
+        content: str,
+        message: str,
+        git_env: dict[str, str],
+    ) -> None:
+        (repo / filename).write_text(content, encoding="utf-8")
+        self._git(repo, "add", filename, env=git_env)
+        self._git(repo, "commit", "-q", "-m", message, env=git_env)
+
+    def _run_diagnose(self, local: Path, td: str, git_env: dict[str, str]) -> dict:
+        fake_home = Path(td) / "fake-home"
+        fake_home.mkdir(exist_ok=True)
+        env = {
+            **git_env,
+            "CHOP_CONVENTIONS_ROOT": str(Path(td) / "nowhere"),
+            "HOME": str(fake_home),
+        }
+        proc = subprocess.run(
+            [sys.executable, str(self.DIAGNOSE_PATH)],
+            cwd=local,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        return json.loads(proc.stdout)
+
+    def test_unique_local_commit_on_main_blocks_force_align(self):
+        """Main ahead with genuinely unique work → force-align forbidden."""
+        with tempfile.TemporaryDirectory() as td:
+            git_env = self._scrubbed_env()
+            _, local = self._setup_origin_and_clone(td, git_env)
+            self._commit_file(
+                local, "feature.txt", "local-only work\n", "local-only work", git_env
+            )
+
+            branch = self._run_diagnose(local, td, git_env)["branch"]
+            self.assertTrue(branch["is_main"])
+            self.assertEqual(branch["ahead"], 1)
+            self.assertFalse(
+                branch["can_force_align"],
+                "can_force_align must be False when main's ahead commit is "
+                "unique local work — force-aligning would destroy it",
+            )
+            self.assertEqual(len(branch["ahead_patch_unique_commits"]), 1)
+            self.assertEqual(branch["ahead_patch_equivalent_commits"], [])
+
+    def test_patch_equivalent_commit_on_main_allows_force_align(self):
+        """Main ahead only by a commit already upstream under a different
+        SHA (same patch-id) → force-align loses no work and is allowed."""
+        with tempfile.TemporaryDirectory() as td:
+            git_env = self._scrubbed_env()
+            origin, local = self._setup_origin_and_clone(td, git_env)
+            # Land the identical change on both sides with different
+            # commit messages → different SHAs, same patch-id.
+            self._commit_file(
+                local, "feature.txt", "shared change\n", "local copy", git_env
+            )
+            self._commit_file(
+                origin, "feature.txt", "shared change\n", "upstream copy", git_env
+            )
+
+            branch = self._run_diagnose(local, td, git_env)["branch"]
+            self.assertTrue(branch["is_main"])
+            self.assertEqual(branch["ahead"], 1)
+            self.assertTrue(branch["can_force_align"])
+            self.assertEqual(branch["ahead_patch_unique_commits"], [])
+            self.assertEqual(len(branch["ahead_patch_equivalent_commits"]), 1)
 
 
 class TestGhPrListMergedHeads(unittest.TestCase):


### PR DESCRIPTION
## What

`diagnose.py` reported `can_force_align: true` whenever local `main` was ahead of `source/main` for **any** reason — including genuinely unique local commits. Its documented contract (SKILL.md) is: true only when every ahead commit is patch-equivalent upstream, so force-aligning loses no work. The flag drives the skill's `git pull --rebase` + `git push --force-with-lease` path, so the bug granted destructive force-push license on real, unpushed work.

Bead: **chop-conventions-bmo**.

## Why (failure scenario)

`run_diagnose` discards the default branch from the parallel `git cherry` batch — correctly, since that batch feeds the absorption audit and main must never be audited against itself. But HEAD's cherry result was read from that same batch:

```python
cherry_targets.discard(default_branch)          # main never gets a cherry call
...
cherry = cherry_by_branch.get(branch_name, CherryAnalysis([], []))  # on main: always the empty fallback
can_force_align = is_main and ahead > 0 and not cherry.unique_commits  # → True whenever main is ahead
```

Scenario: you commit directly to local `main` (unique work, not upstream), run `/up-to-date`, and the report says force-align is safe. Following the skill's recommended recovery discards your commits. As a side effect, `ahead_patch_unique_commits` / `ahead_patch_equivalent_commits` were silently always `[]` on main, and the comment above the batch falsely claimed HEAD's result came from it.

## Fix

- When HEAD **is** the default branch, run a dedicated `git cherry -v <src>/<default> <branch>` call in the same thread pool. The result stays **out** of `cherry_by_branch`, so the absorption audit and the worktree `absorbed` classification (whose `None` branch relies on main being absent) are unchanged.
- `can_force_align` now fails closed: it requires a *successful* cherry result — an errored cherry call no longer yields force-push license.
- Fixed the stale comment.
- Test-hazard fix (#109 follow-up): `TestRunDiagnoseChopRootUnresolved` built the diagnose subprocess env from `os.environ`, re-inheriting `GIT_DIR`/`GIT_INDEX_FILE`/`GIT_WORK_TREE` from a pre-commit runner into diagnose.py's child git calls (which include `git fetch --prune` against the outer repo). Now built from the already-scrubbed `git_env`.

## Tests

New `TestRunDiagnoseForceAlignOnMain` runs `run_diagnose` end-to-end (subprocess, throwaway origin repo + clone, scrubbed env), on the default branch:

- unique ahead commit → `can_force_align` **False**, commit listed in `ahead_patch_unique_commits`
- patch-equivalent ahead commit (same diff cherry-picked upstream under a different SHA) → `can_force_align` **True**, listed in `ahead_patch_equivalent_commits`

Both tests **fail against the pre-fix code** (verified by stashing the fix: the unique-commit case reported `can_force_align: true`). Full suite: `test_diagnose.py` + `test_hook_trust.py` — **93 passed**. Pre-commit `test` hook skipped for the known pre-existing `skills/harden-telegram/server/tests/test_watchdog.py` failures (unrelated); ruff lint/format hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)