### PR TITLE
harden-telegram: delivery attribution + doctor DELIVERY check (silent-loss modes go red)

### DIFF
--- a/skills/harden-telegram/SKILL.md
+++ b/skills/harden-telegram/SKILL.md
@@ -76,6 +76,21 @@ Runs every check, prints ✅/⚠️/❌ per section, tails `server.log`, shows s
 
 Read the output top-to-bottom. If everything is green, say so and stop. If anything is red, proceed to Tier 2 for redeploys or Tier 3 for known failure modes.
 
+### DELIVERY check (multi-session race)
+
+`delivered = 1` alone is anonymous. Every Claude session spawns its own bun `server.ts`, and **all of them poll the same `inbound.db`** — whichever bridge wakes first claims the row and delivers it to _its_ session. With N sessions on one machine (igor-city deployments, stale sessions), a message can land in a session nobody is watching while every per-chain check stays green. That's the 2026-07-22 failure: rows 5884/5888 marked delivered, never reached the primary Larry session, doctor green.
+
+The doctor's `DELIVERY` section detects this:
+
+- ❌ `delivery race: N competing bridges polling inbound.db` — more than one telegram bridge is live. Red, not a warning: the race itself silently loses messages — whichever bridge wakes first claims the row, and every other session (including the one you're watching) never sees it.
+- ❌ `recent inbound delivered to foreign session(s): row <id>→<identity>` — one of the last 10 delivered rows is <1h old and its `delivered_to` stamp belongs to a bridge outside this Claude session. Messages are actively being lost from this session's perspective.
+- ✅ `single bridge polling inbound.db` / `last N delivered rows: X this session, Y unattributed, Z foreign >1h old` — healthy.
+- · Pre-migration DBs (no `delivered_to` column) skip attribution with a note — never a crash. Old rows stay NULL; restarting `telegram_bot.py` applies the idempotent `ALTER TABLE`.
+
+Attribution mechanics: `server.ts` stamps `inbound.delivered_to` with its bridge identity (`BRIDGE_ID`) whenever it marks a row delivered — `CLAUDE_CODE_SESSION_ID` when the plugin env provides it (verified present on plugin-spawned bridges), else `hostname:pid:starttime`. `telegram_bot.py` owns the schema and adds the column on startup. The doctor matches stamps against this session's bridges by session id (read from `/proc/<pid>/environ`) with a pid fallback.
+
+The related `SESSION` check — claude launched without `--channels plugin:telegram@claude-plugins-official` — is also ❌ as of the same incident. The other half of the 2026-07-22 failure was a primary session resumed without `--channels`: inbound could never surface there, and the doctor printed that as a ⚠️ while still exiting green. A session that cannot receive inbound is a broken chain; the check keeps its relaunch hint. Intentionally send-only sessions can ignore that specific red.
+
 ### Architecture (one-paragraph recap)
 
 Two processes share the Telegram MCP responsibility. `telegram_bot.py` is the persistent Python poller — owns `getUpdates`, writes every event to `~/larry-telegram/inbound.db` (SQLite WAL), survives Claude restarts, singleton via `flock`. `server.ts` is the ephemeral bun MCP bridge — reads undelivered rows, emits MCP notifications, dies with the Claude session. Flow: `Telegram → telegram_bot.py → inbound.db → bot.sock wakeup → server.ts catchup → MCP → Claude`. Dual-reaction liveness: 👀 (inner, bot.py) + 🫡 (outer, server.ts). Both glyphs on a message means both halves of the pipeline ran.

--- a/skills/harden-telegram/server/server.ts
+++ b/skills/harden-telegram/server/server.ts
@@ -22,7 +22,7 @@ import { z } from 'zod'
 import { Bot, InlineKeyboard, InputFile } from 'grammy'
 import type { ReactionTypeEmoji } from 'grammy/types'
 import { readFileSync, writeFileSync, mkdirSync, statSync, renameSync, realpathSync, chmodSync, appendFileSync } from 'fs'
-import { homedir } from 'os'
+import { homedir, hostname } from 'os'
 import { join, extname, sep } from 'path'
 import { Database } from 'bun:sqlite'
 import { createConnection, type Socket } from 'net'
@@ -562,7 +562,8 @@ CREATE TABLE IF NOT EXISTS inbound (
     callback_data TEXT,
     gate_action TEXT NOT NULL,
     delivered INTEGER DEFAULT 0,
-    error TEXT
+    error TEXT,
+    delivered_to TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_inbound_undelivered ON inbound(delivered, id) WHERE delivered = 0;
@@ -591,6 +592,19 @@ type InboundRow = {
   error: string | null
 }
 
+// This bridge's identity for delivery attribution (bead igor2-bgt.25).
+// delivered=1 alone is anonymous: with N bun bridges (one per Claude session)
+// racing to claim rows from the same inbound.db, a message can be delivered
+// to a session the operator isn't watching with zero signal (rows 5884/5888,
+// 2026-07-22). Every claim stamps delivered_to with this id so the doctor's
+// DELIVERY check can flag foreign-session deliveries. Prefer the harness-
+// provided session id (present in plugin-spawned env — verified 2026-07-22);
+// fall back to hostname:pid:starttime, where starttime (ms epoch of process
+// start via performance.timeOrigin) disambiguates pid reuse.
+const BRIDGE_ID =
+  process.env.CLAUDE_CODE_SESSION_ID ??
+  `${hostname()}:${process.pid}:${Math.round(performance.timeOrigin)}`
+
 // Ensure the base directory exists — telegram_bot.py normally creates it,
 // but if server.ts starts first the bun:sqlite open would fail on ENOENT.
 mkdirSync(BASE_DIR, { recursive: true, mode: 0o700 })
@@ -610,7 +624,17 @@ try {
     process.exit(1)
   }
   inboundDb.run(INBOUND_SCHEMA)
-  log(`telegram channel: inbound.db opened at ${INBOUND_DB_PATH}`)
+  // delivered_to migration — telegram_bot.py owns the schema and applies the
+  // same guarded ALTER on startup, but this bridge may open a DB created by
+  // an older bot. Idempotent: ALTER only when the column is missing.
+  const inboundCols = inboundDb
+    .query<{ name: string }, []>('PRAGMA table_info(inbound)')
+    .all()
+  if (!inboundCols.some(c => c.name === 'delivered_to')) {
+    inboundDb.run('ALTER TABLE inbound ADD COLUMN delivered_to TEXT')
+    log('telegram channel: migrated inbound.db — added delivered_to column')
+  }
+  log(`telegram channel: inbound.db opened at ${INBOUND_DB_PATH} bridge_id=${BRIDGE_ID}`)
 } catch (err) {
   log(`telegram channel: failed to open inbound.db: ${err} — exiting`)
   process.exit(1)
@@ -627,10 +651,12 @@ const selectUndelivered = inboundDb.query<InboundRow, []>(
    ORDER BY id`,
 )
 
-// Mark delivered. BEGIN IMMEDIATE surfaces lock conflicts at the statement
-// boundary rather than at COMMIT (faster error path under contention).
-const markDelivered = inboundDb.query<unknown, [number]>(
-  'UPDATE inbound SET delivered = 1 WHERE id = ?',
+// Mark delivered + stamp WHICH bridge claimed the row (delivery attribution,
+// see BRIDGE_ID above). BEGIN IMMEDIATE surfaces lock conflicts at the
+// statement boundary rather than at COMMIT (faster error path under
+// contention).
+const markDelivered = inboundDb.query<unknown, [string, number]>(
+  'UPDATE inbound SET delivered = 1, delivered_to = ? WHERE id = ?',
 )
 
 // ---------------------------------------------------------------------------
@@ -696,14 +722,14 @@ async function deliverRow(row: InboundRow): Promise<void> {
       break
     default:
       log(`telegram channel: unknown message_type '${row.message_type}' for row id=${row.id} — marking delivered`)
-      markDelivered.run(row.id)
+      markDelivered.run(BRIDGE_ID, row.id)
       return
   }
 
   // Mark before the outer reaction — reaction is cosmetic (UX, not durability)
   // and swallows errors, so we don't want a botched reaction to re-deliver
   // the row on the next catch-up pass.
-  markDelivered.run(row.id)
+  markDelivered.run(BRIDGE_ID, row.id)
 
   // OUTER reaction — 🫡 liveness signal. Skip for permission_reply: bot.py
   // already set the outcome glyph (✔️/✖️) and free-tier reactions replace

--- a/skills/harden-telegram/server/telegram_bot.py
+++ b/skills/harden-telegram/server/telegram_bot.py
@@ -73,12 +73,34 @@ CREATE TABLE IF NOT EXISTS inbound (
     callback_data TEXT,
     gate_action TEXT NOT NULL,
     delivered INTEGER DEFAULT 0,
-    error TEXT
+    error TEXT,
+    delivered_to TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_inbound_undelivered ON inbound(delivered, id) WHERE delivered = 0;
 CREATE INDEX IF NOT EXISTS idx_inbound_ts ON inbound(ts);
 """
+
+# Columns added after the original CREATE TABLE shipped. "CREATE TABLE IF NOT
+# EXISTS" is a no-op on existing DBs, so every later column also needs an
+# idempotent guarded ALTER applied at startup. Keep SCHEMA above in sync so
+# fresh DBs and migrated DBs converge on the same shape.
+INBOUND_MIGRATIONS: tuple[tuple[str, str], ...] = (
+    # delivered_to (bead igor2-bgt.25): identity of the server.ts bridge that
+    # marked the row delivered. delivered=1 alone is anonymous — with several
+    # bun bridges racing on one inbound.db, a row can be claimed by a session
+    # the operator isn't watching. server.ts stamps this on claim (see its
+    # BRIDGE_ID); the doctor's DELIVERY check reads it. Old rows stay NULL.
+    ("delivered_to", "ALTER TABLE inbound ADD COLUMN delivered_to TEXT"),
+)
+
+
+def migrate_inbound_schema(conn: sqlite3.Connection) -> None:
+    """Apply idempotent column migrations to an existing inbound table."""
+    existing = {row[1] for row in conn.execute("PRAGMA table_info(inbound)")}
+    for column, ddl in INBOUND_MIGRATIONS:
+        if column not in existing:
+            conn.execute(ddl)
 
 
 def init_db_sync(db_path: Path) -> None:
@@ -88,6 +110,7 @@ def init_db_sync(db_path: Path) -> None:
     conn = sqlite3.connect(db_path)
     try:
         conn.executescript(SCHEMA)
+        migrate_inbound_schema(conn)
         conn.commit()
     finally:
         conn.close()

--- a/skills/harden-telegram/server/tests/test_telegram_bot.py
+++ b/skills/harden-telegram/server/tests/test_telegram_bot.py
@@ -64,10 +64,48 @@ def test_init_db_creates_schema(tmp_path):
         "gate_action",
         "delivered",
         "error",
+        "delivered_to",
     }
     assert required.issubset(cols), f"missing: {required - cols}"
     assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
     conn.close()
+
+
+def test_init_db_migrates_delivered_to(tmp_path):
+    """A pre-migration DB (no delivered_to) gains the column on init.
+
+    CREATE TABLE IF NOT EXISTS is a no-op on existing DBs, so new columns
+    ship via the guarded ALTER in migrate_inbound_schema. Running init twice
+    proves idempotence (a second ALTER would raise 'duplicate column name').
+    Existing rows keep delivered_to NULL — that's the documented state for
+    rows delivered before attribution existed.
+    """
+    from telegram_bot import init_db_sync
+
+    db_path = tmp_path / "inbound.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE inbound ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT NOT NULL,"
+        " chat_id TEXT NOT NULL, gate_action TEXT NOT NULL,"
+        " delivered INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "INSERT INTO inbound (ts, chat_id, gate_action, delivered)"
+        " VALUES ('2026-07-22T09:00:00+00:00', '42', 'allow', 1)"
+    )
+    conn.commit()
+    conn.close()
+
+    init_db_sync(db_path)  # applies the guarded ALTER
+    init_db_sync(db_path)  # idempotent — must not raise
+
+    conn = sqlite3.connect(db_path)
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(inbound)")}
+    assert "delivered_to" in cols
+    row = conn.execute("SELECT delivered, delivered_to FROM inbound").fetchone()
+    conn.close()
+    assert row == (1, None)  # old rows stay NULL — never an error
 
 
 def test_access_load_missing(tmp_path, monkeypatch):

--- a/skills/harden-telegram/tools/telegram_debug.py
+++ b/skills/harden-telegram/tools/telegram_debug.py
@@ -267,6 +267,87 @@ def classify_bridges(
     return bridges
 
 
+def parse_bridge_pid(identity: str) -> int | None:
+    """Extract the bridge pid from a `hostname:pid:starttime` delivered_to stamp.
+
+    server.ts stamps `inbound.delivered_to` with either the harness session id
+    (an opaque uuid, no colons) or `hostname:pid:starttime` (see BRIDGE_ID in
+    server.ts). Returns the pid for the latter shape, None otherwise —
+    session-id stamps are matched by exact string equality instead.
+    """
+    parts = identity.split(":")
+    if len(parts) != 3:
+        return None
+    try:
+        return int(parts[1])
+    except ValueError:
+        return None
+
+
+def parse_iso_ts(ts: str) -> float | None:
+    """Parse an inbound.db ISO-8601 `ts` into epoch seconds, or None.
+
+    Rows are written by telegram_bot.py with tz-aware UTC timestamps; a naive
+    timestamp is assumed UTC (matches the writer's convention).
+    """
+    if not ts:
+        return None
+    import datetime as _dt
+
+    try:
+        parsed = _dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=_dt.timezone.utc)
+    return parsed.timestamp()
+
+
+def classify_delivered_rows(
+    rows: list[dict],
+    our_identities: set[str],
+    our_bridge_pids: set[int],
+    now: float,
+    recent_window_s: float = 3600.0,
+) -> dict[str, list[dict]]:
+    """Classify delivered inbound rows for the doctor's DELIVERY check.
+
+    Each row dict needs `id`, `ts`, `delivered_to`. A row is OURS when its
+    delivered_to stamp is in `our_identities` (session-id form) or its
+    embedded pid is in `our_bridge_pids` (hostname:pid:starttime form).
+    Foreign rows split on age: within `recent_window_s` of `now` they are
+    `foreign_recent` (red — messages are actively being lost to another
+    session); older ones are `foreign_stale` (informational — e.g. a prior
+    session legitimately handled them). Unparseable timestamps count as
+    stale so a clock/format glitch can't page the operator. NULL/empty
+    delivered_to is `unattributed` — normal for pre-migration rows.
+
+    Pure — all process/DB I/O happens in the caller so tests can drive it
+    directly.
+    """
+    out: dict[str, list[dict]] = {
+        "ours": [],
+        "unattributed": [],
+        "foreign_recent": [],
+        "foreign_stale": [],
+    }
+    for row in rows:
+        identity = row.get("delivered_to")
+        if not identity:
+            out["unattributed"].append(row)
+            continue
+        pid = parse_bridge_pid(identity)
+        if identity in our_identities or (pid is not None and pid in our_bridge_pids):
+            out["ours"].append(row)
+            continue
+        ts_epoch = parse_iso_ts(row.get("ts") or "")
+        if ts_epoch is not None and (now - ts_epoch) <= recent_window_s:
+            out["foreign_recent"].append(row)
+        else:
+            out["foreign_stale"].append(row)
+    return out
+
+
 def check_claude_sessions() -> list[dict]:
     """Find all Claude Code sessions."""
     output = run(["bash", "-c", r"\ps -ef | grep -v grep | grep claude.*dangerously"])
@@ -830,8 +911,15 @@ def _doctor_check_inbound_db(report: DoctorReport, base: Path) -> None:
         report.ok(summary)
 
 
-def _doctor_check_server_ts(report: DoctorReport) -> None:
-    report.section("SERVER.TS")
+def _find_telegram_bridge_pids() -> list[int] | str:
+    """pgrep for bun server.ts processes and filter to the Telegram plugin's.
+
+    Filters by /proc/<pid>/cwd containing TELEGRAM_PLUGIN_MARKER — other bun
+    server.ts processes (unrelated projects) don't count. Returns the pid
+    list on success, or an error string when pgrep itself failed. Shared by
+    the SERVER.TS and DELIVERY doctor checks so both agree on what counts
+    as a bridge.
+    """
     try:
         r = subprocess.run(
             ["pgrep", "-f", "bun.*server.ts"],
@@ -840,17 +928,22 @@ def _doctor_check_server_ts(report: DoctorReport) -> None:
             timeout=5,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        report.fail(f"pgrep failed: {e}")
-        return
-
-    # Filter to the Telegram plugin's bridges by /proc/<pid>/cwd.
-    # Other bun server.ts processes (unrelated projects) don't count here.
+        return f"pgrep failed: {e}"
     candidate_pids = [int(p) for p in r.stdout.strip().split() if p.isdigit()]
-    tg_pids = [
+    return [
         pid
         for pid in candidate_pids
         if TELEGRAM_PLUGIN_MARKER in (_proc_cwd(str(pid)) or "")
     ]
+
+
+def _doctor_check_server_ts(report: DoctorReport) -> None:
+    report.section("SERVER.TS")
+    pids_or_err = _find_telegram_bridge_pids()
+    if isinstance(pids_or_err, str):
+        report.fail(pids_or_err)
+        return
+    tg_pids = pids_or_err
 
     our_claude = _find_owning_claude(os.getpid())
     bridges = classify_bridges(tg_pids, our_claude)
@@ -907,8 +1000,161 @@ def _doctor_check_server_ts(report: DoctorReport) -> None:
         )
 
 
-def _doctor_check_session_subscription(report: DoctorReport) -> None:
-    """Warn if this Claude session wasn't launched with --channels telegram.
+# DELIVERY check knobs: how many recently-delivered rows to attribute, and how
+# fresh a foreign-delivered row must be to count as red (older ones are noted
+# as stale — a prior session may have legitimately handled them).
+DELIVERY_SAMPLE_ROWS = 10
+DELIVERY_RECENT_WINDOW_S = 3600.0
+
+
+def _bridge_session_ids(pids: set[int]) -> set[str]:
+    """Read CLAUDE_CODE_SESSION_ID from /proc/<pid>/environ for each bridge pid.
+
+    A bridge that stamped delivered_to with its session id can only be
+    matched back to OUR session by reading the same env var out of the live
+    process. Unreadable /proc entries (process gone, permissions) are
+    silently skipped — the pid-based fallback still covers those bridges.
+    """
+    ids: set[str] = set()
+    for pid in pids:
+        try:
+            data = Path(f"/proc/{pid}/environ").read_bytes()
+        except (OSError, ValueError):
+            continue
+        for chunk in data.split(b"\x00"):
+            if chunk.startswith(b"CLAUDE_CODE_SESSION_ID="):
+                ids.add(chunk.split(b"=", 1)[1].decode("utf-8", "replace"))
+                break
+    return ids
+
+
+def _doctor_check_delivery(
+    report: DoctorReport,
+    base: Path,
+    *,
+    find_bridge_pids=_find_telegram_bridge_pids,
+    find_owning_claude=_find_owning_claude,
+    bridge_session_ids=_bridge_session_ids,
+    stat_reader=_read_proc_stat,
+    is_alive=_pid_alive,
+    now: float | None = None,
+) -> None:
+    """DELIVERY — detect the multi-bridge race that silently loses messages.
+
+    The checks above validate ONE chain's plumbing; they stay green while N
+    bun bridges (one per Claude session — igor-city deployments, stale
+    sessions) race to claim rows from the same inbound.db and a message
+    lands in a session the operator isn't watching. 2026-07-22: rows
+    5884/5888 were marked delivered=1 by a foreign bridge, never reached
+    the primary Larry session, and the doctor stayed green. This section
+    makes that failure visible:
+
+      * >1 telegram bridge polling the same inbound.db → FAIL (the race
+        itself silently loses messages — red, not a warning)
+      * recent rows whose delivered_to is another session's bridge → FAIL
+      * pre-migration DBs without delivered_to → note + skip, never crash
+
+    Discovery/env/clock inputs are injected for tests.
+    """
+    report.section("DELIVERY")
+    if now is None:
+        now = time.time()
+
+    pids_or_err = find_bridge_pids()
+    if isinstance(pids_or_err, str):
+        report.warn(f"{pids_or_err} — DELIVERY check skipped")
+        return
+    tg_pids = pids_or_err
+
+    if len(tg_pids) > 1:
+        pids_str = ", ".join(str(p) for p in sorted(tg_pids))
+        # fail, not warn: every extra bridge can claim rows meant for this
+        # session with zero signal — that IS the silent-loss incident, not a
+        # precursor to it.
+        report.fail(
+            f"delivery race: {len(tg_pids)} competing bridges polling "
+            f"inbound.db (pids {pids_str}) — any of them can claim new rows"
+        )
+    elif len(tg_pids) == 1:
+        report.ok(f"single bridge polling inbound.db (pid {tg_pids[0]})")
+    else:
+        report.note("no telegram bridges running — nothing polling inbound.db")
+
+    db_path = base / "inbound.db"
+    if not db_path.exists():
+        # INBOUND.DB section already fails on a missing DB — don't double-fail.
+        report.note("inbound.db missing — delivery attribution skipped")
+        return
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=2)
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(inbound)")}
+            if "delivered_to" not in cols:
+                report.note(
+                    "delivered_to column not present (pre-migration DB) — "
+                    "attribution skipped; restart telegram_bot.py to migrate"
+                )
+                return
+            rows = [
+                {"id": r[0], "ts": r[1], "delivered_to": r[2]}
+                for r in conn.execute(
+                    "SELECT id, ts, delivered_to FROM inbound"
+                    " WHERE delivered = 1 AND gate_action = 'allow'"
+                    " ORDER BY id DESC LIMIT ?",
+                    (DELIVERY_SAMPLE_ROWS,),
+                )
+            ]
+        finally:
+            conn.close()
+    except sqlite3.Error as e:
+        report.warn(f"delivered_to query failed: {e} — attribution skipped")
+        return
+
+    if not rows:
+        report.note("no delivered rows yet — nothing to attribute")
+        return
+
+    our_claude = find_owning_claude(os.getpid())
+    if our_claude is None:
+        report.note(
+            "doctor not inside a Claude session — foreign-delivery check skipped"
+        )
+        return
+
+    bridges = classify_bridges(
+        tg_pids, our_claude, stat_reader=stat_reader, is_alive=is_alive
+    )
+    our_pids = {b["pid"] for b in bridges if b["classification"] == "ours"}
+    our_identities = set(bridge_session_ids(our_pids))
+    env_session = os.environ.get("CLAUDE_CODE_SESSION_ID")
+    if env_session:
+        our_identities.add(env_session)
+
+    result = classify_delivered_rows(
+        rows, our_identities, our_pids, now, DELIVERY_RECENT_WINDOW_S
+    )
+    foreign_recent = result["foreign_recent"]
+    if foreign_recent:
+        detail = ", ".join(f"row {r['id']}→{r['delivered_to']}" for r in foreign_recent)
+        report.fail(
+            f"recent inbound delivered to foreign session(s): {detail} — "
+            "messages are landing in a session you aren't watching"
+        )
+    else:
+        report.ok(
+            f"last {len(rows)} delivered rows: {len(result['ours'])} this "
+            f"session, {len(result['unattributed'])} unattributed, "
+            f"{len(result['foreign_stale'])} foreign >1h old"
+        )
+
+
+def _doctor_check_session_subscription(
+    report: DoctorReport,
+    *,
+    find_owning_claude=_find_owning_claude,
+    read_cmdline=_read_proc_cmdline,
+) -> None:
+    """Fail if this Claude session wasn't launched with --channels telegram.
 
     Without `--channels plugin:telegram@claude-plugins-official`, the MCP
     bridge can still send messages (plain tool call) but inbound Telegram
@@ -916,15 +1162,25 @@ def _doctor_check_session_subscription(report: DoctorReport) -> None:
     harness drops the notifications. This check catches the silent-
     receive-path failure that is otherwise only detectable by sending a
     test message and watching it vanish.
+
+    fail, not warn (escalated after 2026-07-22): the primary session had
+    been resumed without --channels, so inbound could never surface there —
+    and the doctor printed exactly this condition as a ⚠️ while still
+    exiting 0/green. A session that cannot receive inbound is a broken
+    chain, not a degraded one. Send-only sessions that intentionally skip
+    --channels can ignore this specific red, but the doctor's job is to
+    make the operator decide, not to stay silent.
+
+    Discovery inputs are injected for tests.
     """
     report.section("SESSION")
-    our_claude = _find_owning_claude(os.getpid())
+    our_claude = find_owning_claude(os.getpid())
     if our_claude is None:
         report.note(
             "doctor not running inside a Claude session — subscription check skipped"
         )
         return
-    argv = _read_proc_cmdline(our_claude)
+    argv = read_cmdline(our_claude)
     if argv is None:
         report.warn(
             f"could not read /proc/{our_claude}/cmdline — subscription check skipped"
@@ -936,10 +1192,7 @@ def _doctor_check_session_subscription(report: DoctorReport) -> None:
             "inbound messages will surface as channel blocks"
         )
     else:
-        # warn, not fail: send-only sessions (outbound MCP tool calls without
-        # needing inbound notifications) are a legitimate use case, so don't
-        # poison the doctor's exit code.
-        report.warn(
+        report.fail(
             f"claude pid={our_claude} launched WITHOUT --channels telegram — "
             "bridge can send but incoming messages won't surface. "
             "Relaunch with: claude ... "
@@ -1185,6 +1438,7 @@ def run_doctor() -> int:
     _doctor_check_socket(report, base)
     _doctor_check_inbound_db(report, base)
     _doctor_check_server_ts(report)
+    _doctor_check_delivery(report, base)
     _doctor_check_session_subscription(report)
     _doctor_check_deploy(report)
     report.section("CONFIG")

--- a/skills/harden-telegram/tools/test_telegram_debug.py
+++ b/skills/harden-telegram/tools/test_telegram_debug.py
@@ -15,7 +15,10 @@ sys.path.insert(0, str(Path(__file__).parent))
 
 from telegram_debug import (  # noqa: E402
     REACTION_WHITELIST,
+    DoctorReport,
     _default_chat_id,
+    _doctor_check_delivery,
+    _doctor_check_session_subscription,
     _find_owning_claude,
     _read_bot_token,
     _redact,
@@ -23,7 +26,10 @@ from telegram_debug import (  # noqa: E402
     build_react_request,
     build_reply_request,
     classify_bridges,
+    classify_delivered_rows,
+    parse_bridge_pid,
     parse_env_token,
+    parse_iso_ts,
     parse_proc_stat,
     parse_sent_message_id,
     session_subscribed_to_telegram,
@@ -820,6 +826,346 @@ class TestShowUndelivered(unittest.TestCase):
             rc, out = self._run(d)
         self.assertEqual(rc, 1)
         self.assertEqual(out, "")
+
+
+class TestParseBridgePid(unittest.TestCase):
+    def test_host_pid_starttime(self):
+        self.assertEqual(parse_bridge_pid("c-5001:4242:1753100000000"), 4242)
+
+    def test_session_uuid_returns_none(self):
+        # Session-id stamps have no colon structure — matched by equality,
+        # not pid extraction.
+        self.assertIsNone(parse_bridge_pid("c21f2a53-b3c9-40cf-a31a-f0fb59e781dd"))
+
+    def test_non_numeric_pid_returns_none(self):
+        self.assertIsNone(parse_bridge_pid("host:notapid:123"))
+
+    def test_wrong_arity_returns_none(self):
+        self.assertIsNone(parse_bridge_pid("host:123"))
+        self.assertIsNone(parse_bridge_pid("a:1:2:3"))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(parse_bridge_pid(""))
+
+
+class TestParseIsoTs(unittest.TestCase):
+    def test_utc_offset_form(self):
+        # telegram_bot.py writes tz-aware UTC isoformat (+00:00).
+        self.assertEqual(parse_iso_ts("2026-07-22T10:00:00+00:00"), 1784714400.0)
+
+    def test_z_suffix_form(self):
+        self.assertEqual(parse_iso_ts("2026-07-22T10:00:00Z"), 1784714400.0)
+
+    def test_naive_assumed_utc(self):
+        # A naive ts must NOT be interpreted in local time — the writer's
+        # convention is UTC.
+        self.assertEqual(parse_iso_ts("2026-07-22T10:00:00"), 1784714400.0)
+
+    def test_fractional_seconds(self):
+        self.assertAlmostEqual(
+            parse_iso_ts("2026-07-22T10:00:00.500+00:00") or 0.0, 1784714400.5
+        )
+
+    def test_garbage_returns_none(self):
+        self.assertIsNone(parse_iso_ts("not-a-timestamp"))
+
+    def test_empty_returns_none(self):
+        self.assertIsNone(parse_iso_ts(""))
+
+
+class TestClassifyDeliveredRows(unittest.TestCase):
+    NOW = 1784714400.0  # 2026-07-22T10:00:00Z
+    RECENT = "2026-07-22T09:30:00+00:00"  # 30 min before NOW
+    STALE = "2026-07-21T09:00:00+00:00"  # 25 h before NOW
+
+    def classify(self, rows, our_identities=None, our_pids=None):
+        return classify_delivered_rows(
+            rows,
+            our_identities or set(),
+            our_pids or set(),
+            self.NOW,
+            recent_window_s=3600.0,
+        )
+
+    def test_null_delivered_to_is_unattributed(self):
+        # Pre-migration rows — never an error.
+        rows = [{"id": 1, "ts": self.RECENT, "delivered_to": None}]
+        result = self.classify(rows)
+        self.assertEqual([r["id"] for r in result["unattributed"]], [1])
+        self.assertEqual(result["foreign_recent"], [])
+
+    def test_ours_by_session_id(self):
+        rows = [{"id": 2, "ts": self.RECENT, "delivered_to": "sess-abc"}]
+        result = self.classify(rows, our_identities={"sess-abc"})
+        self.assertEqual([r["id"] for r in result["ours"]], [2])
+
+    def test_ours_by_pid_fallback(self):
+        rows = [{"id": 3, "ts": self.RECENT, "delivered_to": "c-5001:4242:170000"}]
+        result = self.classify(rows, our_pids={4242})
+        self.assertEqual([r["id"] for r in result["ours"]], [3])
+
+    def test_foreign_recent_within_window(self):
+        # The 2026-07-22 failure story: a fresh row claimed by another
+        # session's bridge.
+        rows = [{"id": 5884, "ts": self.RECENT, "delivered_to": "other-session-id"}]
+        result = self.classify(rows, our_identities={"sess-abc"}, our_pids={4242})
+        self.assertEqual([r["id"] for r in result["foreign_recent"]], [5884])
+
+    def test_foreign_old_is_stale(self):
+        rows = [{"id": 4, "ts": self.STALE, "delivered_to": "other-session-id"}]
+        result = self.classify(rows, our_identities={"sess-abc"})
+        self.assertEqual([r["id"] for r in result["foreign_stale"]], [4])
+        self.assertEqual(result["foreign_recent"], [])
+
+    def test_foreign_unparseable_ts_is_stale_not_red(self):
+        # Documented conservative choice: a clock/format glitch must not
+        # page the operator.
+        rows = [{"id": 5, "ts": "garbage", "delivered_to": "other"}]
+        result = self.classify(rows)
+        self.assertEqual([r["id"] for r in result["foreign_stale"]], [5])
+
+    def test_mixed_rows_partition_completely(self):
+        rows = [
+            {"id": 1, "ts": self.RECENT, "delivered_to": None},
+            {"id": 2, "ts": self.RECENT, "delivered_to": "sess-abc"},
+            {"id": 3, "ts": self.RECENT, "delivered_to": "h:4242:1"},
+            {"id": 4, "ts": self.RECENT, "delivered_to": "foreign"},
+            {"id": 5, "ts": self.STALE, "delivered_to": "foreign"},
+        ]
+        result = self.classify(rows, our_identities={"sess-abc"}, our_pids={4242})
+        self.assertEqual(
+            sum(len(v) for v in result.values()), len(rows), "every row lands somewhere"
+        )
+        self.assertEqual([r["id"] for r in result["foreign_recent"]], [4])
+
+
+class TestDoctorCheckDelivery(unittest.TestCase):
+    """Drive _doctor_check_delivery end-to-end against a temp DB with all
+    process discovery injected — no live processes are ever touched."""
+
+    NOW = 1784714400.0  # 2026-07-22T10:00:00Z
+    RECENT = "2026-07-22T09:30:00+00:00"
+
+    def _make_db(self, tmp_dir, rows, *, with_column=True):
+        """rows: list of (ts, gate_action, delivered, delivered_to)."""
+        db = Path(tmp_dir) / "inbound.db"
+        con = sqlite3.connect(db)
+        cols = "id INTEGER PRIMARY KEY, ts TEXT, gate_action TEXT, delivered INTEGER DEFAULT 0"
+        if with_column:
+            cols += ", delivered_to TEXT"
+        con.execute(f"CREATE TABLE inbound ({cols})")
+        if with_column:
+            con.executemany(
+                "INSERT INTO inbound (ts, gate_action, delivered, delivered_to)"
+                " VALUES (?, ?, ?, ?)",
+                rows,
+            )
+        else:
+            con.executemany(
+                "INSERT INTO inbound (ts, gate_action, delivered) VALUES (?, ?, ?)",
+                [r[:3] for r in rows],
+            )
+        con.commit()
+        con.close()
+
+    def _run(
+        self,
+        tmp_dir,
+        *,
+        bridge_pids,
+        owning_claude=300,
+        session_ids=None,
+        stat_table=None,
+    ):
+        report = DoctorReport()
+        # Default /proc topology: every bridge pid is a child of OUR claude
+        # (pid 300) unless the test supplies its own table.
+        if stat_table is not None:
+            table = stat_table
+        elif isinstance(bridge_pids, list):
+            table = {pid: ("bun", 300) for pid in bridge_pids}
+        else:
+            table = {}
+        table.setdefault(300, ("claude", 1))
+
+        _doctor_check_delivery(
+            report,
+            Path(tmp_dir),
+            find_bridge_pids=lambda: bridge_pids,
+            find_owning_claude=lambda pid, **kw: owning_claude,
+            bridge_session_ids=lambda pids: session_ids or set(),
+            stat_reader=lambda pid: table.get(pid),
+            is_alive=lambda pid: True,
+            now=self.NOW,
+        )
+        return report
+
+    def test_pre_migration_db_skips_with_note_no_crash(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._make_db(d, [(self.RECENT, "allow", 1, None)], with_column=False)
+            report = self._run(d, bridge_pids=[500])
+        self.assertEqual(report.failures, 0)
+        self.assertTrue(
+            any("pre-migration" in line for line in report.lines),
+            report.lines,
+        )
+
+    def test_multi_bridge_race_is_red(self):
+        # Red, not warn: with N bridges racing on one inbound.db, any of
+        # them can claim rows meant for this session with zero signal —
+        # the race itself is the silent-loss incident (2026-07-22).
+        with tempfile.TemporaryDirectory() as d:
+            self._make_db(d, [])
+            report = self._run(d, bridge_pids=[500, 600, 700])
+        self.assertEqual(report.failures, 1)
+        self.assertTrue(
+            any("delivery race: 3 competing bridges" in line for line in report.lines),
+            report.lines,
+        )
+
+    def test_single_bridge_no_race_red(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._make_db(d, [])
+            report = self._run(d, bridge_pids=[500])
+        self.assertEqual(report.failures, 0)
+        self.assertTrue(
+            any("single bridge polling inbound.db" in line for line in report.lines),
+            report.lines,
+        )
+
+    def test_recent_foreign_delivery_is_red(self):
+        # The failure story this check exists for: fresh rows claimed by a
+        # bridge outside this session.
+        with tempfile.TemporaryDirectory() as d:
+            self._make_db(
+                d,
+                [
+                    (self.RECENT, "allow", 1, "foreign-session-uuid"),
+                    (self.RECENT, "allow", 1, "our-session-uuid"),
+                ],
+            )
+            report = self._run(d, bridge_pids=[500], session_ids={"our-session-uuid"})
+        self.assertEqual(report.failures, 1)
+        self.assertTrue(
+            any(
+                "recent inbound delivered to foreign session" in line
+                for line in report.lines
+            ),
+            report.lines,
+        )
+
+    def test_all_ours_is_green(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._make_db(
+                d,
+                [
+                    (self.RECENT, "allow", 1, "our-session-uuid"),
+                    (self.RECENT, "allow", 1, None),  # pre-migration row
+                ],
+            )
+            report = self._run(d, bridge_pids=[500], session_ids={"our-session-uuid"})
+        self.assertEqual(report.failures, 0)
+        self.assertTrue(
+            any("1 this session, 1 unattributed" in line for line in report.lines),
+            report.lines,
+        )
+
+    def test_ours_via_pid_stamp(self):
+        # Bridge stamped hostname:pid:starttime (no session id in its env) —
+        # attribution matches via the pid of a bridge owned by our claude.
+        with tempfile.TemporaryDirectory() as d:
+            self._make_db(d, [(self.RECENT, "allow", 1, "c-5001:500:1753000000000")])
+            report = self._run(d, bridge_pids=[500])
+        self.assertEqual(report.failures, 0)
+
+    def test_outside_claude_session_skips_attribution(self):
+        # Cron/CI invocation — no session scope, so no foreign judgment.
+        with tempfile.TemporaryDirectory() as d:
+            self._make_db(d, [(self.RECENT, "allow", 1, "whatever")])
+            report = self._run(d, bridge_pids=[500], owning_claude=None)
+        self.assertEqual(report.failures, 0)
+        self.assertTrue(
+            any("foreign-delivery check skipped" in line for line in report.lines),
+            report.lines,
+        )
+
+    def test_missing_db_notes_and_returns(self):
+        with tempfile.TemporaryDirectory() as d:
+            report = self._run(d, bridge_pids=[500])
+        self.assertEqual(report.failures, 0)
+        self.assertTrue(
+            any("inbound.db missing" in line for line in report.lines),
+            report.lines,
+        )
+
+    def test_discovery_failure_skips_gracefully(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._make_db(d, [])
+            report = self._run(d, bridge_pids="pgrep failed: boom")
+        self.assertEqual(report.failures, 0)
+        self.assertTrue(
+            any("DELIVERY check skipped" in line for line in report.lines),
+            report.lines,
+        )
+
+
+class TestDoctorCheckSessionSubscription(unittest.TestCase):
+    """Severity of the --channels check. The pure argv parser is covered by
+    TestSessionSubscribedToTelegram; these pin the red/green/skip outcomes
+    with process discovery injected."""
+
+    def _run(self, *, owning_claude=300, argv):
+        report = DoctorReport()
+        _doctor_check_session_subscription(
+            report,
+            find_owning_claude=lambda pid, **kw: owning_claude,
+            read_cmdline=lambda pid: argv,
+        )
+        return report
+
+    def test_without_channels_is_red(self):
+        # Escalated after 2026-07-22: a session resumed without --channels
+        # can never surface inbound, and the old ⚠️ still exited 0/green.
+        report = self._run(argv=["claude", "--dangerously-skip-permissions"])
+        self.assertEqual(report.failures, 1)
+        self.assertTrue(
+            any("WITHOUT --channels telegram" in line for line in report.lines),
+            report.lines,
+        )
+        # The relaunch hint must survive the escalation.
+        self.assertTrue(
+            any(
+                "--channels plugin:telegram@claude-plugins-official" in line
+                for line in report.lines
+            ),
+            report.lines,
+        )
+
+    def test_with_channels_is_green(self):
+        report = self._run(
+            argv=[
+                "claude",
+                "--channels",
+                "plugin:telegram@claude-plugins-official",
+            ]
+        )
+        self.assertEqual(report.failures, 0)
+        self.assertTrue(
+            any("launched with --channels telegram" in line for line in report.lines),
+            report.lines,
+        )
+
+    def test_outside_claude_session_skips(self):
+        report = self._run(owning_claude=None, argv=None)
+        self.assertEqual(report.failures, 0)
+
+    def test_unreadable_cmdline_warns_not_red(self):
+        report = self._run(argv=None)
+        self.assertEqual(report.failures, 0)
+        self.assertTrue(
+            any("subscription check skipped" in line for line in report.lines),
+            report.lines,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Incident (2026-07-22)

Two silent-loss modes, both invisible to the doctor:

1. Igor's inbound rows were marked `delivered=1` but claimed by **other sessions' bridges** — N bun `server.ts` processes (one per Claude session, incl. an igor-city deployment) race to claim rows from the same `inbound.db`. Rows 5884/5888 landed in a session nobody was watching; every per-chain check stayed green.
2. The primary session had been **resumed without `--channels plugin:telegram@claude-plugins-official`**, so inbound could never surface there — and the doctor printed that only as a ⚠️ while still exiting 0.

## Changes

**Attribution** (`server.ts` + `telegram_bot.py`)
- New `inbound.delivered_to` TEXT column. `server.ts` stamps its bridge identity on every claim: `CLAUDE_CODE_SESSION_ID` when the plugin env provides it, else `hostname:pid:starttime`.
- `telegram_bot.py` owns the schema: idempotent guarded `ALTER` on startup (new `INBOUND_MIGRATIONS` table, same pattern as prior column adds). `server.ts` applies the same guarded ALTER defensively in case it opens an older DB first. Old rows stay NULL.

**Doctor `DELIVERY` section** (`telegram_debug.py`)
- ❌ `delivery race: N competing bridges polling inbound.db` — >1 live telegram bridge. Red, not warn: the race itself silently loses messages.
- ❌ `recent inbound delivered to foreign session(s)` — any of the last 10 delivered rows <1h old whose `delivered_to` belongs to a bridge outside this session (matched by session id read from `/proc/<pid>/environ`, pid fallback).
- Pre-migration DBs (no column) skip with a note — never a crash. Missing DB / pgrep failure / outside-a-session all degrade gracefully.

**`--channels` check escalated warn → RED**
- A session that cannot receive inbound is a broken chain, not a degraded one. Relaunch hint text kept. Intentionally send-only sessions can ignore that specific red.

**Docs**: SKILL.md doctor section gains the DELIVERY subsection + incident story.

## Tests

- `tools/test_telegram_debug.py`: 135 pass — pure-logic coverage for `parse_bridge_pid`, `parse_iso_ts`, `classify_delivered_rows`, plus injected-discovery drives of `_doctor_check_delivery` (race-red, foreign-recent-red, pre-migration skip, missing DB, outside-session, discovery failure) and `_doctor_check_session_subscription` (channels-red with hint, green, skips).
- `server/tests/test_telegram_bot.py`: 25 pass (pytest) — schema includes `delivered_to`; pre-migration DB gains the column, double-init idempotent, old rows stay NULL.
- Live read-only doctor run reproduces the incident: DELIVERY red on 2 competing bridges + SESSION red on missing `--channels`, exit 1. Pre-existing `test_watchdog.py` failures reproduce identically on clean `main` (unrelated).

Not included: deploying to the plugin cache (separate cp + /reload-plugins step).

Bead: igor2-bgt.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added delivery diagnostics to detect competing Telegram bridges and identify messages delivered by another session.
  - Added delivery attribution to improve troubleshooting of missed inbound messages.
  - Added automatic database migration for existing installations.

- **Bug Fixes**
  - Improved session checks to flag Claude sessions launched without Telegram channel support.

- **Documentation**
  - Updated the Doctor runbook with multi-session delivery race guidance and new diagnostic indicators.

- **Tests**
  - Expanded coverage for delivery attribution, migrations, diagnostics, and session validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->