### PR TITLE
Claude 5 skill cleanup: opus-5 pricing row + architect-review model inheritance

### DIFF
--- a/skills/architect-review/SKILL.md
+++ b/skills/architect-review/SKILL.md
@@ -59,7 +59,7 @@ When in doubt, ask the user: "I'm putting the architect review changelog at `<pa
 
 ### 2. Run passes as background agents
 
-Launch each pass using the **Agent tool** with `model: "opus"` and `run_in_background: true`. Wait for each pass to complete before launching the next. Each agent gets this prompt structure:
+Launch each pass using the **Agent tool** with `run_in_background: true` and no `model` override — passes inherit the session's model, so review quality tracks whatever tier you're running. Wait for each pass to complete before launching the next. Each agent gets this prompt structure:
 
 ```
 You are a senior software architect doing pass <N> on a design spec.
@@ -149,7 +149,7 @@ Requires the `gh` CLI installed and authenticated. If either is missing, this wh
 
 - **Always run agents in background** — don't block the conversation
 - **Sequential, not parallel** — each pass must read the previous pass's edits
-- **Opus model** for all passes — architecture review needs the strongest reasoning
+- **Session model** for all passes — no `model` override on the Agent tool; inheriting the session's model keeps review quality at the tier you chose and never goes stale when new models ship
 - **Changelog is mandatory** — without it, you can't measure convergence
 - **Beside the plan as `<spec>-changelog.md` when reviewing one in-repo plan file; `~/tmp/architect-review/<slug>-<datestamp>.md` otherwise** — see step 1
 - **Multiple reviews on the same beside-the-spec changelog append as new dated sections — don't make a second file**

--- a/skills/cost-impact/SKILL.md
+++ b/skills/cost-impact/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cost-impact
-description: Compute a Claude Code cost-impact report across a time window, grouped by repo with per-session detail. Prices per-turn per-model at published list rates (Fable 5 / Opus 4.x / Sonnet 4.x-5 / Haiku), includes subagent tokens, outputs markdown with clickable PR links and collapsible per-repo sections. Use when user asks "how much did I spend on Claude this week", "cost report", "/cost-impact", or wants a weekly retrospective on Claude usage.
+description: Compute a Claude Code cost-impact report across a time window, grouped by repo with per-session detail. Prices per-turn per-model at published list rates (Fable 5 / Opus 5 & 4.x / Sonnet 4.x-5 / Haiku), includes subagent tokens, outputs markdown with clickable PR links and collapsible per-repo sections. Use when user asks "how much did I spend on Claude this week", "cost report", "/cost-impact", or wants a weekly retrospective on Claude usage.
 allowed-tools: Bash, Read
 ---
 
@@ -70,7 +70,7 @@ The script:
 2. Filters to turns whose `timestamp` (converted to local TZ) falls in
    the requested window
 3. Bills each turn at its model's published list price — pricing table
-   in `_impl.py::PRICING` tracks Fable 5, Opus 4.8/4.7/4.6/4.5,
+   in `_impl.py::PRICING` tracks Fable 5, Opus 5, Opus 4.8/4.7/4.6/4.5,
    Sonnet 5/4.6/4.5/4, Haiku 4.5/3.5, and older tiers
 4. Rolls subagent costs into the parent session so per-session totals
    reflect all work done on behalf of that session
@@ -174,10 +174,10 @@ unsent once the gist URL is indexed.
 
 Edit these constants at the top of the file if your setup differs:
 
-| Constant           | Purpose                                                                    | Default                                                                    |
-| ------------------ | -------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `PRICING`          | Per-model price table (input/output/cache-write-1h/5m/cache-read per MTok) | Fable 5 $10/$50, Opus 4.8-4.5 $5/$25, Sonnet 5/4.6 $3/$15, Haiku 4.5 $1/$5 |
-| `MAX_PLAN_MONTHLY` | Used only for the subsidy footnote                                         | `200.00`                                                                   |
+| Constant           | Purpose                                                                    | Default                                                                        |
+| ------------------ | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `PRICING`          | Per-model price table (input/output/cache-write-1h/5m/cache-read per MTok) | Fable 5 $10/$50, Opus 5 & 4.8-4.5 $5/$25, Sonnet 5/4.6 $3/$15, Haiku 4.5 $1/$5 |
+| `MAX_PLAN_MONTHLY` | Used only for the subsidy footnote                                         | `200.00`                                                                       |
 
 Pricing is sourced from
 [platform.claude.com/docs/en/about-claude/pricing](https://platform.claude.com/docs/en/about-claude/pricing).
@@ -208,7 +208,7 @@ Update the table if Anthropic changes published rates.
   report prices at list; peak vs off-peak is not reflected in the
   dollar column.
 - **Current-gen flat pricing**: no 200k threshold — older 4 / 4.1
-  tiers had 2× above 200k, but 4.5+ (incl. Fable 5, Opus 4.8/4.7,
+  tiers had 2× above 200k, but 4.5+ (incl. Fable 5, Opus 5/4.8/4.7,
   Sonnet 5) bill flat across the full 1M context window.
 - **TTL bug ([anthropics/claude-code#45381](https://github.com/anthropics/claude-code/issues/45381))**:
   if `DISABLE_TELEMETRY` or `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`

--- a/skills/cost-impact/_impl.py
+++ b/skills/cost-impact/_impl.py
@@ -24,6 +24,9 @@ from pathlib import Path
 # model ids (date suffix stripped).
 PRICING = {
     "claude-fable-5": dict(inp=10.00, out=50.00, c1h=20.00, c5m=12.50, cread=1.00),
+    # Opus 5 standard rate. Fast mode bills 2x ($10/$50) under the same model
+    # id; per-turn speed isn't recorded here, so fast-mode turns undercount.
+    "claude-opus-5": dict(inp=5.00, out=25.00, c1h=10.00, c5m=6.25, cread=0.50),
     "claude-opus-4-8": dict(inp=5.00, out=25.00, c1h=10.00, c5m=6.25, cread=0.50),
     "claude-opus-4-7": dict(inp=5.00, out=25.00, c1h=10.00, c5m=6.25, cread=0.50),
     "claude-opus-4-6": dict(inp=5.00, out=25.00, c1h=10.00, c5m=6.25, cread=0.50),

--- a/skills/cost-impact/test_impl.py
+++ b/skills/cost-impact/test_impl.py
@@ -70,6 +70,7 @@ class TestNormalizeModel(unittest.TestCase):
         # Current-gen API ids are bare aliases (no date suffix) — they must
         # match PRICING directly or the dominant spend lands in unknown_models.
         self.assertEqual(normalize_model("claude-fable-5"), "claude-fable-5")
+        self.assertEqual(normalize_model("claude-opus-5"), "claude-opus-5")
         self.assertEqual(normalize_model("claude-opus-4-8"), "claude-opus-4-8")
         self.assertEqual(normalize_model("claude-opus-4-7"), "claude-opus-4-7")
         self.assertEqual(normalize_model("claude-sonnet-5"), "claude-sonnet-5")
@@ -154,6 +155,15 @@ class TestCurrentGenPricing(unittest.TestCase):
         self.assertAlmostEqual(comps["out"], 50.00)
         self.assertAlmostEqual(by_model["claude-fable-5"], 60.00)
         self.assertAlmostEqual(total, 60.00)
+
+    def test_opus_5_rates(self):
+        # $5/$25 per MTok, same as Opus 4.8. Fast mode's 2x rate shares the
+        # model id and isn't modeled — see the PRICING row comment.
+        s = empty_stats()
+        s["models"]["claude-opus-5"]["inp"] = 1_000_000
+        s["models"]["claude-opus-5"]["out"] = 1_000_000
+        total, _comps, _by_model, _naive = cost_breakdown(s)
+        self.assertAlmostEqual(total, 30.00)
 
     def test_opus_4_8_and_4_7_rates(self):
         # Both $5/$25 per MTok, same as Opus 4.6


### PR DESCRIPTION
Two cleanups from a review of all skills against the Claude 5 lineup:

## fix(cost-impact): add `claude-opus-5` pricing row

`_impl.py::PRICING` had Fable 5, Opus 4.8–4.5, Sonnet 5, and Haiku rows but no `claude-opus-5`, so Opus 5 turns landed in the "⚠ Unpriced models" bucket instead of being billed. Claude Code fast mode runs on Opus 5, so this fires as soon as `/fast` is used. Added the row at the published $5/$25 list rate (cache $10 / $6.25 / $0.50, same as Opus 4.8) plus a rates test and a `normalize_model` assertion; updated the SKILL.md tier enumerations to match.

Known limitation, noted in the row comment: Opus 5 **fast mode** bills at $10/$50 under the same model id, and per-turn speed isn't recorded in PRICING — fast-mode turns undercount 2×. If the session JSONL turns out to record `speed`, that's a follow-up.

## refactor(architect-review): inherit session model instead of pinning opus

The skill pinned every review pass to `model: "opus"` with the rationale "architecture review needs the strongest reasoning" — stale now that Opus is no longer the top tier. Passes now omit the model override and inherit the session's model, so review quality tracks whatever tier the user is running and the guidance won't rot on the next model generation. Note the cost implication: on a Fable 5 session, passes now run at Fable rates instead of Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cost tracking support for the Opus 5 model, including standard and cache pricing.
  * Updated pricing documentation to cover Fable 5, Opus 5, and Opus 4.x.

* **Improvements**
  * Architect reviews now inherit the session’s selected model instead of using a fixed model.
  * Added validation for Opus 5 model aliases and pricing calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->